### PR TITLE
MN EDU Civil Rights 001 — Source Ingest Scaffold (No Data)

### DIFF
--- a/_truth/edu_civil_rights/ct/CT_EDU_CIVIL_RIGHTS_001.leaf.json
+++ b/_truth/edu_civil_rights/ct/CT_EDU_CIVIL_RIGHTS_001.leaf.json
@@ -1,0 +1,22 @@
+{
+  "receipt_id": "CT_EDU_CIVIL_RIGHTS_001",
+  "system": "EDU_CIVIL_RIGHTS_OBSERVER",
+  "receipt_family": "STATE_EDU_CIVIL_RIGHTS_RESOLUTION_RATE",
+  "schema_status": "LOCKED",
+  "ingest_status": "READY",
+  "numeric_fields_populated": false,
+  "source_hashes_present": false,
+  "data": {
+    "state": "Connecticut",
+    "year": null,
+    "agency_breakdown": [],
+    "aggregates": null,
+    "positive_resolution_definition": "Use same definition as MN_EDU_CIVIL_RIGHTS_001",
+    "extraction_fields_manifest": "CT_EDU_CIVIL_RIGHTS_001.sources.json"
+  },
+  "verdict": "PARTIAL_DATA_ONLY",
+  "hash": {
+    "algorithm": "SHA256",
+    "value": null
+  }
+}

--- a/_truth/edu_civil_rights/ct/CT_EDU_CIVIL_RIGHTS_001.sources.json
+++ b/_truth/edu_civil_rights/ct/CT_EDU_CIVIL_RIGHTS_001.sources.json
@@ -1,0 +1,57 @@
+{
+  "receipt_id": "CT_EDU_CIVIL_RIGHTS_001",
+  "ingest_status": "NOT_STARTED",
+  "source_acquisition_order": [
+    {
+      "rank": 1,
+      "source": "US_DOE_OCR",
+      "target": "Connecticut education civil-rights complaint outcomes",
+      "goal": "Get state-level filed/resolved/dismissed/pending/remedy data",
+      "failure_state": "MISSING_STATE_BREAKDOWN"
+    },
+    {
+      "rank": 2,
+      "source": "CT_STATE_EDUCATION_AGENCY",
+      "target": "State complaint and discrimination-resolution records",
+      "goal": "Compare state complaint outcomes against federal OCR view",
+      "failure_state": "PARTIAL_DATA_ONLY"
+    },
+    {
+      "rank": 3,
+      "source": "DISTRICT_PUBLIC_RECORDS",
+      "target": "District-level complaint/resolution artifacts",
+      "goal": "Only ingest if public, source-hashable, and machine-readable",
+      "failure_state": "LOCAL_DATA_UNAVAILABLE"
+    },
+    {
+      "rank": 4,
+      "source": "FOIA_OR_DATA_REQUEST",
+      "target": "Missing OCR/CT breakdowns",
+      "goal": "Trigger if public data does not expose Connecticut category/outcome counts",
+      "failure_state": "NON_RESPONSIVE_REPLY"
+    }
+  ],
+  "canonical_extraction_fields": [
+    "year",
+    "state",
+    "agency",
+    "office",
+    "complaint_category",
+    "case_count",
+    "resolution_count",
+    "positive_resolution_count",
+    "dismissal_count",
+    "pending_count",
+    "mediated_count",
+    "median_days_to_resolution",
+    "source_url",
+    "source_hash",
+    "retrieved_at"
+  ],
+  "null_rule": "If a field is not explicitly present in the source, keep null. Do not infer.",
+  "closure_rule": "Closed, dismissed, or administratively resolved does not count as positive_resolution_count unless a documented remedy exists.",
+  "notes": [
+    "No numeric data in this manifest.",
+    "Safe to hash and commit."
+  ]
+}

--- a/_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.leaf.json
+++ b/_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.leaf.json
@@ -1,0 +1,21 @@
+{
+  "receipt_id": "MN_EDU_CIVIL_RIGHTS_001",
+  "system": "EDU_CIVIL_RIGHTS_OBSERVER",
+  "receipt_family": "MN_EDU_CIVIL_RIGHTS_RESOLUTION_RATE",
+  "schema_status": "LOCKED",
+  "ingest_status": "READY",
+  "numeric_fields_populated": false,
+  "source_hashes_present": false,
+  "data": {
+    "year": null,
+    "state": "Minnesota",
+    "agency_breakdown": [],
+    "positive_resolution_definition": "See schema-locked definition in MN_EDU_CIVIL_RIGHTS_001",
+    "extraction_fields": "See MN_EDU_CIVIL_RIGHTS_001.sources.json"
+  },
+  "verdict": "PARTIAL_DATA_ONLY",
+  "hash": {
+    "algorithm": "SHA256",
+    "value": null
+  }
+}

