### PR TITLE
Add Deterministic Civic Memory + ALMS CVD whitepaper foundation

### DIFF
--- a/docs/diagrams/CONSTITUTIONAL_KERNEL_MAP_V1.svg
+++ b/docs/diagrams/CONSTITUTIONAL_KERNEL_MAP_V1.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900">
+<rect width="100%" height="100%" fill="white"/>
+<text x="40" y="50" font-size="28">ALMS Constitutional Kernel v0.1</text>
+<text x="40" y="85" font-size="16">Theory → Specification → Execution → Public Opinion</text>
+
+<rect x="60" y="140" width="240" height="90" fill="none" stroke="black"/>
+<text x="80" y="185" font-size="18">Minimal Records Doctrine</text>
+
+<rect x="360" y="140" width="240" height="90" fill="none" stroke="black"/>
+<text x="410" y="185" font-size="18">REPLAY_SPEC_V1</text>
+
+<rect x="660" y="140" width="240" height="90" fill="none" stroke="black"/>
+<text x="705" y="185" font-size="18">FIXTURE_SPEC_V1</text>
+
+<rect x="960" y="140" width="280" height="90" fill="none" stroke="black"/>
+<text x="1005" y="185" font-size="18">VERIFIER_SPEC_V1</text>
+
+<line x1="300" y1="185" x2="360" y2="185" stroke="black"/>
+<line x1="600" y1="185" x2="660" y2="185" stroke="black"/>
+<line x1="900" y1="185" x2="960" y2="185" stroke="black"/>
+
+<rect x="360" y="340" width="260" height="90" fill="none" stroke="black"/>
+<text x="390" y="385" font-size="18">CVD_OUTPUT_SCHEMA_V1</text>
+
+<rect x="720" y="340" width="320" height="90" fill="none" stroke="black"/>
+<text x="770" y="385" font-size="18">Public Replay Opinions</text>
+
+<line x1="1100" y1="230" x2="1100" y2="340" stroke="black"/>
+<line x1="620" y1="385" x2="720" y2="385" stroke="black"/>
+
+<rect x="80" y="560" width="340" height="100" fill="none" stroke="black"/>
+<text x="120" y="610" font-size="18">Minnesota STATE_FIXTURE_001</text>
+
+<rect x="500" y="560" width="340" height="100" fill="none" stroke="black"/>
+<text x="555" y="610" font-size="18">Replay Court Execution</text>
+
+<rect x="920" y="560" width="360" height="100" fill="none" stroke="black"/>
+<text x="980" y="610" font-size="18">Machine-Verifiable Civic Memory</text>
+
+<line x1="250" y1="430" x2="250" y2="560" stroke="black"/>
+<line x1="880" y1="430" x2="670" y2="560" stroke="black"/>
+<line x1="1040" y1="430" x2="1100" y2="560" stroke="black"/>
+
+<text x="40" y="820" font-size="16">Core Rules:</text>
+<text x="40" y="850" font-size="14">No replay, no proof. No trace, no opinion. No network calls during replay.</text>
+</svg>

--- a/docs/governance/CONSTITUTIONAL_BOUNDARY_LEDGER_V1.md
+++ b/docs/governance/CONSTITUTIONAL_BOUNDARY_LEDGER_V1.md
@@ -1,0 +1,70 @@
+# CONSTITUTIONAL_BOUNDARY_LEDGER_V1 — ALMS Kernel Boundaries
+
+## Status
+
+`CONSTITUTIONAL_BOUNDARY_LEDGER_V1_OPENED`
+
+---
+
+## Purpose
+
+Codify the mandatory, forbidden, and executable boundaries of ALMS Constitutional Kernel v0.1.
+
+The ledger is a control surface for auditors, implementers, verifiers, and future agents.
+
+It records what ALMS must do, must forbid, and must execute deterministically.
+
+---
+
+## Boundary Table
+
+| ID | Class | Rule | Enforcement Surface | Failure Mode |
+|---|---|---|---|---|
+| B001 | MUST | GitHub is the canonical byte surface unless another canonical source is explicitly declared. | Root schema / fixtures | INDETERMINATE |
+| B002 | MUST | Identity resolves discovery. | ENS / public root / witnesses | REVIEW_REQUIRED |
+| B003 | MUST | Replay resolves truth. | Verifier / replay spec | FAIL or INDETERMINATE |
+| B004 | MUST | Every proof claim requires canonical bytes. | REPLAY_SPEC_V1 | INDETERMINATE |
+| B005 | MUST | Every fixture requires provenance declaration. | FIXTURE_SPEC_V1 | INDETERMINATE |
+| B006 | MUST | Every replay requires declared transform policy. | REPLAY_SPEC_V1 | INDETERMINATE or TAINTED |
+| B007 | MUST | Every verifier verdict requires replay trace. | VERIFIER_SPEC_V1 / CVD_OUTPUT_SCHEMA_V1 | invalid opinion |
+| B008 | MUST | Every public drift opinion emits CVD_OUTPUT_SCHEMA_V1. | CVD output | invalid report |
+| B009 | MUST | Witnesses remain optional timestamp/discovery surfaces. | Witness validator | REVIEW_REQUIRED |
+| B010 | MUST | Minnesota is STATE_FIXTURE_001 until superseded by explicit versioned doctrine. | MN corpus spec | REVIEW_REQUIRED |
+| F001 | FORBID | No network calls during replay. | Reference verifier | TAINTED |
+| F002 | FORBID | No hidden API keys or private secrets required for public proof. | Verifier / CI | invalid proof |
+| F003 | FORBID | No witness may replace canonical bytes. | Witness validator | REVIEW_REQUIRED or FAIL |
+| F004 | FORBID | No platform ID may be treated as authoritative UID. | Root schema | REVIEW_REQUIRED |
+| F005 | FORBID | No implicit transform. | Canonicalizer | INDETERMINATE |
+| F006 | FORBID | No self-referential report hashing. | CVD output / CI | invalid report |
+| F007 | FORBID | No narrative summary may substitute for canonical evidence. | Fixture / receipt | FAIL or INDETERMINATE |
+| F008 | FORBID | No PASS without digest recomputation. | Verifier / CI | invalid verdict |
+| E001 | EXECUTE | Validate schema before replay. | Verifier | invalid input |
+| E002 | EXECUTE | Validate provenance before admissibility. | Fixture validator | INDETERMINATE |
+| E003 | EXECUTE | Canonicalize under declared policy. | Canonicalizer | TAINTED if policy-divergent |
+| E004 | EXECUTE | Compute digest over canonical bytes. | Digest engine | FAIL on mismatch |
+| E005 | EXECUTE | Verify receipt binding. | Receipt engine | FAIL or INDETERMINATE |
+| E006 | EXECUTE | Validate manifest aggregation rule. | Manifest validator | INDETERMINATE |
+| E007 | EXECUTE | Classify drift under CVD V1-V5. | CVD classifier | variant verdict |
+| E008 | EXECUTE | Emit deterministic public opinion artifact. | CVD output generator | invalid opinion |
+| E009 | EXECUTE | Preserve replay trace hash. | Report generator | invalid opinion |
+| E010 | EXECUTE | Fail closed when evidence is insufficient. | Verdict engine | INDETERMINATE |
+
+---
+
+## Closure Conditions
+
+```text
+No replay, no proof.
+No canonical bytes, no replay.
+No declared transform policy, no admissibility.
+No trace, no opinion.
+No network calls during replay.
+```
+
+---
+
+## Final Rule
+
+A constitutional replay system is trusted only when its boundaries are enforceable.
+
+Verify > narrative.

