### PR TITLE
MEME_COURT: add canonical docket authority

### DIFF
--- a/_truth/meme_court/docket.jsonl
+++ b/_truth/meme_court/docket.jsonl
@@ -1,0 +1,5 @@
+{"case_id":"WFG-0001","issue":52,"status":"STRESS_TEST","path":"site/meme-court/wfg-0001.html","authority_issue":76,"precedent":"NOT_YET_ATTESTED","verdict":"PENDING"}
+{"case_id":"MC-702-001","issue":65,"status":"CAMPAIGN_LAYER","path":"alms/meme_court/cases/","authority_issue":76,"precedent":"NOT_YET_ATTESTED","verdict":"PENDING"}
+{"case_id":"MC-702-LEAGUE-001","issue":66,"status":"ACTIVE_CAMPAIGN_KIT","path":"alms/meme_court/cases/","authority_issue":76,"precedent":"NOT_YET_ATTESTED","verdict":"PENDING"}
+{"case_id":"ADR-RECEIPTS-001","issue":68,"status":"RECEIPT_PENDING","path":"_truth/meme_court/cases/","authority_issue":76,"precedent":"NOT_YET_ATTESTED","verdict":"PENDING"}
+{"case_id":"TARIFF-001","issue":69,"status":"RECEIPT_PENDING_SOURCES","path":"_truth/meme_court/cases/","authority_issue":76,"precedent":"NOT_YET_ATTESTED","verdict":"PENDING"}


### PR DESCRIPTION
Closes #76

Adds `_truth/meme_court/docket.jsonl` as the append-only jurisdiction index.

Non-claims:
- no precedent finalized
- no MATCH_CONFIRMED claims
- no EAS UID asserted
- no Base/ENS/Zora finality asserted

All entries remain PENDING and NOT_YET_ATTESTED.