### PR TITLE
LINK_V1: parent-child lineage layer

### DIFF
--- a/schema/AgentActionLinkV1.json
+++ b/schema/AgentActionLinkV1.json
@@ -1,0 +1,16 @@
+{
+  "name": "AgentActionLinkV1",
+  "relations": ["spawned", "verified", "delegated", "superseded"],
+  "fields": [
+    { "name": "parentUID", "type": "bytes32" },
+    { "name": "childUID", "type": "bytes32" },
+    { "name": "parentActionHash", "type": "bytes32" },
+    { "name": "childActionHash", "type": "bytes32" },
+    { "name": "parentSigner", "type": "address" },
+    { "name": "childSigner", "type": "address" },
+    { "name": "relation", "type": "string" },
+    { "name": "timestamp", "type": "uint64" },
+    { "name": "payloadRef", "type": "string" }
+  ],
+  "schema": "bytes32 parentUID,bytes32 childUID,bytes32 parentActionHash,bytes32 childActionHash,address parentSigner,address childSigner,string relation,uint64 timestamp,string payloadRef"
+}

--- a/scripts/deploy-link-schema.ts
+++ b/scripts/deploy-link-schema.ts
@@ -1,0 +1,19 @@
+import { SchemaRegistry } from '@ethereum-attestation-service/eas-sdk';
+import { ethers } from 'ethers';
+
+const SCHEMA = 'bytes32 parentUID,bytes32 childUID,bytes32 parentActionHash,bytes32 childActionHash,address parentSigner,address childSigner,string relation,uint64 timestamp,string payloadRef';
+
+async function main() {
+  const provider = new ethers.JsonRpcProvider(process.env.BASE_SEPOLIA_RPC);
+  const signer = new ethers.Wallet(process.env.PRIVATE_KEY!, provider);
+
+  const registry = new SchemaRegistry('0x4200000000000000000000000000000000000020');
+  registry.connect(signer);
+
+  const tx = await registry.register({ schema: SCHEMA, resolverAddress: ethers.ZeroAddress, revocable: true });
+  const uid = await tx.wait();
+
+  console.log(JSON.stringify({ linkSchemaUID: uid }, null, 2));
+}
+
+main();

--- a/scripts/link-receipts.ts
+++ b/scripts/link-receipts.ts
@@ -1,0 +1,43 @@
+import { EAS, SchemaEncoder } from '@ethereum-attestation-service/eas-sdk';
+import { ethers } from 'ethers';
+import fs from 'fs';
+
+const EAS_ADDR = '0x4200000000000000000000000000000000000021';
+const SCHEMA = 'bytes32 parentUID,bytes32 childUID,bytes32 parentActionHash,bytes32 childActionHash,address parentSigner,address childSigner,string relation,uint64 timestamp,string payloadRef';
+
+async function main() {
+  const [parentPath, childPath, relation] = process.argv.slice(2);
+  if (!parentPath || !childPath || !relation) throw new Error('Usage: link parent.json child.json relation');
+
+  const parent = JSON.parse(fs.readFileSync(parentPath, 'utf8'));
+  const child = JSON.parse(fs.readFileSync(childPath, 'utf8'));
+
+  const provider = new ethers.JsonRpcProvider(process.env.BASE_SEPOLIA_RPC);
+  const signer = new ethers.Wallet(process.env.PRIVATE_KEY!, provider);
+
+  const eas = new EAS(EAS_ADDR);
+  eas.connect(signer);
+
+  const encoder = new SchemaEncoder(SCHEMA);
+  const data = encoder.encodeData([
+    { name: 'parentUID', value: parent.attestationUID, type: 'bytes32' },
+    { name: 'childUID', value: child.attestationUID, type: 'bytes32' },
+    { name: 'parentActionHash', value: parent.actionHash, type: 'bytes32' },
+    { name: 'childActionHash', value: child.actionHash, type: 'bytes32' },
+    { name: 'parentSigner', value: parent.signer, type: 'address' },
+    { name: 'childSigner', value: child.signer, type: 'address' },
+    { name: 'relation', value: relation, type: 'string' },
+    { name: 'timestamp', value: Math.floor(Date.now()/1000), type: 'uint64' },
+    { name: 'payloadRef', value: '', type: 'string' }
+  ]);
+
+  const tx = await eas.attest({
+    schema: process.env.LINK_SCHEMA_UID!,
+    data: { recipient: child.signer, expirationTime: 0, revocable: true, refUID: ethers.ZeroHash, data, value: 0n }
+  });
+
+  const uid = await tx.wait();
+  console.log(JSON.stringify({ linkUID: uid, txHash: tx.hash }, null, 2));
+}
+
+main();

