### PR TITLE
LG Track 001: Deterministic Source Registry

### DIFF
--- a/.github/workflows/lg_gate.yml
+++ b/.github/workflows/lg_gate.yml
@@ -1,0 +1,27 @@
+name: LG Gate
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt
+
+      - name: Run LG source registry validator
+        run: |
+          python3 scripts/lg_validate_sources.py

--- a/docs/normalize/html_to_text_v1.md
+++ b/docs/normalize/html_to_text_v1.md
@@ -1,0 +1,31 @@
+# HTML to Text Normalization Spec — LG v1
+
+Status: normative for LG Track 001 HTML sources.
+
+## Purpose
+
+Convert HTML source payloads into deterministic UTF-8 text before hashing.
+
+## Required behavior
+
+1. Fetch raw response bytes.
+2. Decode as UTF-8 unless source-specific headers require another declared encoding.
+3. Remove script, style, noscript, and SVG blocks.
+4. Strip HTML tags after preserving block boundaries.
+5. Decode HTML entities.
+6. Normalize Unicode to NFC.
+7. Collapse runs of spaces and tabs to one space.
+8. Collapse three or more blank lines to two newlines.
+9. Trim leading and trailing whitespace.
+10. Emit UTF-8 text bytes ending with exactly one newline.
+
+## Hash boundary
+
+Hash only the normalized text bytes.
+
+## Forbidden behavior
+
+- Do not include crawl timestamp in normalized text.
+- Do not include request headers in normalized text.
+- Do not reorder page content.
+- Do not silently drop visible text unless this spec is versioned.

--- a/docs/normalize/json_canonical_jcs.md
+++ b/docs/normalize/json_canonical_jcs.md
@@ -1,0 +1,35 @@
+# JSON Canonicalization Spec — LG v1
+
+Status: normative for LG Track 001.
+
+## Purpose
+
+Convert JSON source payloads into deterministic bytes before hashing.
+
+## Rule
+
+Use RFC 8785 / JSON Canonicalization Scheme semantics unless this repository states a stricter rule.
+
+## Required behavior
+
+1. Parse JSON as data, not text.
+2. Reject invalid JSON.
+3. Sort object keys lexicographically by Unicode code point.
+4. Preserve array order.
+5. Emit compact JSON with no insignificant whitespace.
+6. Preserve string content exactly after JSON parsing.
+7. Do not delete null fields unless a source-specific normalizer explicitly says so.
+8. Hash UTF-8 encoded canonical output bytes.
+
+## Reference command
+
+For simple JSON objects where jq behavior is acceptable for the source:
+
+```bash
+jq -cS . input.json > normalized.json
+sha256sum normalized.json
+```
+
+## Boundary
+
+If jq and RFC 8785 disagree for a source, the source registry must name a stricter implementation before ingest may run.

--- a/docs/normalize/pdf_text_v1.md
+++ b/docs/normalize/pdf_text_v1.md
@@ -1,0 +1,28 @@
+# PDF to Text Normalization Spec — LG v1
+
+Status: normative for LG Track 001 PDF sources.
+
+## Purpose
+
+Convert PDF source payloads into deterministic UTF-8 text before hashing.
+
+## Required behavior
+
+1. Extract text using a deterministic toolchain (e.g., pdftotext -layout -nopgbrk).
+2. Normalize Unicode to NFC.
+3. Remove form feed characters.
+4. Preserve reading order as emitted by the extractor.
+5. Collapse runs of spaces and tabs to one space.
+6. Collapse three or more blank lines to two newlines.
+7. Trim leading and trailing whitespace.
+8. Emit UTF-8 text bytes ending with exactly one newline.
+
+## Hash boundary
+
+Hash only the normalized text bytes.
+
+## Forbidden behavior
+
+- Do not include file metadata (creation date, producer) in normalized text.
+- Do not reorder paragraphs.
+- Do not apply OCR unless declared and versioned in this spec.