--- a/docs/specs/CVD_OUTPUT_SCHEMA_V1.md
+++ b/docs/specs/CVD_OUTPUT_SCHEMA_V1.md
@@ -1,0 +1,367 @@
+# CVD_OUTPUT_SCHEMA_V1 — ALMS Public Drift Opinion Schema
+
+## Status
+
+`CVD_OUTPUT_SCHEMA_V1_OPENED`
+
+---
+
+## Purpose
+
+Define the public output artifact for ALMS Core Variant Detector findings.
+
+A CVD output is the machine-readable and human-readable civic drift opinion emitted by a verifier after replay.
+
+It converts verifier results into a stable public accountability artifact that can be rendered, indexed, searched, cited, and independently audited.
+
+The CVD output does not decide political legitimacy, legal authority, institutional intent, or narrative meaning.
+
+It records replay divergence and classifies it under deterministic ALMS variant classes.
+
+---
+
+## Core Rule
+
+```text
+one verifier run
+-> one replay trace
+-> one CVD output
+-> one public opinion artifact
+```
+
+No private verdicts.
+
+No unbounded narrative fields.
+
+No hidden evidence.
+
+No drift claim without replay trace.
+
+---
+
+## Relationship to Other Specs
+
+`CVD_OUTPUT_SCHEMA_V1` consumes outputs from:
+
+- `REPLAY_SPEC_V1`
+- `FIXTURE_SPEC_V1`
+- `VERIFIER_SPEC_V1`
+
+It produces:
+
+- public verifier reports
+- registry entries
+- UI-renderable drift opinions
+- voice/search-indexable civic memory records
+
+---
+
+## Required Invariants
+
+1. One report MUST correspond to one verifier run.
+2. Report JSON MUST be deterministic and canonically serializable.
+3. Report fields MUST be bounded.
+4. Report MUST include verifier version and spec references.
+5. Report MUST include fixture ID when a fixture is used.
+6. Report MUST include canonical vs observed comparison when available.
+7. Report MUST distinguish detection from interpretation.
+8. Report MUST preserve replay trace references.
+9. Report MUST be hashable as a standalone civic memory artifact.
+
+---
+
+## Top-Level Schema
+
+A CVD output SHOULD be represented as JSON:
+
+```json
+{
+  "schema": "CVD_OUTPUT_SCHEMA_V1",
+  "schema_version": "1.0.0",
+  "report_id": "cvd:<run_id>:sha256:<digest>",
+  "run": {
+    "run_id": "string",
+    "run_at": "ISO-8601 timestamp",
+    "verifier_spec": "VERIFIER_SPEC_V1",
+    "verifier_name": "string",
+    "verifier_version": "string",
+    "environment_ref": "string|null"
+  },
+  "subject": {
+    "fixture_id": "string|null",
+    "artifact_id": "string|null",
+    "jurisdiction": "string|null",
+    "domain": "string|null",
+    "source_uri": "string|null",
+    "source_type": "string|null"
+  },
+  "specs": {
+    "replay_spec": "REPLAY_SPEC_V1",
+    "fixture_spec": "FIXTURE_SPEC_V1|null",
+    "transform_policy_id": "string|null",
+    "transform_policy_hash": "sha256:<hex>|null"
+  },
+  "verdict": {
+    "state": "PASS|FAIL|INDETERMINATE|TAINTED|REVIEW_REQUIRED|HIGH_RISK_VARIANT",
+    "cvd_class": "NONE|V1_BYTE_VARIANT|V2_TRANSFORM_VARIANT|V3_PROVENANCE_VARIANT|V4_IDENTITY_VARIANT|V5_SEMANTIC_VARIANT",
+    "confidence": "DECLARED|COMPUTED|PARTIAL|UNDETERMINED",
+    "summary": "bounded string"
+  },
+  "comparison": {
+    "expected_digest": "sha256:<hex>|keccak256:<hex>|null",
+    "computed_digest": "sha256:<hex>|keccak256:<hex>|null",
+    "expected_manifest_root": "sha256:<hex>|keccak256:<hex>|null",
+    "computed_manifest_root": "sha256:<hex>|keccak256:<hex>|null",
+    "match": true
+  },
+  "evidence_graph": {
+    "nodes": [],
+    "edges": []
+  },
+  "replay_trace": [],
+  "diff": {
+    "available": false,
+    "type": "none|byte|text|json|table|semantic|other",
+    "uri": "string|null",
+    "summary": "bounded string|null"
+  },
+  "provenance_chain": [],
+  "witnesses": [],
+  "errors": [],
+  "human_readable": {
+    "title": "string",
+    "finding": "bounded string",
+    "operator_note": "bounded string|null"
+  },
+  "hash": {
+    "canonicalization": "jq -cS or declared canonical method",
+    "digest": "sha256:<hex>|null"
+  }
+}
+```
+
+---
+
+## Verdict Field Rules
+
+The `verdict.state` field MUST be one of:
+
+- `PASS`
+- `FAIL`
+- `INDETERMINATE`
+- `TAINTED`
+- `REVIEW_REQUIRED`
+- `HIGH_RISK_VARIANT`
+
+The `verdict.cvd_class` field MUST be one of:
+
+- `NONE`
+- `V1_BYTE_VARIANT`
+- `V2_TRANSFORM_VARIANT`
+- `V3_PROVENANCE_VARIANT`
+- `V4_IDENTITY_VARIANT`
+- `V5_SEMANTIC_VARIANT`
+
+A `PASS` verdict SHOULD use:
+
+```json
+{
+  "cvd_class": "NONE"
+}
+```
+
+---
+
+## Evidence Graph
+
+The evidence graph records the replay relationship between objects.
+
+Recommended node types:
+
+- `source_artifact`
+- `transform_policy`
+- `canonical_bytes`
+- `digest`
+- `receipt`
+- `manifest`
+- `witness`
+- `fixture`
+- `verifier_run`
+- `cvd_report`
+
+Recommended edge types:
+
+- `retrieved_from`
+- `canonicalized_by`
+- `hashes_to`
+- `bound_by_receipt`
+- `included_in_manifest`
+- `witnessed_by`
+- `verified_by`
+- `classified_as`
+
+Graph order MUST be deterministic.
+
+---
+
+## Replay Trace
+
+The replay trace records ordered verifier steps.
+
+Each step SHOULD include:
+
+```json
+{
+  "step": 1,
+  "name": "schema_validation",
+  "status": "PASS|FAIL|SKIPPED|INDETERMINATE",
+  "input_ref": "string|null",
+  "output_ref": "string|null",
+  "message": "bounded string|null"
+}
+```
+
+Trace steps MUST be ordered by execution sequence.
+
+A report without a replay trace is not a public CVD opinion.
+
+---
+
+## Diff Rules
+
+A diff MAY be embedded only when bounded and safe.
+
+Large diffs SHOULD be referenced by URI and digest.
+
+Diffs MUST distinguish:
+
+- byte difference,
+- text difference,
+- JSON structural difference,
+- table/numeric difference,
+- semantic/policy-level difference.
+
+Semantic diff output MUST be treated as detection support, not final interpretation.
+
+---
+
+## Provenance Chain
+
+The provenance chain SHOULD list source-to-report custody:
+
+```json
+{
+  "type": "source|retrieval|transform|receipt|manifest|witness|report",
+  "ref": "string",
+  "digest": "sha256:<hex>|null",
+  "timestamp": "ISO-8601 timestamp|null",
+  "actor": "string|null"
+}
+```
+
+Missing provenance MUST downgrade the verdict to `INDETERMINATE`, `TAINTED`, or `FAIL` depending on observed contradiction.
+
+---
+
+## Rendering Rules
+
+A CVD output MAY render to:
+
+- JSON
+- Markdown
+- HTML
+- public verifier UI
+- voice/search summaries
+- registry index rows
+
+All renderings MUST preserve:
+
+- report ID,
+- fixture ID when present,
+- verdict state,
+- CVD class,
+- verifier version,
+- canonical digest comparison,
+- replay trace reference.
+
+A rendered view MUST NOT omit a non-PASS verdict.
+
+---
+
+## Canonicalization and Hashing
+
+A CVD report SHOULD be hashable as its own civic memory artifact.
+
+Recommended canonicalization:
+
+```text
+jq -cS
+```
+
+The report hash MUST exclude its own `hash.digest` field or set that field to `null` before hashing.
+
+Self-referential report hashing is forbidden.
+
+---
+
+## Versioning
+
+This schema follows semantic versioning.
+
+`CVD_OUTPUT_SCHEMA_V1` is tied to:
+
+- `REPLAY_SPEC_V1`
+- `FIXTURE_SPEC_V1`
+- `VERIFIER_SPEC_V1`
+
+Breaking changes MUST create a new schema version.
+
+Prior reports MUST remain replayable under the schema version they declare.
+
+---
+
+## Failure Conditions
+
+A CVD output is invalid if:
+
+- schema version is missing,
+- verifier run ID is missing,
+- verdict state is missing,
+- CVD class is missing,
+- replay trace is missing,
+- digest comparison is omitted when applicable,
+- report hash is self-referential,
+- unbounded narrative replaces evidence fields,
+- private evidence is required to verify a public claim.
+
+---
+
+## Minnesota #001 Use
+
+Minnesota fixture reports SHOULD use this schema for the first civic replay case law layer.
+
+The target report form:
+
+```text
+MN public record fixture
+-> verifier run
+-> CVD output
+-> public opinion artifact
+-> registry/search/UI entry
+```
+
+The Minnesota success condition is not publication alone.
+
+The success condition is a reproducible public drift opinion generated from replayable civic evidence.
+
+---
+
+## Final Rule
+
+A verifier verdict becomes civic memory only when it is published as a deterministic CVD output.
+
+Private conclusions do not create public proof.
+
+No trace, no opinion.
+
+Verify > narrative.