--- a/verifier/lineage.html
+++ b/verifier/lineage.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <h1>ALMS Lineage Verifier</h1>
-  <p>Input a child link UID. The verifier reads the link attestation from Base Sepolia EAS and renders the parent → child edge.</p>
+  <p>Input a child link attestation UID. The verifier reads the link attestation from Base Sepolia EAS and renders the parent → child edge.</p>
 
   <label>Link attestation UID</label>
   <input id="uid" placeholder="0x..." />
@@ -26,7 +26,7 @@ import { ethers } from 'https://cdn.jsdelivr.net/npm/ethers/+esm';
 
 const EAS = '0x4200000000000000000000000000000000000021';
 const RPC = 'https://sepolia.base.org';
-const LINK_SCHEMA = 'bytes32 parentUID,bytes32 childUID,bytes32 parentActionHash,bytes32 childActionHash,address parentSigner,address childSigner,string relation,uint64 timestamp,string payloadRef';
+const LINK_SCHEMA_UID = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
 const uidEl = document.getElementById('uid');
 const out = document.getElementById('out');
@@ -41,6 +41,9 @@ async function verifyLineage(uid) {
   );
   const att = await eas.getAttestation(uid);
   if (!att.uid || att.uid === ethers.ZeroHash) return { verdict: 'CHAIN_LINEAGE_BROKEN', reason: 'link_attestation_not_found' };
