### PR TITLE
integrate: VCLP protocol as AL verification engine

### DIFF
--- a/docs/protocols/vclp/README.md
+++ b/docs/protocols/vclp/README.md
@@ -1,0 +1,45 @@
+# Verifiable Claim Ledger Protocol (VCLP)
+
+VCLP is a byte-exact claim verification protocol for public records.
+
+It turns static documents and tabular data into append-only, replayable ledgers where every claim can be checked against source bytes.
+
+## Protocol family
+
+| Layer | Purpose | Trust model |
+|---|---|---|
+| VCLP-PDF | Verify claims against extracted document lines | SHA256 + preserved extraction |
+| VCLP-TAB | Verify CSV rows and row ranges | SHA256 + deterministic CSV bytes |
+| VCLP-COMPUTE | Verify derived totals from anchored rows | Trusted parser + deterministic arithmetic |
+
+## Core invariant
+
+```text
+source bytes -> claim hash -> ledger-line hash chain -> verifier
+```
+
+## Directory
+
+```text
+docs/protocols/vclp/
+├── SPEC.md
+├── VERIFY_BEFORE_YOU_TRUST.md
+└── tabular/
+    ├── TABULAR_SPEC.md
+    ├── COMPUTE_SPEC.md
+    ├── csv_to_claims.py
+    ├── compute_claims.py
+    ├── verify_tabular.sh
+    ├── verify_compute.py
+    └── examples/
+```
+
+## Design boundary
+
+Byte claims prove that source bytes did not drift.
+
+Computation claims prove that a declared operation recomputes from anchored inputs. They are derived claims and carry extra trust assumptions: parser correctness and arithmetic correctness.
+
+## Status
+
+This is AL doctrine-layer protocol material. Runtime watchers, Nitro observers, and application code remain separate.

--- a/docs/protocols/vclp/SPEC.md
+++ b/docs/protocols/vclp/SPEC.md
@@ -1,0 +1,25 @@
+# VCLP v1.0
+
+## Inputs
+
+- source.pdf
+- source.txt (byte-exact extraction)
+- ledger.jsonl (append-only)
+
+## Invariants
+
+1. claim_text must match source bytes exactly
+2. text_hash = sha256(claim_text)
+3. prev_hash = sha256(previous ledger line)
+4. append-only (no edits, no reorder, no delete)
+
+## Verification
+
+1. verify PDF hash
+2. verify ledger hash
+3. verify prev_hash chain
+4. recompute text hashes
+
+## Failure
+
+Any mutation breaks at least one invariant.


### PR DESCRIPTION
This PR integrates VCLP (Verifiable Claim Ledger Protocol) as AL's native verification layer.

- Adds VCLP doctrine under `docs/protocols/vclp/`
- Adds `verify.sh` as the AL verification entry point
- Adds `_truth/` ledger structure
- Adds `claim_emitter.sh` with compact JSONL emission: exactly one JSON object per line
- Adds CI workflow to verify on every push/PR

Goal: AL claims become anchored, chained, and replay-verifiable while preserving AL's existing architecture.