--- a/_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.sources.json
+++ b/_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.sources.json
@@ -1,0 +1,58 @@
+{
+  "receipt_id": "MN_EDU_CIVIL_RIGHTS_001",
+  "ingest_status": "NOT_STARTED",
+  "source_acquisition_order": [
+    {
+      "rank": 1,
+      "source": "US_DOE_OCR",
+      "target": "Minnesota education civil-rights complaint outcomes",
+      "goal": "Get state-level filed/resolved/dismissed/pending/remedy data",
+      "failure_state": "MISSING_STATE_BREAKDOWN"
+    },
+    {
+      "rank": 2,
+      "source": "MN_DEPARTMENT_OF_EDUCATION",
+      "target": "State complaint and discrimination-resolution records",
+      "goal": "Compare state complaint outcomes against federal OCR view",
+      "failure_state": "PARTIAL_DATA_ONLY"
+    },
+    {
+      "rank": 3,
+      "source": "DISTRICT_PUBLIC_RECORDS",
+      "target": "District-level complaint/resolution artifacts",
+      "goal": "Only ingest if public, source-hashable, and machine-readable",
+      "failure_state": "LOCAL_DATA_UNAVAILABLE"
+    },
+    {
+      "rank": 4,
+      "source": "FOIA_OR_DATA_REQUEST",
+      "target": "Missing OCR/MDE breakdowns",
+      "goal": "Trigger if public data does not expose Minnesota category/outcome counts",
+      "failure_state": "NON_RESPONSIVE_REPLY"
+    }
+  ],
+  "canonical_extraction_fields": [
+    "year",
+    "state",
+    "agency",
+    "office",
+    "complaint_category",
+    "case_count",
+    "resolution_count",
+    "positive_resolution_count",
+    "dismissal_count",
+    "pending_count",
+    "mediated_count",
+    "median_days_to_resolution",
+    "source_url",
+    "source_hash",
+    "retrieved_at"
+  ],
+  "null_rule": "If a field is not explicitly present in the source, keep null. Do not infer.",
+  "closure_rule": "Closed, dismissed, or administratively resolved does not count as positive_resolution_count unless a documented remedy exists.",
+  "notes": [
+    "This manifest contains no numeric data.",
+    "This manifest contains no inferred fields.",
+    "This manifest is safe to hash and commit."
+  ]
+}

--- a/_truth/edu_civil_rights/national/STATE_EDU_CIVIL_RIGHTS_RESOLUTION_RATE.contract.json
+++ b/_truth/edu_civil_rights/national/STATE_EDU_CIVIL_RIGHTS_RESOLUTION_RATE.contract.json
@@ -1,0 +1,20 @@
+{
+  "system": "EDU_CIVIL_RIGHTS_OBSERVER",
+  "receipt_family": "STATE_EDU_CIVIL_RIGHTS_RESOLUTION_RATE",
+  "required_fields": [
+    "state",
+    "year",
+    "aggregates.case_count",
+    "aggregates.resolution_count",
+    "aggregates.positive_resolution_count",
+    "hash.value"
+  ],
+  "allowed_states": "50_states_plus_DC",
+  "national_rule": {
+    "no_state_without_leaf": true,
+    "no_leaf_without_hash": true,
+    "no_aggregate_without_validated_rows": true,
+    "no_narrative_without_receipt": true,
+    "missing_states_are_absent_not_estimated": true
+  }
+}

--- a/docs/edu_civil_rights/ct/FOIA_CT_001.txt
+++ b/docs/edu_civil_rights/ct/FOIA_CT_001.txt
@@ -1,0 +1,20 @@
+CT_EDU_CIVIL_RIGHTS_001 — FOIA / Data Request Template (Hardened v1)
+
+Purpose: Acquire the missing Connecticut-specific complaint counts, outcome codes, and remedy documentation required to populate the leaf.
+
+A. OCR FOIA Request (Federal)
+
+To: foia@ed.gov
+Subject: FOIA Request – Connecticut Education Civil Rights Complaints (Latest Complete Year)
+
+[Same structure as MN request, with Minnesota replaced by Connecticut]
+
+B. Connecticut State Education Agency Request
+
+To: [CT SEA data request contact]
+Subject: Data Request – Connecticut Education Civil Rights / Discrimination Complaints
+
+[Same structure as MN request, adapted to CT]
+
+Operator Line:
+Leaf is frozen. FOIA pressure begins. No numbers enter the machine without a source hash.