--- a/docs/specs/FIXTURE_SPEC_V1.md
+++ b/docs/specs/FIXTURE_SPEC_V1.md
@@ -1,0 +1,286 @@
+# FIXTURE_SPEC_V1 — ALMS Civic Fixture Substrate
+
+## Status
+
+`FIXTURE_SPEC_V1_OPENED`
+
+---
+
+## Purpose
+
+Define the minimal unit of civic memory that can be independently replayed under ALMS.
+
+A fixture is a structured evidence object that binds a public source, provenance declaration, transform policy, canonical bytes, receipt, and replay conditions into one admissible civic verification unit.
+
+This specification is source-format neutral.
+
+A fixture may originate from CSV, JSON, Markdown, PDF, image, media, webpage, official portal export, or other declared public artifact.
+
+---
+
+## Core Rule
+
+```text
+No provenance declaration, no fixture.
+No canonical bytes, no receipt.
+No receipt, no replay.
+No replay, no civic memory.
+```
+
+A fixture is not merely a file.
+
+A fixture is a replay-admissible evidence unit.
+
+---
+
+## Core Invariants
+
+1. A fixture is the minimal unit of civic memory that can be independently replayed.
+2. Fixture identity is content-addressed, not location-addressed.
+3. Fixture provenance MUST be declared before replay.
+4. Fixture canonicalization MUST reference a deterministic transform policy.
+5. Fixture receipts MUST bind to canonical bytes, not summaries.
+6. Fixture drift MUST classify through ALMS Core Variant Detector classes.
+7. Witness layers MAY publish, timestamp, or route fixtures, but MUST NOT replace replay.
+
+---
+
+## Fixture Qualification
+
+A civic artifact qualifies as a fixture only if it declares:
+
+- source identity,
+- source retrieval method,
+- retrieval timestamp,
+- source type,
+- transform policy,
+- canonicalization method,
+- digest method,
+- expected canonical digest,
+- receipt location or embedded receipt,
+- replay conditions.
+
+Derived summaries, commentary, screenshots without source declaration, platform posts, or narrative claims are not fixtures by themselves.
+
+They MAY become derived artifacts linked to fixtures.
+
+---
+
+## Fixture Identity and Versioning
+
+A fixture ID SHOULD be derived from stable semantic scope plus canonical digest.
+
+Recommended form:
+
+```text
+fixture:<jurisdiction>:<domain>:<source_slug>:<date_or_version>:sha256:<digest>
+```
+
+Example:
+
+```text
+fixture:mn:budget:mmb-forecast:2026-02:sha256:<digest>
+```
+
+Fixture identity is content-addressed.
+
+If canonical bytes change, the fixture version changes.
+
+Location changes do not change fixture identity unless source identity or canonical bytes change.
+
+---
+
+## Fixture Object
+
+A fixture SHOULD be represented as JSON:
+
+```json
+{
+  "fixture_spec": "FIXTURE_SPEC_V1",
+  "fixture_id": "fixture:mn:budget:mmb-forecast:2026-02:sha256:<digest>",
+  "jurisdiction": "mn",
+  "domain": "budget",
+  "source": {
+    "title": "string",
+    "uri": "string",
+    "publisher": "string",
+    "retrieved_at": "ISO-8601 timestamp",
+    "retrieval_method": "manual | scripted | api | archive | other",
+    "source_type": "csv | json | markdown | pdf | image | media | webpage | other"
+  },
+  "transform": {
+    "policy_id": "string",
+    "policy_hash": "sha256:<hex>",
+    "canonicalization_method": "string",
+    "toolchain": ["string"],
+    "notes": "string|null"
+  },
+  "canonical": {
+    "digest_method": "sha256",
+    "digest": "sha256:<hex>",
+    "byte_length": 0,
+    "uri": "string|null"
+  },
+  "receipt": {
+    "receipt_spec": "ALMS_RECEIPT_V1",
+    "uri": "string|null",
+    "digest": "sha256:<hex>|null"
+  },
+  "replay": {
+    "replay_spec": "REPLAY_SPEC_V1",
+    "required_inputs": ["source", "transform_policy", "canonical_digest", "receipt"],
+    "expected_verdict": "PASS"
+  },
+  "witness": {
+    "required_for_verification": false,
+    "items": []
+  }
+}
+```
+
+---
+
+## Provenance Requirements
+
+A fixture provenance declaration MUST include:
+
+- source URI or archive URI,
+- publisher or originating body,
+- retrieval timestamp,
+- retrieval method,
+- operator identity or attestor,
+- source type,
+- any source access constraints,
+- any known source volatility.
+
+A fixture with missing provenance is not replay-admissible.
+
+---
+
+## Canonicalization Rules
+
+Fixture canonicalization MUST be deterministic, versioned, and reproducible.
+
+For JSON and CSV fixtures, policies MUST declare ordering, encoding, newline handling, quoting behavior, and whitespace normalization.
+
+For PDF fixtures, policies MUST declare parser, parser version when available, layout mode, page boundary handling, encoding behavior, footnote policy, table extraction assumptions, and any stitching rules.
+
+For image or media fixtures, policies MUST declare whether the canonical bytes are raw file bytes, normalized metadata-stripped bytes, frame extracts, transcript extracts, or derived hashes.
+
+No implicit transform is admissible.
+
+---
+
+## Receipt Emission
+
+A fixture receipt MUST bind:
+
+- fixture ID,
+- source identity,
+- transform policy ID,
+- canonical digest,
+- operator identity,
+- repository path or publication path,
+- creation timestamp,
+- optional witness references.
+
+A receipt MUST NOT bind only to narrative summary text unless the summary itself is the declared fixture.
+
+---
+
+## Replay Conditions
+
+A fixture is replayable when an independent operator can obtain or reconstruct:
+
+1. declared source artifact,
+2. declared transform policy,
+3. declared canonicalization toolchain,
+4. declared digest method,
+5. declared receipt,
+6. declared manifest or fixture index if applicable.
+
+If any of these are missing, replay MUST return `INDETERMINATE` unless contradiction is directly observable.
+
+---
+
+## Drift Classification
+
+Fixture-level divergence maps to ALMS Core Variant Detector classes:
+
+| CVD Class | Fixture Drift Meaning | Default Verdict |
+|---|---|---|
+| V1 — BYTE_VARIANT | canonical bytes differ | FAIL |
+| V2 — TRANSFORM_VARIANT | transform policy or toolchain differs | TAINTED or INDETERMINATE |
+| V3 — PROVENANCE_VARIANT | source lineage, receipt ancestry, or manifest continuity breaks | FAIL |
+| V4 — IDENTITY_VARIANT | identity, signer, ENS, attestor, or witness relationship changes while bytes remain stable | REVIEW_REQUIRED |
+| V5 — SEMANTIC_VARIANT | meaning, legal effect, policy posture, numeric claim, or operational instruction materially diverges | HIGH_RISK_VARIANT |
+
+---
+
+## Admissibility Failures
+
+A fixture is not replay-admissible if:
+
+- source identity is missing,
+- provenance is undeclared,
+- transform policy is missing,
+- canonical bytes cannot be reproduced,
+- digest method is undeclared,
+- receipt lineage is broken,
+- manifest rule is missing for aggregate fixtures,
+- witness is falsely treated as the truth boundary,
+- narrative summary is substituted for canonical evidence.
+
+---
+
+## Governance Hooks
+
+Fixture class changes MAY be reviewed under Jay's Pincer Movement governance model:
+
+Side A:
+Institutions, publishers, agencies, or official sources emit records.
+
+Side B:
+Independent operators, agents, auditors, and public verifiers replay canonical evidence.
+
+Fixture governance MUST NOT retroactively mutate prior fixture identity.
+
+Updates MUST create new fixture versions or new derived artifacts.
+
+Replay stability takes priority over narrative continuity.
+
+---
+
+## Minnesota Fixture Rule
+
+Minnesota is designated as the first civic replay fixture class:
+
+```text
+STATE_FIXTURE_001 = Minnesota
+```
+
+Minnesota fixtures SHOULD prioritize:
+
+- state budgets,
+- official forecasts,
+- legislative records,
+- statutes,
+- audit reports,
+- public finance documents,
+- agency-published evidence objects.
+
+The Minnesota success condition is not onchain adoption.
+
+The success condition is reproducible civic replay from public records to canonical proofs.
+
+---
+
+## Final Rule
+
+A fixture is civic memory only when it can be replayed.
+
+A record seen once is transparency.
+
+A record independently recomputed is verification.
+
+Verify > narrative.

