### PR TITLE
Add run log decoder utility for observer mode

### DIFF
--- a/tools/decode_run_log.sh
+++ b/tools/decode_run_log.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_LOG="${ROOT}/_truth/run_log.jsonl"
+
+if [[ ! -f "$RUN_LOG" ]]; then
+  echo "run log not found: $RUN_LOG" >&2
+  exit 1
+fi
+
+if [[ ! -s "$RUN_LOG" ]]; then
+  echo "run log is empty: $RUN_LOG"
+  exit 0
+fi
+
+jq -c '.' "$RUN_LOG" | while read -r line; do
+  ts="$(jq -r '.ts // ""' <<<"$line")"
+  source_id="$(jq -r '.source_id // ""' <<<"$line")"
+  status="$(jq -r '.status // ""' <<<"$line")"
+  event="$(jq -r '.event // ""' <<<"$line")"
+  reason="$(jq -r '.reason // ""' <<<"$line")"
+  watcher_path="$(jq -r '.watcher_path // ""' <<<"$line")"
+  output_b64="$(jq -r '.output_b64 // ""' <<<"$line")"
+
+  decoded=""
+  if [[ -n "$output_b64" ]]; then
+    decoded="$(printf '%s' "$output_b64" | base64 --decode 2>/dev/null || true)"
+  fi
+
+  printf '%s | %s | %s' "$ts" "$source_id" "$status"
+
+  if [[ -n "$event" ]]; then
+    printf ' | event=%s' "$event"
+  fi
+
+  if [[ -n "$reason" ]]; then
+    printf ' | reason=%s' "$reason"
+  fi
+
+  if [[ -n "$watcher_path" ]]; then
+    printf ' | watcher_path=%s' "$watcher_path"
+  fi
+
+  if [[ -n "$decoded" ]]; then
+    compact_decoded="$(printf '%s' "$decoded" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+    printf ' | decoded=%s' "$compact_decoded"
+  fi
+
+  printf '\n'
+done


### PR DESCRIPTION
### Motivation
- Provide a small, local utility to quickly decode and summarize entries in `_truth/run_log.jsonl` for rapid observer-mode triage. 
- Keep changes limited to a tools-only helper so no watcher, scheduler, or architecture code is modified. 

### Description
- Add executable script `tools/decode_run_log.sh` that reads `/_truth/run_log.jsonl`, validates presence and non-empty state, and processes each JSONL entry. 
- The script extracts `ts`, `source_id`, `status`, `event`, `reason`, and `watcher_path`, decodes `output_b64` when present, and prints a compact single-line summary per entry. 
- Decoding uses `base64` with errors ignored and the decoded payload is normalized to one-line text via `tr`/`sed`. 
- The new file is added as an executable (`100755`) and committed. 

### Testing
- Ran `./tools/decode_run_log.sh` which successfully printed decoded entries including `NO_CHANGE` events and prior `FAIL` reasons. 
- Attempted `git push` from this environment which failed due to no configured remote, so the commit was not pushed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7f247c3483319f2d0df879c06ed8)