+  if (LINK_SCHEMA_UID !== ethers.ZeroHash && att.schema.toLowerCase() !== LINK_SCHEMA_UID.toLowerCase()) {
+    return { verdict: 'CHAIN_LINEAGE_BROKEN', reason: 'wrong_schema', expected: LINK_SCHEMA_UID, actual: att.schema };
+  }
 
   const decoded = ethers.AbiCoder.defaultAbiCoder().decode(
     ['bytes32','bytes32','bytes32','bytes32','address','address','string','uint64','string'],
@@ -61,9 +64,11 @@ async function verifyLineage(uid) {
 
   const allowed = ['spawned', 'verified', 'delegated', 'superseded'];
   const relationValid = allowed.includes(edge.relation);
+  if (!relationValid) return { verdict: 'CHAIN_LINEAGE_BROKEN', reason: 'invalid_relation', edge };
+  if (edge.childUID.toLowerCase() !== uid.toLowerCase()) return { verdict: 'CHAIN_LINEAGE_BROKEN', reason: 'uid_mismatch', expected: uid, actual: edge.childUID, edge };
 
   return {
-    verdict: relationValid ? 'CHAIN_LINEAGE_VALID' : 'CHAIN_LINEAGE_BROKEN',
+    verdict: 'CHAIN_LINEAGE_VALID',
     uid,
     schemaUID: att.schema,
     attester: att.attester,

--- a/verifier/lineage.html
+++ b/verifier/lineage.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <h1>ALMS Lineage Verifier</h1>
-  <p>Input a child link attestation UID. The verifier reads the link attestation from Base Sepolia EAS and renders the parent → child edge.</p>
+  <p>Input a child link attestation UID. The verifier reads the link attestation from Base and renders the parent → child edge.</p>
 
   <label>Link attestation UID</label>
   <input id="uid" placeholder="0x..." />
@@ -25,8 +25,8 @@
 import { ethers } from 'https://cdn.jsdelivr.net/npm/ethers/+esm';
 
 const EAS = '0x4200000000000000000000000000000000000021';
-const RPC = 'https://sepolia.base.org';
-const LINK_SCHEMA_UID = '0x0000000000000000000000000000000000000000000000000000000000000000';
+const RPC = 'https://mainnet.base.org';
+const LINK_SCHEMA_UID = '0x93c5ccbb6334ce3f9b56e77580c45cbeb616ad27a9f1955a65ab51b8f7e2d35e';
 
 const uidEl = document.getElementById('uid');
 const out = document.getElementById('out');
@@ -41,7 +41,7 @@ async function verifyLineage(uid) {
   );
   const att = await eas.getAttestation(uid);
   if (!att.uid || att.uid === ethers.ZeroHash) return { verdict: 'CHAIN_LINEAGE_BROKEN', reason: 'link_attestation_not_found' };
-  if (LINK_SCHEMA_UID !== ethers.ZeroHash && att.schema.toLowerCase() !== LINK_SCHEMA_UID.toLowerCase()) {
+  if (att.schema.toLowerCase() !== LINK_SCHEMA_UID.toLowerCase()) {
     return { verdict: 'CHAIN_LINEAGE_BROKEN', reason: 'wrong_schema', expected: LINK_SCHEMA_UID, actual: att.schema };
   }
 

--- a/verifier/lineage.html
+++ b/verifier/lineage.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ALMS Lineage Verifier</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; }
+    input { width: 100%; box-sizing: border-box; margin: .5rem 0 1rem; }
+    pre { background: #111; color: #eee; padding: 1rem; overflow: auto; }
+  </style>
+</head>
+<body>
+  <h1>ALMS Lineage Verifier</h1>
+  <p>Input a child link UID. The verifier reads the link attestation from Base Sepolia EAS and renders the parent → child edge.</p>
+
+  <label>Link attestation UID</label>
+  <input id="uid" placeholder="0x..." />
+  <button id="verify">Verify Lineage Edge</button>
+
+  <h2>Result</h2>
+  <pre id="out">Waiting.</pre>
+
+<script type="module">
+import { ethers } from 'https://cdn.jsdelivr.net/npm/ethers/+esm';
+
+const EAS = '0x4200000000000000000000000000000000000021';
+const RPC = 'https://sepolia.base.org';
+const LINK_SCHEMA = 'bytes32 parentUID,bytes32 childUID,bytes32 parentActionHash,bytes32 childActionHash,address parentSigner,address childSigner,string relation,uint64 timestamp,string payloadRef';
+
+const uidEl = document.getElementById('uid');
+const out = document.getElementById('out');
+function print(x) { out.textContent = JSON.stringify(x, null, 2); }
+
+async function verifyLineage(uid) {
+  const provider = new ethers.JsonRpcProvider(RPC);
+  const eas = new ethers.Contract(
+    EAS,
+    ['function getAttestation(bytes32 uid) view returns (tuple(bytes32 uid,bytes32 schema,uint64 time,uint64 expirationTime,uint64 revocationTime,bytes32 refUID,address recipient,address attester,bool revocable,bytes data))'],
+    provider
+  );
+  const att = await eas.getAttestation(uid);
+  if (!att.uid || att.uid === ethers.ZeroHash) return { verdict: 'CHAIN_LINEAGE_BROKEN', reason: 'link_attestation_not_found' };
+
+  const decoded = ethers.AbiCoder.defaultAbiCoder().decode(
+    ['bytes32','bytes32','bytes32','bytes32','address','address','string','uint64','string'],
+    att.data
+  );
+
+  const edge = {
+    parentUID: decoded[0],
+    childUID: decoded[1],
+    parentActionHash: decoded[2],
+    childActionHash: decoded[3],
+    parentSigner: decoded[4],
+    childSigner: decoded[5],
+    relation: decoded[6],
+    timestamp: Number(decoded[7]),
+    payloadRef: decoded[8]
+  };
+
+  const allowed = ['spawned', 'verified', 'delegated', 'superseded'];
+  const relationValid = allowed.includes(edge.relation);
+
+  return {
+    verdict: relationValid ? 'CHAIN_LINEAGE_VALID' : 'CHAIN_LINEAGE_BROKEN',
+    uid,
+    schemaUID: att.schema,
+    attester: att.attester,
+    recipient: att.recipient,
+    edge,
+    rendered: `${edge.parentSigner} --${edge.relation}--> ${edge.childSigner}`
+  };
+}
+
+document.getElementById('verify').onclick = async () => {
+  try { print(await verifyLineage(uidEl.value.trim())); }
+  catch (e) { print({ verdict: 'CHAIN_LINEAGE_BROKEN', error: e instanceof Error ? e.message : String(e) }); }
+};
+
+const params = new URLSearchParams(location.search);
+if (params.get('uid')) {
+  uidEl.value = params.get('uid');
+  document.getElementById('verify').click();
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## v2 — Parent-Child Lineage Layer

Builds on v1a (local proof) + v1b (EAS anchoring).

Scope:
- AgentActionLinkV1 schema
- Link schema deploy script
- Link receipts script
- Lineage verifier UI

Excludes:
- payments
- observers
- v1 mutation

Discipline:
- append-only
- deterministic encoding
- one link = one attestation

Outcome:
Receipts can now form provable lineage chains (parent → child).