--- a/law/ingest/law_sources.json
+++ b/law/ingest/law_sources.json
@@ -14,7 +14,8 @@
         "format": "html",
         "canonicalization": {
           "spec": "docs/normalize/html_to_text_v1.md",
-          "version": "v1"
+          "version": "v1",
+          "spec_hash": "sha256:9ae4b9c454339747eed7fb4ffbe146c6c2410b627f0bee5a4543a9973cb38c2b"
         }
       },
       "hash_policy": {
@@ -41,7 +42,8 @@
         "format": "json",
         "canonicalization": {
           "spec": "docs/normalize/json_canonical_jcs.md",
-          "version": "v1"
+          "version": "v1",
+          "spec_hash": "sha256:cc989d0775a2bc0bfe312031421c05b8b97907f12f6cc90b2db62aaa3b66e2a2"
         }
       },
       "hash_policy": {
@@ -68,7 +70,8 @@
         "format": "pdf",
         "canonicalization": {
           "spec": "docs/normalize/pdf_text_v1.md",
-          "version": "v1"
+          "version": "v1",
+          "spec_hash": "sha256:ab55ee7f0d9c53e18b68f1bfacd56cdba5a156df36e5784240b58a72d19aa256"
         }
       },
       "hash_policy": {

--- a/law/ingest/law_sources.json
+++ b/law/ingest/law_sources.json
@@ -2,24 +2,84 @@
   "sources": [
     {
       "id": "doj_press_releases",
-      "type": "public_json_or_html",
       "lane": "doj",
+      "jurisdiction": "US",
       "url": "https://www.justice.gov/news",
-      "status": "seed"
+      "method": "GET",
+      "auth": "none",
+      "cadence": "daily",
+      "pagination": "page",
+      "normalization": {
+        "version": "lg-normalize-v1",
+        "format": "html",
+        "canonicalization": {
+          "spec": "docs/normalize/html_to_text_v1.md",
+          "version": "v1"
+        }
+      },
+      "hash_policy": {
+        "algorithm": "sha256",
+        "scope": "normalized_text"
+      },
+      "receipt_policy": {
+        "emit": true,
+        "path": "law/receipts/doj/"
+      },
+      "status": "active"
     },
     {
       "id": "courtlistener_opinions",
-      "type": "public_api",
       "lane": "cases",
+      "jurisdiction": "US",
       "url": "https://www.courtlistener.com/api/rest/v4/opinions/",
-      "status": "seed"
+      "method": "GET",
+      "auth": "none",
+      "cadence": "daily",
+      "pagination": "page",
+      "normalization": {
+        "version": "lg-normalize-v1",
+        "format": "json",
+        "canonicalization": {
+          "spec": "docs/normalize/json_canonical_jcs.md",
+          "version": "v1"
+        }
+      },
+      "hash_policy": {
+        "algorithm": "sha256",
+        "scope": "normalized_json"
+      },
+      "receipt_policy": {
+        "emit": true,
+        "path": "law/receipts/cases/"
+      },
+      "status": "active"
     },
     {
       "id": "us_code_house",
-      "type": "public_law",
       "lane": "lawbooks",
+      "jurisdiction": "US",
       "url": "https://uscode.house.gov/download/download.shtml",
-      "status": "seed"
+      "method": "GET",
+      "auth": "none",
+      "cadence": "weekly",
+      "pagination": "none",
+      "normalization": {
+        "version": "lg-normalize-v1",
+        "format": "pdf",
+        "canonicalization": {
+          "spec": "docs/normalize/pdf_text_v1.md",
+          "version": "v1"
+        }
+      },
+      "hash_policy": {
+        "algorithm": "sha256",
+        "scope": "normalized_text"
+      },
+      "receipt_policy": {
+        "emit": true,
+        "path": "law/receipts/lawbooks/"
+      },
+      "status": "active"
     }
   ]
 }

--- a/law/ingest/law_sources.schema.json
+++ b/law/ingest/law_sources.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Law Sources Registry",
+  "type": "object",
+  "properties": {
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id","lane","jurisdiction","url","method","auth","cadence","pagination","normalization","hash_policy","receipt_policy","status"],
+        "properties": {
+          "id": {"type": "string"},
+          "lane": {"type": "string"},
+          "jurisdiction": {"type": "string"},
+          "url": {"type": "string","format": "uri"},
+          "method": {"type": "string","enum": ["GET","POST"]},
+          "auth": {"type": "string","enum": ["none","api_key","token"]},
+          "cadence": {"type": "string","enum": ["manual","daily","weekly"]},
+          "pagination": {"type": "string","enum": ["none","cursor","page"]},
+          "normalization": {
+            "type": "object",
+            "required": ["version","format","canonicalization"],
+            "properties": {
+              "version": {"type": "string"},
+              "format": {"type": "string","enum": ["json","html","pdf","text"]},
+              "canonicalization": {
+                "type": "object",
+                "properties": {
+                  "spec": {"type": "string"},
+                  "version": {"type": "string"}
+                }
+              }
+            }
+          },
+          "hash_policy": {
+            "type": "object",
+            "properties": {
+              "algorithm": {"type": "string","enum": ["sha256"]},
+              "scope": {"type": "string","enum": ["raw_bytes","normalized_json","normalized_text"]}
+            }
+          },
+          "receipt_policy": {
+            "type": "object",
+            "properties": {
+              "emit": {"type": "boolean"},
+              "path": {"type": "string"}
+            }
+          },
+          "status": {"type": "string","enum": ["seed","active","disabled"]}
+        }
+      }
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema==4.21.1

--- a/scripts/lg_validate_sources.py
+++ b/scripts/lg_validate_sources.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import hashlib, json, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "law/ingest/law_sources.json"
+
+def sha256_file(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+def main():
+    data = json.loads(REGISTRY.read_text())
+    errors = []
+
+    for src in data.get("sources", []):
+        sid = src.get("id", "<missing>")
+        canon = src.get("normalization", {}).get("canonicalization", {})
+        spec = canon.get("spec")
+        expected = canon.get("spec_hash")
+
+        if not spec:
+            errors.append(f"{sid}: missing canonicalization.spec")
+            continue
+
+        spec_path = ROOT / spec
+        if not spec_path.exists():
+            errors.append(f"{sid}: missing spec file {spec}")
+            continue
+
+        actual = "sha256:" + sha256_file(spec_path)
+
+        if not expected:
+            print(f"TO_FIX {sid}: spec_hash should be {actual}")
+            errors.append(f"{sid}: missing canonicalization.spec_hash")
+            continue
+
+        if actual != expected:
+            print(f"TO_FIX {sid}: spec_hash should be {actual}")
+            errors.append(f"{sid}: spec_hash mismatch expected={expected} actual={actual}")
+
+    if errors:
+        print("LG_SOURCE_REGISTRY_INVALID")
+        for e in errors:
+            print("FAIL:", e)
+        return 1
+
+    print("LG_SOURCE_REGISTRY_VALID")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds schema and upgrades law_sources.json to deterministic, replay-safe registry.

- Adds law/ingest/law_sources.schema.json
- Upgrades all sources with cadence, normalization, hash policy
- Enables LG Track 001 gate