--- a/docs/specs/MINNESOTA_FIXTURE_CORPUS_V1.md
+++ b/docs/specs/MINNESOTA_FIXTURE_CORPUS_V1.md
@@ -1,0 +1,293 @@
+# MINNESOTA_FIXTURE_CORPUS_V1 — ALMS First Civic Replay Corpus
+
+## Status
+
+`MINNESOTA_FIXTURE_CORPUS_V1_OPENED`
+
+---
+
+## Purpose
+
+Define the first public civic replay corpus for ALMS.
+
+Minnesota is designated:
+
+```text
+STATE_FIXTURE_001 = Minnesota
+```
+
+This corpus provides the first replay-admissible public fixture set used to validate:
+
+- `REPLAY_SPEC_V1`
+- `FIXTURE_SPEC_V1`
+- `VERIFIER_SPEC_V1`
+- `CVD_OUTPUT_SCHEMA_V1`
+- ALMS Core Variant Detector classifications
+
+The corpus is not a political position.
+
+It is a deterministic civic replay test surface.
+
+---
+
+## Corpus Objectives
+
+1. Prove replay equivalence over real public records.
+2. Prove fixture admissibility rules.
+3. Prove verifier determinism.
+4. Prove CVD classification behavior.
+5. Establish the first public civic replay case law layer.
+
+---
+
+## Initial Fixture Classes
+
+### Budget Fixtures
+
+Target examples:
+
+- Minnesota Management and Budget forecasts
+- appropriations tables
+- spending summaries
+- fiscal notes
+- agency budget reports
+
+---
+
+### Legislative Fixtures
+
+Target examples:
+
+- bills
+- amendments
+- statutes
+- session laws
+- committee reports
+- vote records
+
+---
+
+### Audit Fixtures
+
+Target examples:
+
+- Office of the Legislative Auditor reports
+- state audit reports
+- procurement findings
+- compliance reports
+
+---
+
+### Agency Fixtures
+
+Target examples:
+
+- agency-published PDFs
+- CSV exports
+- dashboards with downloadable evidence
+- machine-readable datasets
+
+---
+
+## Corpus Rules
+
+Every fixture MUST:
+
+- declare provenance,
+- declare transform policy,
+- declare canonicalization method,
+- declare digest method,
+- emit a receipt,
+- emit or reference a replay packet,
+- produce a verifier report,
+- produce a `CVD_OUTPUT_SCHEMA_V1` opinion.
+
+No raw upload alone qualifies as a corpus fixture.
+
+---
+
+## Corpus Directory Layout
+
+Recommended structure:
+
+```text
+_truth/fixtures/state/mn/
+  budgets/
+  legislation/
+  audits/
+  agencies/
+
+_truth/replay/mn/
+_truth/receipts/mn/
+_truth/cvd/mn/
+_truth/manifests/mn/
+
+policies/mn/
+
+schemas/
+```
+
+---
+
+## Example Fixture Flow
+
+```text
+Minnesota source record
+-> retrieval declaration
+-> transform policy
+-> canonical bytes
+-> digest
+-> receipt
+-> replay packet
+-> verifier run
+-> CVD output
+-> public civic memory artifact
+```
+
+---
+
+## Required Provenance Fields
+
+Every Minnesota fixture SHOULD declare:
+
+- source title
+- originating agency/body
+- source URI
+- retrieval timestamp
+- retrieval method
+- source type
+- transform policy ID
+- canonicalization toolchain
+- operator identity
+- repository path
+
+---
+
+## Canonicalization Targets
+
+### JSON / CSV
+
+Initial target:
+
+```text
+UTF-8
+stable newline behavior
+stable ordering
+jq -cS where applicable
+```
+
+---
+
+### PDF
+
+PDF fixtures MUST declare:
+
+- parser/toolchain
+- parser version when available
+- layout mode
+- page-boundary policy
+- encoding behavior
+- table extraction assumptions
+- footnote policy
+- stitching rules
+
+No implicit PDF transform is admissible.
+
+---
+
+## Initial Replay Targets
+
+The first replay targets SHOULD include:
+
+1. One clean PASS fixture
+2. One transform-tainted fixture
+3. One provenance-break fixture
+4. One semantic drift fixture
+5. One identity/witness drift fixture
+
+This ensures all core verdict states are exercised.
+
+---
+
+## Corpus Test Goals
+
+The Minnesota corpus SHOULD prove:
+
+- deterministic replay,
+- replay equivalence across independent operators,
+- stable canonicalization,
+- stable manifest aggregation,
+- CVD variant detection,
+- public report reproducibility.
+
+---
+
+## Public Opinion Layer
+
+Every verifier run SHOULD emit:
+
+```text
+fixture
+-> replay trace
+-> CVD output
+-> public opinion artifact
+```
+
+The public opinion artifact becomes machine-verifiable civic memory.
+
+---
+
+## Drift Monitoring
+
+Minnesota fixtures MAY be replayed periodically to detect:
+
+- source drift
+- transform drift
+- provenance breaks
+- witness inconsistency
+- semantic/policy changes
+
+Detected divergence MUST emit new CVD reports.
+
+Prior reports MUST remain replayable.
+
+---
+
+## Governance Rule
+
+Minnesota fixture governance follows Jay's Pincer Movement:
+
+Side A:
+Institutions publish records.
+
+Side B:
+Independent operators replay records.
+
+Replay equivalence is the convergence boundary.
+
+Narrative agreement is not required.
+
+---
+
+## Success Condition
+
+Minnesota succeeds as `STATE_FIXTURE_001` only when:
+
+- independent operators replay the same fixtures,
+- independent verifiers emit equivalent verdicts,
+- CVD reports remain reproducible,
+- provenance continuity survives over time.
+
+Publication alone is insufficient.
+
+Replay equivalence is required.
+
+---
+
+## Final Rule
+
+Minnesota is not the first ALMS state because it is onchain.
+
+Minnesota is the first ALMS state because its public records are stable enough to support deterministic civic replay.
+
+Verify > narrative.