--- a/docs/edu_civil_rights/mn/FOIA_MN_001.txt
+++ b/docs/edu_civil_rights/mn/FOIA_MN_001.txt
@@ -1,0 +1,135 @@
+MN_EDU_CIVIL_RIGHTS_001 — FOIA / Data Request Template (Hardened v1)
+
+Purpose: Acquire the missing Minnesota-specific complaint counts, outcome codes, and remedy documentation required to populate the leaf.
+
+A. OCR FOIA Request (Federal)
+
+To: foia@ed.gov
+Subject: FOIA Request – Minnesota Education Civil Rights Complaints (Latest Complete Year)
+
+This is a request under the Freedom of Information Act.
+
+I request machine-readable records for the latest complete reporting year covering all education-related civil-rights complaints involving Minnesota students, schools, or districts, including but not limited to:
+
+1. Case-level fields:
+   - complaint ID
+   - date filed
+   - date closed (if applicable)
+   - complaint category (e.g., disability/504, disability/IDEA, race, sex, retaliation, discipline, etc.)
+   - outcome code
+   - whether a remedy was required
+   - description of corrective action, compensatory services, or policy change (if applicable)
+   - mediation outcome (if applicable)
+
+2. Aggregated fields:
+   - total complaints filed
+   - total resolved
+   - total dismissed
+   - total pending
+   - total mediated (with and without remedy)
+   - median days to resolution
+
+3. Documentation:
+   - resolution letters
+   - voluntary resolution agreements
+   - corrective action plans
+   - any summary documents used internally to classify outcomes
+
+Format requested:
+- JSON, CSV, or other machine-readable format.
+- If documents exist only as PDFs, please provide them.
+
+Scope:
+- Minnesota-only complaints.
+- Education-related civil-rights matters handled by the Office for Civil Rights.
+- Latest complete reporting year.
+
+This request is made for public transparency and analysis.
+Please provide a tracking number for this request.
+
+Sincerely,
+[Your Name]
+
+---
+
+B. Minnesota Department of Education Data Request (State)
+
+To: datarequests.mde@state.mn.us
+Subject: Data Request – Minnesota Education Civil Rights / Discrimination Complaints
+
+This is a request for public data under the Minnesota Government Data Practices Act.
+
+I request machine-readable records for the latest complete year covering all discrimination or civil-rights complaints received or processed by the Minnesota Department of Education, including:
+
+1. Case-level fields:
+   - complaint ID
+   - date filed
+   - date closed
+   - complaint category
+   - outcome code
+   - whether a remedy was required
+   - description of remedy or corrective action (if applicable)
+
+2. Aggregated fields:
+   - total complaints filed
+   - total resolved
+   - total dismissed
+   - total pending
+   - total mediated (with and without remedy)
+   - median days to resolution
+
+3. Documentation:
+   - resolution letters
+   - corrective action plans
+   - mediation agreements
+   - any summary documents used to classify outcomes
+
+Format requested:
+- JSON, CSV, or other machine-readable format.
+
+Scope:
+- Minnesota-only.
+- Education-related civil-rights or discrimination complaints.
+- Latest complete reporting year.
+
+Please confirm receipt and provide a tracking number.
+
+Sincerely,
+[Your Name]
+
+---
+
+C. District-Level Public Records Request (Optional Trigger)
+
+Only used if OCR + MDE fail to provide category/outcome breakdowns.
+
+To: [District Data Practices Contact]
+Subject: Data Request – Civil Rights / Discrimination Complaints (Latest Year)
+
+Under the Minnesota Government Data Practices Act, I request:
+
+- Complaint categories
+- Outcome codes
+- Remedy documentation (if any)
+- Aggregated counts (filed/resolved/dismissed/pending)
+
+Machine-readable format preferred.
+
+---
+
+D. Machine Alignment Block
+
+{
+  "receipt_id": "MN_EDU_CIVIL_RIGHTS_001",
+  "ingest_mode": "AWAITING_PRIMARY_SOURCE",
+  "foia_status": "TEMPLATES_READY",
+  "next_action": "SEND_REQUESTS",
+  "blocked_actions": [
+    "populate_numeric_fields",
+    "derive_outcomes_from_clip",
+    "infer_missing_counts"
+  ]
+}
+
+Operator Line:
+Leaf is frozen. FOIA pressure begins. No numbers enter the machine without a source hash.

--- a/docs/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.md
+++ b/docs/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.md
@@ -1,0 +1,17 @@
+# MN_EDU_CIVIL_RIGHTS_001
+
+Status: SCHEMA_LOCKED → SOURCE_INGEST_READY
+
+This document tracks the first Minnesota baseline for education civil-rights complaint outcomes.
+
+No claims, numbers, or conclusions are present yet.
+
+## Rules
+
+- No numbers without source hashes
+- No backlog interpretation without case outcomes
+- No closure counted as remedy
+
+## Next Step
+
+SOURCE_INGEST

--- a/docs/edu_civil_rights/national/DASHBOARD.md
+++ b/docs/edu_civil_rights/national/DASHBOARD.md
@@ -1,0 +1,21 @@
+# EDU_CIVIL_RIGHTS_OBSERVER – State Receipt Dashboard
+
+This dashboard is generated from:
+
+- `_truth/edu_civil_rights/*/*_EDU_CIVIL_RIGHTS_001.leaf.json`
+- `_truth/edu_civil_rights/national/dashboard_state_status.json`
+
+## State Status Codes
+
+- **SCHEMA_LOCKED + no hash + no aggregates** → Scaffold only (no data).
+- **numeric_fields_populated = true + hash_present = true** → Eligible for national aggregation.
+- **Absent from dashboard_state_status.json** → No leaf exists.
+
+## Commands
+
+```bash
+bash scripts/edu_civil_rights/run_dashboard_status.sh
+python3 scripts/edu_civil_rights/national_aggregate.py > _truth/edu_civil_rights/national/national_aggregate.json
+```
+
+Narrative may gesture. Only receipts prove.