--- a/docs/specs/REPLAY_SPEC_V1.md
+++ b/docs/specs/REPLAY_SPEC_V1.md
@@ -1,0 +1,203 @@
+# REPLAY_SPEC_V1 — ALMS Deterministic Replay Contract
+
+## Status
+
+`REPLAY_SPEC_V1_OPENED`
+
+---
+
+## Purpose
+
+Define the minimal replay contract for ALMS verification.
+
+This specification establishes how a public artifact becomes replay-admissible through canonicalization, hashing, receipt formation, manifest binding, and independent recomputation.
+
+The replay contract is not a political claim, platform claim, or legal ruling.
+
+It is a machine-verifiable boundary for determining replay equivalence.
+
+---
+
+## Core Rule
+
+```text
+source artifact
+-> transform policy
+-> canonical bytes
+-> cryptographic digest
+-> receipt
+-> manifest / Merkle binding
+-> verifier recomputation
+-> replay verdict
+```
+
+A claim is not replay-admissible until independent recomputation can reproduce the same verification state from the same declared evidence.
+
+---
+
+## Replay Inputs
+
+A replay packet SHOULD declare:
+
+```json
+{
+  "spec": "REPLAY_SPEC_V1",
+  "artifact_id": "string",
+  "source_uri": "string",
+  "source_type": "csv | json | markdown | pdf | image | media | other",
+  "transform_policy_id": "string",
+  "transform_policy_hash": "sha256:<hex>",
+  "canonicalization_method": "string",
+  "digest_method": "sha256 | keccak256 | sha256+keccak256",
+  "expected_digest": "<hex>",
+  "receipt_uri": "string",
+  "manifest_uri": "string|null",
+  "witness_uri": "string|null"
+}
+```
+
+---
+
+## Canonicalization Requirements
+
+A canonicalization method MUST be:
+
+1. deterministic,
+2. versioned,
+3. reproducible by an independent operator,
+4. byte-preserving after normalization,
+5. explicit about whitespace, ordering, encoding, page boundaries, and parser assumptions.
+
+For JSON objects, ALMS MAY use deterministic sorted compact JSON such as:
+
+```text
+jq -cS
+```
+
+For PDFs, ALMS MUST declare the extraction policy, parser, layout mode, encoding behavior, and any page-boundary rules.
+
+---
+
+## Digest Requirements
+
+Digest outputs MUST bind to canonical bytes, not narrative summaries.
+
+Accepted digest forms:
+
+```text
+sha256:<64 lowercase hex chars>
+keccak256:<64 lowercase hex chars>
+```
+
+A digest mismatch produces a replay failure unless the packet is explicitly classified as transform-tainted or indeterminate.
+
+---
+
+## Receipt Requirements
+
+A receipt SHOULD include:
+
+```json
+{
+  "receipt_spec": "ALMS_RECEIPT_V1",
+  "artifact_id": "string",
+  "source_uri": "string",
+  "transform_policy_id": "string",
+  "canonical_digest": "sha256:<hex>",
+  "created_at": "ISO-8601 timestamp",
+  "operator_identity": "string",
+  "repo": "jsonwisdom/AL",
+  "commit": "git commit sha|null",
+  "witness": {
+    "type": "none | EAS | ENS | BaseTx | IPFS | other",
+    "uri": "string|null",
+    "required_for_verification": false
+  }
+}
+```
+
+Witnesses are external publication or timestamp surfaces.
+
+They are not the truth boundary.
+
+---
+
+## Manifest / Merkle Binding
+
+A manifest binds one or more receipts into a larger verification state.
+
+For a single-leaf checkpoint:
+
+```text
+manifest_root = leaf_digest
+```
+
+For multi-leaf checkpoints, the manifest MUST declare the tree rule, leaf ordering rule, and domain separation rule.
+
+A manifest without a declared aggregation rule is not replay-admissible.
+
+---
+
+## Replay Verdicts
+
+### PASS
+
+Observed replay state equals canonical verification state.
+
+### FAIL
+
+Observed replay state contradicts canonical verification state.
+
+### INDETERMINATE
+
+Replay cannot complete because evidence, parser behavior, source availability, or transform environment is insufficient.
+
+### TAINTED
+
+Replay completes only through an unstable, unauthorized, or policy-divergent transform boundary.
+
+### REVIEW_REQUIRED
+
+Replay surfaces identity, authority, or witness inconsistency that does not by itself invalidate canonical bytes.
+
+### HIGH_RISK_VARIANT
+
+Replay detects semantic or policy-level divergence requiring downstream human, institutional, or court review.
+
+---
+
+## Boundary Conditions
+
+ALMS replay does not determine:
+
+- political legitimacy,
+- legal admissibility in a court,
+- moral authority,
+- institutional intent,
+- or factual truth beyond declared evidence.
+
+ALMS replay determines whether the declared evidence recomputes to the same verification state under the declared transform policy.
+
+---
+
+## Identity Rule
+
+Identity resolves discovery.
+
+Replay resolves truth.
+
+ENS, Base, EAS, GitHub profiles, platform accounts, and public websites MAY route users to proof objects.
+
+They MUST NOT replace canonical bytes, receipts, manifests, and independent recomputation.
+
+---
+
+## Final Rule
+
+No replay, no proof.
+
+No canonical bytes, no replay.
+
+No declared transform policy, no admissibility.
+
+Verify > narrative.

--- a/docs/specs/VERIFIER_REFERENCE_IMPLEMENTATION_PLAN_V1.md
+++ b/docs/specs/VERIFIER_REFERENCE_IMPLEMENTATION_PLAN_V1.md
@@ -1,0 +1,352 @@
+# VERIFIER_REFERENCE_IMPLEMENTATION_PLAN_V1 — ALMS Reference Court Build Plan
+
+## Status
+
+`VERIFIER_REFERENCE_IMPLEMENTATION_PLAN_V1_OPENED`
+
+---
+
+## Purpose
+
+Define the first implementation plan for turning `VERIFIER_SPEC_V1` into an executable ALMS replay court.
+
+This plan does not claim an implementation already exists.
+
+It defines the build target, module boundaries, determinism constraints, output contract, and CI gates required for a reference verifier.
+
+---
+
+## Goal
+
+Build a reproducible verifier that accepts ALMS fixture/replay packets and emits deterministic `CVD_OUTPUT_SCHEMA_V1` reports.
+
+The verifier answers one question:
+
+```text
+Does the declared evidence recompute to the declared verification state under declared rules?
+```
+
+---
+
+## Required Modules
+
+### 1. Schema Validator
+
+Validates:
+
+- `REPLAY_SPEC_V1` packet shape
+- `FIXTURE_SPEC_V1` fixture objects
+- `CVD_OUTPUT_SCHEMA_V1` report shape
+- required field presence
+- bounded field constraints
+- declared spec versions
+
+Failure mode:
+`INDETERMINATE` or invalid input exit code when no replay can begin.
+
+---
+
+### 2. Source Loader
+
+Loads declared source artifacts from local paths or pre-fetched content-addressed inputs.
+
+Reference verifier rule:
+
+```text
+No network calls during replay.
+```
+
+Network retrieval may happen during fixture creation, not verifier adjudication.
+
+---
+
+### 3. Transform Policy Loader
+
+Loads declared transform policy and verifies:
+
+- policy ID
+- policy hash
+- toolchain declaration
+- source type compatibility
+- canonicalization method
+
+No implicit transform is admissible.
+
+---
+
+### 4. Canonicalizer Engine
+
+Transforms source artifacts into canonical bytes under declared policy.
+
+Required properties:
+
+- deterministic
+- idempotent
+- versioned
+- source-type aware
+- explicit about encoding and newline behavior
+
+Initial target methods:
+
+- JSON: sorted compact canonical JSON
+- CSV: declared encoding/newline/order policy
+- text/Markdown: declared UTF-8 normalization policy
+- PDF: declared extraction policy only after parser/toolchain lock
+
+---
+
+### 5. Digest Engine
+
+Computes declared digest over canonical bytes.
+
+Supported initial digest:
+
+```text
+sha256
+```
+
+Optional future digest:
+
+```text
+keccak256
+```
+
+Digest mismatch defaults to:
+
+```text
+CVD: V1_BYTE_VARIANT
+Verdict: FAIL
+```
+
+unless transform instability or unavailable evidence requires `TAINTED` or `INDETERMINATE`.
+
+---
+
+### 6. Receipt Recompute Engine
+
+Verifies receipt fields bind to:
+
+- fixture ID
+- source identity
+- transform policy ID
+- canonical digest
+- operator identity
+- commit or publication path when declared
+- optional witness references
+
+A receipt that binds only to narrative summary text is invalid unless the summary itself is the declared fixture.
+
+---
+
+### 7. Manifest Validator
+
+Validates aggregate proof state:
+
+- leaf list
+- digest method
+- leaf ordering
+- aggregation rule
+- domain separation
+- claimed root
+- recomputed root
+
+Single-leaf rule:
+
+```text
+manifest_root = leaf_digest
+```
+
+A manifest without an aggregation rule is not replay-admissible.
+
+---
+
+### 8. Verdict Engine
+
+Maps module results to ALMS verdicts:
+
+- `PASS`
+- `FAIL`
+- `INDETERMINATE`
+- `TAINTED`
+- `REVIEW_REQUIRED`
+- `HIGH_RISK_VARIANT`
+
+The verdict engine MUST fail closed.
+
+Failing closed does not always mean `FAIL`.
+
+If contradiction is not directly observable, default to `INDETERMINATE`.
+
+---
+
+### 9. CVD Classifier
+
+Maps drift to CVD classes:
+
+- `V1_BYTE_VARIANT`
+- `V2_TRANSFORM_VARIANT`
+- `V3_PROVENANCE_VARIANT`
+- `V4_IDENTITY_VARIANT`
+- `V5_SEMANTIC_VARIANT`
+
+The classifier detects divergence.
+
+It does not interpret political, legal, or institutional meaning.
+
+---
+
+### 10. CVD Output Generator
+
+Emits strict `CVD_OUTPUT_SCHEMA_V1` JSON containing:
+
+- report ID
+- run ID
+- verifier version
+- fixture ID
+- digest comparison
+- verdict
+- CVD class
+- replay trace
+- evidence graph
+- errors
+- witnesses checked
+- canonical report hash
+
+No trace, no opinion.
+
+---
+
+## Interfaces
+
+### CLI
+
+Reference CLI target:
+
+```text
+alms verify <fixture.json>
+alms verify <replay-packet.json>
+alms verify --source <artifact> --policy <policy.json> --receipt <receipt.json>
+```
+
+### Library API
+
+Reference library target:
+
+```text
+validate_schema(packet)
+load_source(packet)
+load_transform_policy(packet)
+canonicalize(source, policy)
+compute_digest(canonical_bytes)
+verify_receipt(packet, digest)
+verify_manifest(packet)
+classify_variant(results)
+emit_cvd_output(results)
+```
+
+### Browser/Public Verifier
+
+A browser verifier MAY be supported after CLI determinism is proven.
+
+Browser builds MUST preserve the same canonicalization and digest behavior as CLI verifier.
+
+---
+
+## Determinism Constraints
+
+The reference implementation MUST declare:
+
+- runtime version
+- dependency versions
+- parser/toolchain versions
+- locale assumptions
+- timezone assumptions
+- encoding assumptions
+- newline behavior
+- JSON ordering behavior
+
+Reference replay SHOULD avoid network access.
+
+All replay inputs SHOULD be local or content-addressed before verifier execution.
+
+---
+
+## Output Contract
+
+Every completed run MUST emit one `CVD_OUTPUT_SCHEMA_V1` report.
+
+Every report MUST include a replay trace.
+
+Every report SHOULD be canonicalized and hashed with self-hash exclusion:
+
+```text
+set hash.digest = null
+canonicalize report
+sha256 canonical_report
+write hash.digest
+```
+
+Self-referential hashing is forbidden.
+
+---
+
+## Test Vector Classes
+
+The reference suite SHOULD include:
+
+1. `PASS_VALID_FIXTURE`
+2. `FAIL_BYTE_VARIANT`
+3. `TAINTED_TRANSFORM_VARIANT`
+4. `FAIL_PROVENANCE_VARIANT`
+5. `REVIEW_REQUIRED_IDENTITY_VARIANT`
+6. `HIGH_RISK_SEMANTIC_VARIANT`
+7. `INDETERMINATE_MISSING_SOURCE`
+8. `INDETERMINATE_UNDECLARED_POLICY`
+9. `INVALID_SCHEMA`
+10. `SELF_HASH_REJECTION`
+
+---
+
+## CI Gates
+
+CI SHOULD fail if:
+
+- schema validation breaks,
+- canonicalization drifts,
+- report hashes are self-referential,
+- replay trace is missing,
+- verifier output is nondeterministic,
+- expected test verdict changes without fixture version change,
+- network calls are required during replay,
+- PASS is emitted without digest recomputation.
+
+---
+
+## Initial Directory Target
+
+```text
+scripts/alms_verify.py
+schemas/cvd_output_schema_v1.json
+schemas/fixture_spec_v1.json
+schemas/replay_packet_v1.json
+tests/fixtures/pass_valid_fixture/
+tests/fixtures/fail_byte_variant/
+tests/fixtures/tainted_transform_variant/
+tests/fixtures/fail_provenance_variant/
+tests/fixtures/review_required_identity_variant/
+tests/fixtures/high_risk_semantic_variant/
+tests/fixtures/indeterminate_missing_source/
+tests/fixtures/invalid_schema/
+```
+
+---
+
+## Final Rule
+
+The reference verifier is not trusted because it exists.
+
+It is trusted only when independent operators can reproduce its verdict from declared inputs.
+
+No reproducible trace, no public proof.
+
+Verify > narrative.