--- a/scripts/edu_civil_rights/aggregate_mn_leaf_001.py
+++ b/scripts/edu_civil_rights/aggregate_mn_leaf_001.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import json, hashlib, datetime, os
+from statistics import median
+
+LEAF_PATH = "_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.leaf.json"
+DELTA_DIR = "_truth/edu_civil_rights/mn/deltas"
+
+RESOLUTION_OUTCOMES = set([
+    "POSITIVE_RESOLUTION",
+    "DISMISSAL",
+    "MEDIATED_WITH_REMEDY",
+    "MEDIATED_WITHOUT_REMEDY",
+    "VOLUNTARY_RESOLUTION_AGREEMENT",
+    "CORRECTIVE_ACTION_REQUIRED",
+    "NO_VIOLATION_FOUND",
+    "WITHDRAWN",
+    "REFERRED",
+    "ADMINISTRATIVE_CLOSURE"
+])
+
+POSITIVE_RESOLUTION_OUTCOMES = set([
+    "POSITIVE_RESOLUTION",
+    "CORRECTIVE_ACTION_REQUIRED",
+    "VOLUNTARY_RESOLUTION_AGREEMENT",
+    "MEDIATED_WITH_REMEDY"
+])
+
+DISMISSAL_OUTCOMES = set([
+    "DISMISSAL",
+    "ADMINISTRATIVE_CLOSURE"
+])
+
+PENDING_OUTCOMES = set([
+    "PENDING"
+])
+
+MEDIATED_OUTCOMES = set([
+    "MEDIATED_WITH_REMEDY",
+    "MEDIATED_WITHOUT_REMEDY"
+])
+
+def sha256_hex(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+def canonical_json(obj) -> str:
+    return json.dumps(obj, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+with open(LEAF_PATH, "r", encoding="utf-8") as f:
+    leaf = json.load(f)
+
+rows = leaf.get("data", {}).get("agency_breakdown", [])
+
+case_count = 0
+resolution_count = 0
+positive_resolution_count = 0
+dismissal_count = 0
+pending_count = 0
+mediated_count = 0
+days_to_resolution = []
+
+for r in rows:
+    case_count += 1
+    outcome = r.get("case_outcome")
+    days = r.get("days_to_resolution")
+
+    if outcome in RESOLUTION_OUTCOMES:
+        resolution_count += 1
+
+    if outcome in POSITIVE_RESOLUTION_OUTCOMES:
+        positive_resolution_count += 1
+
+    if outcome in DISMISSAL_OUTCOMES:
+        dismissal_count += 1
+
+    if outcome in PENDING_OUTCOMES:
+        pending_count += 1
+
+    if outcome in MEDIATED_OUTCOMES:
+        mediated_count += 1
+
+    if isinstance(days, (int, float)):
+        days_to_resolution.append(days)
+
+median_days_to_resolution = median(days_to_resolution) if days_to_resolution else None
+
+leaf["data"]["aggregates"] = {
+    "case_count": case_count,
+    "resolution_count": resolution_count,
+    "positive_resolution_count": positive_resolution_count,
+    "dismissal_count": dismissal_count,
+    "pending_count": pending_count,
+    "mediated_count": mediated_count,
+    "median_days_to_resolution": median_days_to_resolution
+}
+
+leaf["numeric_fields_populated"] = case_count > 0
+leaf["ingest_status"] = "AGGREGATED_FROM_VALIDATED_ROWS"
+leaf["hash"]["value"] = None
+leaf_hash = sha256_hex(canonical_json(leaf))
+leaf["hash"]["value"] = leaf_hash
+
+with open(LEAF_PATH, "w", encoding="utf-8") as f:
+    json.dump(leaf, f, indent=2, sort_keys=True)
+    f.write("\n")
+
+os.makedirs(DELTA_DIR, exist_ok=True)
+ts = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+delta_path = f"{DELTA_DIR}/{ts.replace(':', '')}_aggregate_delta.json"
+with open(delta_path, "w", encoding="utf-8") as f:
+    json.dump({
+        "timestamp": ts,
+        "receipt_id": "MN_EDU_CIVIL_RIGHTS_001",
+        "status": "AGGREGATED",
+        "hash": leaf_hash,
+        "aggregates": leaf["data"]["aggregates"],
+        "rules": {
+            "pending_is_not_resolution": True,
+            "aggregation_source": "validated_rows_only",
+            "inference": "disabled"
+        }
+    }, f, indent=2, sort_keys=True)
+    f.write("\n")
+
+print(f"Aggregates computed. Hash: {leaf_hash}")
+print(f"Delta: {delta_path}")

--- a/scripts/edu_civil_rights/aggregate_mn_leaf_001.py
+++ b/scripts/edu_civil_rights/aggregate_mn_leaf_001.py
@@ -3,7 +3,7 @@ import json, hashlib, datetime, os
 from statistics import median
 
 LEAF_PATH = "_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.leaf.json"
-DELTA_DIR = "_truth/edu_civil_rights/mn/deltas"
+DELTA_PATH = "_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.deltas.jsonl"
 
 RESOLUTION_OUTCOMES = set([
     "POSITIVE_RESOLUTION",
@@ -44,6 +44,14 @@ def sha256_hex(data: str) -> str:
 
 def canonical_json(obj) -> str:
     return json.dumps(obj, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+def utc_ts():
+    return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+def append_delta(entry):
+    os.makedirs(os.path.dirname(DELTA_PATH), exist_ok=True)
+    with open(DELTA_PATH, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, sort_keys=True, separators=(",", ":")) + "\n")
 
 with open(LEAF_PATH, "r", encoding="utf-8") as f:
     leaf = json.load(f)
@@ -103,23 +111,16 @@ with open(LEAF_PATH, "w", encoding="utf-8") as f:
     json.dump(leaf, f, indent=2, sort_keys=True)
     f.write("\n")
 
-os.makedirs(DELTA_DIR, exist_ok=True)
-ts = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-delta_path = f"{DELTA_DIR}/{ts.replace(':', '')}_aggregate_delta.json"
-with open(delta_path, "w", encoding="utf-8") as f:
-    json.dump({
-        "timestamp": ts,
-        "receipt_id": "MN_EDU_CIVIL_RIGHTS_001",
-        "status": "AGGREGATED",
-        "hash": leaf_hash,
-        "aggregates": leaf["data"]["aggregates"],
-        "rules": {
-            "pending_is_not_resolution": True,
-            "aggregation_source": "validated_rows_only",
-            "inference": "disabled"
-        }
-    }, f, indent=2, sort_keys=True)
-    f.write("\n")
+ts = utc_ts()
+append_delta({
+    "timestamp": ts,
+    "receipt_id": "MN_EDU_CIVIL_RIGHTS_001",
+    "event": "AGGREGATED",
+    "status": "AGGREGATED",
+    "hash": leaf_hash,
+    "numeric_fields_populated": leaf["numeric_fields_populated"],
+    "aggregates": leaf["data"]["aggregates"]
+})
 
 print(f"Aggregates computed. Hash: {leaf_hash}")
-print(f"Delta: {delta_path}")
+print(f"Delta ledger: {DELTA_PATH}")

--- a/scripts/edu_civil_rights/coverage_metric.py
+++ b/scripts/edu_civil_rights/coverage_metric.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import json, glob, os, sys
+
+TOTAL_STATES = 51  # 50 states + DC
+
+ready = 0
+states = []
+
+for path in sorted(glob.glob("_truth/edu_civil_rights/*/*_EDU_CIVIL_RIGHTS_001.leaf.json")):
+    leaf = json.load(open(path))
+    data = leaf.get("data", {})
+    state_code = os.path.basename(os.path.dirname(path)).upper()
+    state = data.get("state")
+
+    eligible = (
+        leaf.get("numeric_fields_populated") is True and
+        bool(leaf.get("hash", {}).get("value")) and
+        data.get("aggregates") is not None
+    )
+
+    states.append({
+        "state_code": state_code,
+        "state": state,
+        "leaf_path": path,
+        "eligible": bool(eligible)
+    })
+
+    if eligible:
+        ready += 1
+
+coverage = ready / TOTAL_STATES
+
+json.dump({
+    "coverage_fraction": coverage,
+    "coverage_percent": round(coverage * 100, 2),
+    "states_ready": ready,
+    "states_total": TOTAL_STATES,
+    "states_with_leaf": len(states),
+    "states_absent": TOTAL_STATES - len(states),
+    "state_breakdown": states,
+    "rule": {
+        "absent_states_count_in_denominator": True,
+        "absent_states_are_not_synthesized_as_rows": True,
+        "eligibility_requires_numeric_fields_hash_and_aggregates": True
+    }
+}, sys.stdout, indent=2, sort_keys=True)
+sys.stdout.write("\n")

--- a/scripts/edu_civil_rights/coverage_timeseries.py
+++ b/scripts/edu_civil_rights/coverage_timeseries.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import json, os, datetime
+
+COVERAGE_PATH = "_truth/edu_civil_rights/national/coverage.json"
+TIMESERIES_PATH = "_truth/edu_civil_rights/national/coverage_timeseries.jsonl"
+
+if not os.path.exists(COVERAGE_PATH):
+    raise SystemExit(f"missing coverage snapshot: {COVERAGE_PATH}")
+
+with open(COVERAGE_PATH, "r", encoding="utf-8") as f:
+    snapshot = json.load(f)
+
+entry = {
+    "timestamp": datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+    "coverage_fraction": snapshot.get("coverage_fraction"),
+    "coverage_percent": snapshot.get("coverage_percent"),
+    "states_ready": snapshot.get("states_ready"),
+    "states_total": snapshot.get("states_total"),
+    "states_with_leaf": snapshot.get("states_with_leaf"),
+    "states_absent": snapshot.get("states_absent"),
+    "state_breakdown": snapshot.get("state_breakdown"),
+    "properties": {
+        "append_only": True,
+        "no_mutation": True,
+        "no_interpretation": True,
+        "no_smoothing": True
+    }
+}
+
+os.makedirs(os.path.dirname(TIMESERIES_PATH), exist_ok=True)
+
+with open(TIMESERIES_PATH, "a", encoding="utf-8") as f:
+    f.write(json.dumps(entry, sort_keys=True, separators=(",", ":")) + "\n")
+
+print("Timeseries entry appended.")
+print(TIMESERIES_PATH)

--- a/scripts/edu_civil_rights/dashboard_state_status.py
+++ b/scripts/edu_civil_rights/dashboard_state_status.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import json, glob, os, sys
+
+states = []
+
+for path in sorted(glob.glob("_truth/edu_civil_rights/*/*_EDU_CIVIL_RIGHTS_001.leaf.json")):
+    leaf = json.load(open(path))
+    data = leaf.get("data", {})
+    aggregates = data.get("aggregates")
+    state_code = os.path.basename(os.path.dirname(path)).upper()
+    hash_present = bool(leaf.get("hash", {}).get("value"))
+    numeric_fields_populated = bool(leaf.get("numeric_fields_populated"))
+    aggregates_present = aggregates is not None
+
+    states.append({
+        "state_code": state_code,
+        "state_name": data.get("state"),
+        "year": data.get("year"),
+        "leaf_path": path,
+        "schema_status": leaf.get("schema_status"),
+        "ingest_status": leaf.get("ingest_status"),
+        "numeric_fields_populated": numeric_fields_populated,
+        "hash_present": hash_present,
+        "aggregates_present": aggregates_present,
+        "national_output_eligible": bool(numeric_fields_populated and hash_present and aggregates_present)
+    })
+
+json.dump({"states": states}, sys.stdout, indent=2, sort_keys=True)
+sys.stdout.write("\n")

--- a/scripts/edu_civil_rights/extract_mn_001.sh
+++ b/scripts/edu_civil_rights/extract_mn_001.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 INPUT.pdf OUTPUT.json" >&2
+  exit 64
+fi
+
+PDF="$1"
+OUT="$2"
+
+TMP_TXT=$(mktemp)
+TMP_ROWS=$(mktemp)
+
+cleanup() {
+  rm -f "$TMP_TXT" "$TMP_ROWS"
+}
+trap cleanup EXIT
+
+"$(dirname "$0")/pdf_to_text.sh" "$PDF" "$TMP_TXT"
+python3 "$(dirname "$0")/table_extract.py" "$TMP_TXT" > "$TMP_ROWS"
+python3 "$(dirname "$0")/normalize_json.py" < "$TMP_ROWS" | jq -S . > "$OUT"

--- a/scripts/edu_civil_rights/hash_mn_leaf_001.sh
+++ b/scripts/edu_civil_rights/hash_mn_leaf_001.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LEAF="_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.leaf.json"
+
+jq -S . "$LEAF" | \
+  tr -d '\r' | \
+  openssl dgst -sha256 | \
+  sed 's/^.* //'

--- a/scripts/edu_civil_rights/mark_first_eligible.py
+++ b/scripts/edu_civil_rights/mark_first_eligible.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import json, glob, os, datetime
+
+def utc_ts():
+    return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+def load_leaf(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def is_eligible(leaf):
+    data = leaf.get("data", {})
+    return (
+        leaf.get("numeric_fields_populated") is True and
+        bool(leaf.get("hash", {}).get("value")) and
+        data.get("aggregates") is not None
+    )
+
+def has_first_eligible_event(delta_path, receipt_id):
+    if not os.path.exists(delta_path):
+        return False
+    with open(delta_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            entry = json.loads(line)
+            if entry.get("receipt_id") == receipt_id and entry.get("event") == "FIRST_ELIGIBLE":
+                return True
+    return False
+
+for path in sorted(glob.glob("_truth/edu_civil_rights/*/*_EDU_CIVIL_RIGHTS_001.leaf.json")):
+    leaf = load_leaf(path)
+    data = leaf.get("data", {})
+    receipt_id = leaf.get("receipt_id")
+    state_dir = os.path.dirname(path)
+    delta_path = os.path.join(state_dir, f"{receipt_id}.deltas.jsonl")
+
+    if not is_eligible(leaf):
+        continue
+
+    if has_first_eligible_event(delta_path, receipt_id):
+        continue
+
+    entry = {
+        "timestamp": utc_ts(),
+        "receipt_id": receipt_id,
+        "event": "FIRST_ELIGIBLE",
+        "hash": leaf.get("hash", {}).get("value"),
+        "numeric_fields_populated": leaf.get("numeric_fields_populated"),
+        "aggregates": data.get("aggregates")
+    }
+
+    os.makedirs(state_dir, exist_ok=True)
+    with open(delta_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, sort_keys=True, separators=(",", ":")) + "\n")
+
+    print(f"FIRST_ELIGIBLE recorded for {receipt_id}")

--- a/scripts/edu_civil_rights/national_aggregate.py
+++ b/scripts/edu_civil_rights/national_aggregate.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import json, glob, sys
+
+states = []
+
+for path in glob.glob("_truth/edu_civil_rights/*/*_EDU_CIVIL_RIGHTS_001.leaf.json"):
+    leaf = json.load(open(path))
+    data = leaf.get("data", {})
+    ag = data.get("aggregates")
+
+    if not ag:
+        continue
+
+    if not leaf.get("numeric_fields_populated"):
+        continue
+
+    if not leaf.get("hash", {}).get("value"):
+        continue
+
+    states.append({
+        "state": data.get("state"),
+        "year": data.get("year"),
+        "case_count": ag.get("case_count"),
+        "resolution_count": ag.get("resolution_count"),
+        "positive_resolution_count": ag.get("positive_resolution_count"),
+        "hash": leaf.get("hash", {}).get("value")
+    })
+
+json.dump({"states": states}, sys.stdout, indent=2, sort_keys=True)

--- a/scripts/edu_civil_rights/normalize_json.py
+++ b/scripts/edu_civil_rights/normalize_json.py
@@ -1,0 +1,58 @@
+import sys, json
+
+VALID_CATEGORIES = set([
+    "DISABILITY_SECTION_504",
+    "DISABILITY_IDEA_RELATED",
+    "RACE_COLOR_NATIONAL_ORIGIN",
+    "SEX_TITLE_IX",
+    "RETALIATION",
+    "LANGUAGE_ACCESS",
+    "RELIGION",
+    "AGE",
+    "DISCIPLINE_DISPARITY",
+    "ACCESSIBILITY_PHYSICAL_OR_DIGITAL",
+    "HARASSMENT_HOSTILE_ENVIRONMENT",
+    "SPECIAL_EDUCATION_SERVICES",
+    "OTHER_CIVIL_RIGHTS",
+    "UNKNOWN_OR_UNCLASSIFIED"
+])
+
+VALID_OUTCOMES = set([
+    "POSITIVE_RESOLUTION",
+    "DISMISSAL",
+    "MEDIATED_WITH_REMEDY",
+    "MEDIATED_WITHOUT_REMEDY",
+    "VOLUNTARY_RESOLUTION_AGREEMENT",
+    "CORRECTIVE_ACTION_REQUIRED",
+    "NO_VIOLATION_FOUND",
+    "WITHDRAWN",
+    "REFERRED",
+    "ADMINISTRATIVE_CLOSURE",
+    "PENDING",
+    "UNKNOWN"
+])
+
+rows = json.load(sys.stdin)["rows"]
+
+out = []
+for r in rows:
+    out.append({
+        "year": None,
+        "state": "Minnesota",
+        "agency": None,
+        "office": None,
+        "complaint_category": None,
+        "case_count": None,
+        "resolution_count": None,
+        "positive_resolution_count": None,
+        "dismissal_count": None,
+        "pending_count": None,
+        "mediated_count": None,
+        "median_days_to_resolution": None,
+        "source_url": None,
+        "source_hash": None,
+        "retrieved_at": None,
+        "raw_row": r
+    })
+
+json.dump(out, sys.stdout, indent=2)

--- a/scripts/edu_civil_rights/pdf_to_text.sh
+++ b/scripts/edu_civil_rights/pdf_to_text.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 INPUT.pdf OUTPUT.txt" >&2
+  exit 64
+fi
+
+INPUT="$1"
+OUTPUT="$2"
+
+pdftotext -layout "$INPUT" "$OUTPUT"

--- a/scripts/edu_civil_rights/populate_mn_leaf_001.py
+++ b/scripts/edu_civil_rights/populate_mn_leaf_001.py
@@ -2,7 +2,7 @@
 import sys, json, hashlib, datetime, os
 
 LEAF_PATH = "_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.leaf.json"
-DELTA_DIR = "_truth/edu_civil_rights/mn/deltas"
+DELTA_PATH = "_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.deltas.jsonl"
 
 VALID_CATEGORIES = set([
     "DISABILITY_SECTION_504",
@@ -61,6 +61,14 @@ def sha256_hex(data: str) -> str:
 def canonical_json(obj) -> str:
     return json.dumps(obj, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
 
+def utc_ts():
+    return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+def append_delta(entry):
+    os.makedirs(os.path.dirname(DELTA_PATH), exist_ok=True)
+    with open(DELTA_PATH, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, sort_keys=True, separators=(",", ":")) + "\n")
+
 def validate_row(row, idx):
     errors = []
     for key in REQUIRED_ROW_KEYS:
@@ -96,21 +104,21 @@ def main():
             continue
         errors.extend(validate_row(row, idx))
 
+    ts = utc_ts()
+
     if errors:
-        os.makedirs(DELTA_DIR, exist_ok=True)
-        ts = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-        error_delta = {
+        append_delta({
             "timestamp": ts,
             "receipt_id": "MN_EDU_CIVIL_RIGHTS_001",
+            "event": "POPULATION_REJECTED",
             "status": "REJECTED",
+            "hash": leaf.get("hash", {}).get("value"),
+            "numeric_fields_populated": leaf.get("numeric_fields_populated"),
+            "aggregates": leaf.get("data", {}).get("aggregates"),
             "errors": errors,
             "rows_attempted": len(rows)
-        }
-        delta_path = f"{DELTA_DIR}/{ts.replace(':', '')}_rejected_delta.json"
-        with open(delta_path, "w", encoding="utf-8") as f:
-            json.dump(error_delta, f, indent=2, sort_keys=True)
-            f.write("\n")
-        print(f"Rejected ingestion. Delta: {delta_path}")
+        })
+        print(f"Rejected ingestion. Delta ledger: {DELTA_PATH}")
         for e in errors:
             print(e, file=sys.stderr)
         sys.exit(65)
@@ -128,23 +136,20 @@ def main():
         json.dump(leaf, f, indent=2, sort_keys=True)
         f.write("\n")
 
-    os.makedirs(DELTA_DIR, exist_ok=True)
-    ts = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-    delta = {
+    append_delta({
         "timestamp": ts,
         "receipt_id": "MN_EDU_CIVIL_RIGHTS_001",
+        "event": "POPULATION_ACCEPTED",
         "status": "ACCEPTED",
         "hash": leaf_hash,
+        "numeric_fields_populated": leaf["numeric_fields_populated"],
+        "aggregates": leaf["data"].get("aggregates"),
         "errors": [],
         "rows_ingested": len(rows)
-    }
-    delta_path = f"{DELTA_DIR}/{ts.replace(':', '')}_accepted_delta.json"
-    with open(delta_path, "w", encoding="utf-8") as f:
-        json.dump(delta, f, indent=2, sort_keys=True)
-        f.write("\n")
+    })
 
     print(f"Updated leaf. Hash: {leaf_hash}")
-    print(f"Delta: {delta_path}")
+    print(f"Delta ledger: {DELTA_PATH}")
 
 if __name__ == "__main__":
     main()

--- a/scripts/edu_civil_rights/populate_mn_leaf_001.py
+++ b/scripts/edu_civil_rights/populate_mn_leaf_001.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+import sys, json, hashlib, datetime, os
+
+LEAF_PATH = "_truth/edu_civil_rights/mn/MN_EDU_CIVIL_RIGHTS_001.leaf.json"
+DELTA_DIR = "_truth/edu_civil_rights/mn/deltas"
+
+VALID_CATEGORIES = set([
+    "DISABILITY_SECTION_504",
+    "DISABILITY_IDEA_RELATED",
+    "RACE_COLOR_NATIONAL_ORIGIN",
+    "SEX_TITLE_IX",
+    "RETALIATION",
+    "LANGUAGE_ACCESS",
+    "RELIGION",
+    "AGE",
+    "DISCIPLINE_DISPARITY",
+    "ACCESSIBILITY_PHYSICAL_OR_DIGITAL",
+    "HARASSMENT_HOSTILE_ENVIRONMENT",
+    "SPECIAL_EDUCATION_SERVICES",
+    "OTHER_CIVIL_RIGHTS",
+    "UNKNOWN_OR_UNCLASSIFIED"
+])
+
+VALID_OUTCOMES = set([
+    "POSITIVE_RESOLUTION",
+    "DISMISSAL",
+    "MEDIATED_WITH_REMEDY",
+    "MEDIATED_WITHOUT_REMEDY",
+    "VOLUNTARY_RESOLUTION_AGREEMENT",
+    "CORRECTIVE_ACTION_REQUIRED",
+    "NO_VIOLATION_FOUND",
+    "WITHDRAWN",
+    "REFERRED",
+    "ADMINISTRATIVE_CLOSURE",
+    "PENDING",
+    "UNKNOWN"
+])
+
+REQUIRED_ROW_KEYS = [
+    "year",
+    "state",
+    "agency",
+    "office",
+    "complaint_category",
+    "case_count",
+    "resolution_count",
+    "positive_resolution_count",
+    "dismissal_count",
+    "pending_count",
+    "mediated_count",
+    "median_days_to_resolution",
+    "source_url",
+    "source_hash",
+    "retrieved_at",
+    "raw_row"
+]
+
+def sha256_hex(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+def canonical_json(obj) -> str:
+    return json.dumps(obj, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+def validate_row(row, idx):
+    errors = []
+    for key in REQUIRED_ROW_KEYS:
+        if key not in row:
+            errors.append(f"row[{idx}] missing required key: {key}")
+
+    cat = row.get("complaint_category")
+    outcome = row.get("case_outcome")
+
+    if cat is not None and cat not in VALID_CATEGORIES:
+        errors.append(f"row[{idx}] invalid complaint_category: {cat}")
+
+    if outcome is not None and outcome not in VALID_OUTCOMES:
+        errors.append(f"row[{idx}] invalid case_outcome: {outcome}")
+
+    if row.get("state") != "Minnesota":
+        errors.append(f"row[{idx}] state must be Minnesota")
+
+    return errors
+
+def main():
+    rows = json.load(sys.stdin)
+    if not isinstance(rows, list):
+        raise SystemExit("input must be a JSON array")
+
+    with open(LEAF_PATH, "r", encoding="utf-8") as f:
+        leaf = json.load(f)
+
+    errors = []
+    for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            errors.append(f"row[{idx}] is not an object")
+            continue
+        errors.extend(validate_row(row, idx))
+
+    if errors:
+        os.makedirs(DELTA_DIR, exist_ok=True)
+        ts = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+        error_delta = {
+            "timestamp": ts,
+            "receipt_id": "MN_EDU_CIVIL_RIGHTS_001",
+            "status": "REJECTED",
+            "errors": errors,
+            "rows_attempted": len(rows)
+        }
+        delta_path = f"{DELTA_DIR}/{ts.replace(':', '')}_rejected_delta.json"
+        with open(delta_path, "w", encoding="utf-8") as f:
+            json.dump(error_delta, f, indent=2, sort_keys=True)
+            f.write("\n")
+        print(f"Rejected ingestion. Delta: {delta_path}")
+        for e in errors:
+            print(e, file=sys.stderr)
+        sys.exit(65)
+
+    leaf["data"]["agency_breakdown"] = rows
+    leaf["numeric_fields_populated"] = False
+    leaf["source_hashes_present"] = all(bool(r.get("source_hash")) for r in rows) if rows else False
+    leaf["ingest_status"] = "POPULATED_WITH_VALIDATED_ROWS"
+
+    leaf["hash"]["value"] = None
+    leaf_hash = sha256_hex(canonical_json(leaf))
+    leaf["hash"]["value"] = leaf_hash
+
+    with open(LEAF_PATH, "w", encoding="utf-8") as f:
+        json.dump(leaf, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    os.makedirs(DELTA_DIR, exist_ok=True)
+    ts = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    delta = {
+        "timestamp": ts,
+        "receipt_id": "MN_EDU_CIVIL_RIGHTS_001",
+        "status": "ACCEPTED",
+        "hash": leaf_hash,
+        "errors": [],
+        "rows_ingested": len(rows)
+    }
+    delta_path = f"{DELTA_DIR}/{ts.replace(':', '')}_accepted_delta.json"
+    with open(delta_path, "w", encoding="utf-8") as f:
+        json.dump(delta, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    print(f"Updated leaf. Hash: {leaf_hash}")
+    print(f"Delta: {delta_path}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/edu_civil_rights/run_aggregate_001.sh
+++ b/scripts/edu_civil_rights/run_aggregate_001.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 scripts/edu_civil_rights/aggregate_mn_leaf_001.py

--- a/scripts/edu_civil_rights/run_coverage_metric.sh
+++ b/scripts/edu_civil_rights/run_coverage_metric.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT="_truth/edu_civil_rights/national/coverage.json"
+mkdir -p "$(dirname "$OUT")"
+
+python3 scripts/edu_civil_rights/coverage_metric.py > "$OUT"

--- a/scripts/edu_civil_rights/run_coverage_timeseries.sh
+++ b/scripts/edu_civil_rights/run_coverage_timeseries.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 scripts/edu_civil_rights/coverage_timeseries.py

--- a/scripts/edu_civil_rights/run_dashboard_status.sh
+++ b/scripts/edu_civil_rights/run_dashboard_status.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT="_truth/edu_civil_rights/national/dashboard_state_status.json"
+mkdir -p "$(dirname "$OUT")"
+
+python3 scripts/edu_civil_rights/dashboard_state_status.py > "$OUT"

--- a/scripts/edu_civil_rights/run_mark_first_eligible.sh
+++ b/scripts/edu_civil_rights/run_mark_first_eligible.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 scripts/edu_civil_rights/mark_first_eligible.py

--- a/scripts/edu_civil_rights/table_extract.py
+++ b/scripts/edu_civil_rights/table_extract.py
@@ -1,0 +1,14 @@
+import sys, json, re
+
+if len(sys.argv) != 2:
+    sys.stderr.write("usage: table_extract.py INPUT.txt\n")
+    sys.exit(64)
+
+text = open(sys.argv[1]).read().splitlines()
+rows = []
+
+for line in text:
+    if re.search(r'\d', line) and ',' in line:
+        rows.append(line)
+
+json.dump({"rows": rows}, sys.stdout, indent=2)

--- a/scripts/edu_civil_rights/update_leaf_001.sh
+++ b/scripts/edu_civil_rights/update_leaf_001.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 INPUT.json" >&2
+  exit 64
+fi
+
+INPUT="$1"
+
+python3 scripts/edu_civil_rights/populate_mn_leaf_001.py < "$INPUT"


### PR DESCRIPTION
Adds canonical ingest-safe artifacts for MN_EDU_CIVIL_RIGHTS_001.

- sources manifest (no data)
- empty leaf shell
- deterministic hash script
- docs stub

No numeric data introduced. No claims made.

Ready for SOURCE_INGEST.