--- a/docs/specs/VERIFIER_SPEC_V1.md
+++ b/docs/specs/VERIFIER_SPEC_V1.md
@@ -1,0 +1,324 @@
+# VERIFIER_SPEC_V1 — ALMS Executable Replay Court
+
+## Status
+
+`VERIFIER_SPEC_V1_OPENED`
+
+---
+
+## Purpose
+
+Define the executable verification boundary for ALMS replay.
+
+The verifier is the machine court that enforces `REPLAY_SPEC_V1`, `FIXTURE_SPEC_V1`, and ALMS Core Variant Detector classifications.
+
+A verifier does not decide political legitimacy, legal authority, institutional intent, or narrative correctness.
+
+A verifier decides whether declared evidence recomputes to the same verification state under declared rules.
+
+---
+
+## Core Rule
+
+```text
+fixture packet
+-> schema validation
+-> provenance validation
+-> transform policy validation
+-> canonical byte recomputation
+-> digest comparison
+-> receipt verification
+-> manifest validation
+-> CVD classification
+-> replay verdict
+-> public verifier report
+```
+
+No verifier report is valid unless the replay trace is reproducible.
+
+---
+
+## Inputs
+
+A verifier MUST accept a replay packet or fixture object referencing:
+
+- `REPLAY_SPEC_V1`
+- `FIXTURE_SPEC_V1` when civic fixtures are used
+- source artifact or source URI
+- transform policy declaration
+- expected canonical digest
+- receipt or receipt URI
+- manifest or manifest URI when aggregate state is claimed
+- optional witness references
+
+---
+
+## Deterministic Environment Constraints
+
+A verifier run MUST declare:
+
+- verifier implementation name
+- verifier implementation version
+- operating environment or runtime
+- canonicalization toolchain
+- parser versions when available
+- locale assumptions
+- encoding assumptions
+- timezone assumptions
+- newline behavior
+- JSON ordering behavior
+- hash implementation
+
+If these are undeclared and material to replay, verdict MUST be `INDETERMINATE` or `TAINTED`.
+
+---
+
+## Canonicalizer Interface
+
+A canonicalizer MUST expose:
+
+```text
+canonicalize(input_artifact, transform_policy) -> canonical_bytes
+```
+
+The canonicalizer MUST be:
+
+1. deterministic,
+2. idempotent,
+3. versioned,
+4. source-type aware,
+5. explicit about normalization behavior.
+
+A canonicalizer MUST NOT silently infer policy.
+
+No implicit transform is admissible.
+
+---
+
+## Receipt Recompute Engine
+
+The verifier MUST recompute the canonical digest from canonical bytes.
+
+Required behavior:
+
+```text
+computed_digest = digest(canonical_bytes)
+computed_digest == expected_digest ? continue : classify_variant
+```
+
+Digest mismatch maps by default to:
+
+```text
+CVD: V1_BYTE_VARIANT
+Verdict: FAIL
+```
+
+unless the mismatch is caused by transform policy divergence, missing source availability, or unstable parser behavior.
+
+---
+
+## Manifest Validator
+
+For aggregate proofs, the verifier MUST validate:
+
+- manifest schema
+- leaf list
+- leaf ordering rule
+- digest method
+- aggregation rule
+- domain separation rule
+- claimed root
+- recomputed root
+
+A manifest without a declared aggregation rule is not replay-admissible.
+
+Single-leaf rule:
+
+```text
+manifest_root = leaf_digest
+```
+
+Multi-leaf rule MUST be explicitly declared.
+
+---
+
+## Witness Validator
+
+Witnesses MAY include:
+
+- GitHub commit SHA
+- IPFS CID
+- EAS UID
+- ENS text/contenthash pointer
+- Base transaction hash
+- public website pointer
+
+Witnesses route, timestamp, or publish proof objects.
+
+Witnesses MUST NOT replace canonical bytes, receipts, manifests, or recomputation.
+
+If a witness conflicts with canonical bytes but the bytes replay correctly, the verifier MUST return `REVIEW_REQUIRED` rather than silently fail the canonical proof.
+
+---
+
+## Verdict State Machine
+
+### PASS
+
+All required evidence is present and recomputation matches declared verification state.
+
+### FAIL
+
+Recomputation directly contradicts declared verification state.
+
+### INDETERMINATE
+
+Replay cannot complete because required evidence, parser behavior, source availability, or environment constraints are insufficient.
+
+### TAINTED
+
+Replay depends on unauthorized, unstable, undeclared, or policy-divergent transform behavior.
+
+### REVIEW_REQUIRED
+
+Identity, witness, signer, authority, or routing inconsistency exists while canonical bytes remain stable.
+
+### HIGH_RISK_VARIANT
+
+Semantic, legal, policy, numeric, or operational drift is detected and requires downstream review.
+
+---
+
+## CVD Hooks
+
+The verifier MUST expose drift classification hooks:
+
+| CVD Class | Trigger | Default Verdict |
+|---|---|---|
+| V1_BYTE_VARIANT | canonical bytes or digest differ | FAIL |
+| V2_TRANSFORM_VARIANT | transform policy/toolchain differs | TAINTED or INDETERMINATE |
+| V3_PROVENANCE_VARIANT | receipt/manifest/source lineage breaks | FAIL |
+| V4_IDENTITY_VARIANT | signer/ENS/attestor/witness identity differs | REVIEW_REQUIRED |
+| V5_SEMANTIC_VARIANT | material meaning, policy, numeric, or legal drift detected | HIGH_RISK_VARIANT |
+
+The verifier MUST distinguish detection from interpretation.
+
+It classifies divergence.
+
+It does not adjudicate institutional meaning.
+
+---
+
+## CLI Boundary
+
+A reference verifier SHOULD expose:
+
+```text
+alms-verify fixture.json
+alms-verify replay-packet.json
+alms-verify --source source.pdf --policy policy.json --receipt receipt.json
+```
+
+Expected exit codes:
+
+| Code | Meaning |
+|---|---|
+| 0 | PASS |
+| 1 | FAIL |
+| 2 | INDETERMINATE |
+| 3 | TAINTED |
+| 4 | REVIEW_REQUIRED |
+| 5 | HIGH_RISK_VARIANT |
+| 64 | invalid verifier input |
+| 70 | verifier internal error |
+
+---
+
+## Library Boundary
+
+A verifier library SHOULD expose:
+
+```text
+validate_schema(packet) -> validation_result
+load_source(packet) -> source_artifact
+canonicalize(source_artifact, transform_policy) -> canonical_bytes
+compute_digest(canonical_bytes) -> digest
+verify_receipt(packet, digest) -> receipt_result
+verify_manifest(packet) -> manifest_result
+classify_variant(results) -> cvd_class
+emit_report(results) -> verifier_report
+```
+
+---
+
+## Public Verifier Report
+
+Every verifier run SHOULD emit a public JSON report.
+
+Minimum fields:
+
+```json
+{
+  "verifier_spec": "VERIFIER_SPEC_V1",
+  "verifier_version": "string",
+  "run_id": "string",
+  "run_at": "ISO-8601 timestamp",
+  "input_ref": "string",
+  "fixture_id": "string|null",
+  "replay_spec": "REPLAY_SPEC_V1",
+  "fixture_spec": "FIXTURE_SPEC_V1|null",
+  "computed_digest": "sha256:<hex>|null",
+  "expected_digest": "sha256:<hex>|null",
+  "manifest_root": "sha256:<hex>|null",
+  "cvd_class": "NONE|V1_BYTE_VARIANT|V2_TRANSFORM_VARIANT|V3_PROVENANCE_VARIANT|V4_IDENTITY_VARIANT|V5_SEMANTIC_VARIANT",
+  "verdict": "PASS|FAIL|INDETERMINATE|TAINTED|REVIEW_REQUIRED|HIGH_RISK_VARIANT",
+  "trace": [],
+  "errors": [],
+  "witnesses_checked": []
+}
+```
+
+---
+
+## Failure Taxonomy
+
+A verifier MUST fail closed when:
+
+- schema is invalid,
+- source is missing,
+- transform policy is missing,
+- canonicalization method is undeclared,
+- digest method is undeclared,
+- receipt lineage is broken,
+- manifest aggregation rule is missing,
+- witness is falsely treated as proof,
+- environment constraints materially affect replay.
+
+Failing closed does not always mean `FAIL`.
+
+If contradiction is not directly observable, verdict SHOULD be `INDETERMINATE`.
+
+---
+
+## Security Rules
+
+A verifier MUST NOT:
+
+- execute untrusted code from fixture packets,
+- fetch private secrets,
+- depend on hidden API keys for proof,
+- treat platform account status as evidence truth,
+- mutate source artifacts during replay,
+- silently normalize evidence without declared policy.
+
+---
+
+## Final Rule
+
+The verifier is not the author of truth.
+
+The verifier is the court of replay equivalence.
+
+No reproducible verifier trace, no public proof.
+
+Verify > narrative.

--- a/docs/whitepaper/DETERMINISTIC_CIVIC_MEMORY_MINIMAL_RECORDS_CVD_V1.md
+++ b/docs/whitepaper/DETERMINISTIC_CIVIC_MEMORY_MINIMAL_RECORDS_CVD_V1.md
@@ -1,0 +1,205 @@
+# Deterministic Civic Memory — Minimal Records, Replayable Proofs, and the ALMS Core Variant Detector
+
+## Status
+
+`DETERMINISTIC_CIVIC_MEMORY_V1_OPENED`
+
+---
+
+## Core Thesis
+
+American civic publishing does not require a new platform first.
+
+It requires a replayable public record layer.
+
+ALMS proposes a minimal civic verification architecture where public records, media, agent actions, and institutional outputs are converted into canonical byte artifacts, receipt hashes, manifests, and replayable proofs.
+
+The system does not require government adoption, platform permission, or full onchain storage.
+
+GitHub, CSV, JSON, IPFS/Pinata, and public verifiers form the primary proof surface.
+
+ENS, Base, and EAS function as optional discovery and witness layers.
+
+---
+
+## Minimal Records Doctrine
+
+```text
+CSV / JSON / media / PDF
+-> canonical bytes
+-> receipt hash
+-> Merkle / manifest
+-> public verifier
+-> optional Base/EAS/ENS witness
+-> voice/schema searchable civic memory
+```
+
+The architecture minimizes trust surface area while maximizing replayability.
+
+Truth derives from deterministic recomputation.
+
+Not from platform authority.
+
+---
+
+## Minnesota — State Fixture #001
+
+Minnesota became the first ALMS civic replay fixture because its public records infrastructure was stable enough to support:
+
+- canonical transforms
+- receipt emission
+- provenance continuity
+- independent verification
+- replayable civic proofs
+
+The innovation is not "government onchain."
+
+The innovation is deterministic civic replay.
+
+---
+
+## Deterministic Civic Memory
+
+Transparency means the public can view the record.
+
+Deterministic civic memory means the public can independently recompute the same truth state from the same canonical evidence.
+
+A civic artifact becomes replay-admissible only when:
+
+1. the source is identifiable,
+2. the transform policy is deterministic,
+3. the canonical byte representation is reproducible,
+4. the receipt lineage is continuous,
+5. and independent operators recompute the same verification state.
+
+Transparency alone is insufficient.
+
+Replay equivalence is required.
+
+---
+
+## ALMS Core Variant Detector (CVD)
+
+The ALMS Core Variant Detector is a deterministic replay subsystem that detects divergence between canonical verification state and observed replay state.
+
+The CVD does not determine:
+
+- political legitimacy
+- institutional authority
+- narrative preference
+- semantic intent
+
+The CVD determines:
+
+- replay equivalence
+- transform stability
+- provenance continuity
+- identity consistency
+- structured divergence classification
+
+### Variant Classes
+
+#### V1 — BYTE_VARIANT
+
+Invariant violated:
+`Canonical Byte Determinism`
+
+Detection:
+- sha256 mismatch
+- keccak mismatch
+- canonicalization drift
+- non-idempotent transforms
+
+Verdict:
+`FAIL`
+
+---
+
+#### V2 — TRANSFORM_VARIANT
+
+Invariant violated:
+`Deterministic Transform Policy`
+
+Detection:
+- transform policy hash mismatch
+- parser divergence
+- OCR nondeterminism
+- layout heuristic mismatch
+
+Verdict:
+`TAINTED` or `INDETERMINATE`
+
+---
+
+#### V3 — PROVENANCE_VARIANT
+
+Invariant violated:
+`Provenance Continuity`
+
+Detection:
+- broken Merkle continuity
+- missing attestations
+- inconsistent ancestry
+- orphan receipts
+
+Verdict:
+`FAIL`
+
+---
+
+#### V4 — IDENTITY_VARIANT
+
+Invariant violated:
+`Identity / Proof Separation`
+
+Detection:
+- ENS reassignment
+- signer rotation
+- conflicting attesters
+- identity drift
+
+Verdict:
+`REVIEW_REQUIRED`
+
+---
+
+#### V5 — SEMANTIC_VARIANT
+
+Invariant violated:
+`Semantic Stability`
+
+Detection:
+- legal language mutation
+- policy inversion
+- numerical drift
+- adversarial rewording
+- selective omission
+
+Verdict:
+`HIGH_RISK_VARIANT`
+
+---
+
+## Governance Model
+
+Jay's Pincer Movement describes a dual-sided verification architecture:
+
+Side A:
+Institutions publish records, budgets, policies, laws, and operational artifacts.
+
+Side B:
+Independent operators and agents replay canonical evidence through deterministic verification pipelines.
+
+The objective is not narrative alignment.
+
+The objective is replay equivalence across independent observers.
+
+---
+
+## Final Rule
+
+Identity resolves discovery.
+
+Replay resolves truth.
+
+Verify > narrative.


### PR DESCRIPTION
Introduces the first dedicated doctrine + replay + fixture + verifier + public opinion + execution roadmap foundation for:

- Deterministic Civic Memory
- Minimal Records Doctrine
- ALMS Core Variant Detector (CVD)
- Minnesota State Fixture #001 framing
- Replay admissibility conditions
- Structured variant taxonomy
- Governance replay model
- REPLAY_SPEC_V1 deterministic replay contract
- FIXTURE_SPEC_V1 civic fixture substrate
- VERIFIER_SPEC_V1 executable replay verifier court
- CVD_OUTPUT_SCHEMA_V1 public drift opinion schema
- VERIFIER_REFERENCE_IMPLEMENTATION_PLAN_V1 executable court roadmap
- MINNESOTA_FIXTURE_CORPUS_V1 first civic replay corpus

Added:
- docs/whitepaper/DETERMINISTIC_CIVIC_MEMORY_MINIMAL_RECORDS_CVD_V1.md
- docs/specs/REPLAY_SPEC_V1.md
- docs/specs/FIXTURE_SPEC_V1.md
- docs/specs/VERIFIER_SPEC_V1.md
- docs/specs/CVD_OUTPUT_SCHEMA_V1.md
- docs/specs/VERIFIER_REFERENCE_IMPLEMENTATION_PLAN_V1.md
- docs/specs/MINNESOTA_FIXTURE_CORPUS_V1.md

This PR intentionally preserves existing root schema docs and adds doctrine/spec layers separately.

Core doctrine preserved:
- GitHub = canonical byte surface
- ENS/Base/EAS = optional witness/discovery layers
- Replay > narrative
- Identity resolves discovery
- Replay resolves truth
- No replay, no proof
- Fixtures are replay-admissible evidence units
- Verifiers are courts of replay equivalence
- CVD outputs are public replay opinions
- Minnesota = STATE_FIXTURE_001
