### PR TITLE
Add Jay's Wisdom public discovery index

### DIFF
--- a/docs/public/JAYS_WISDOM_PUBLIC_INDEX.md
+++ b/docs/public/JAYS_WISDOM_PUBLIC_INDEX.md
@@ -1,0 +1,190 @@
+# Jay's Wisdom — Public Discovery Index
+
+## Status
+
+`PUBLIC_DISCOVERY_INDEX_V1`
+
+---
+
+## Purpose
+
+Provide a plain-text public routing document for humans, agents, crawlers, and third-party AI systems attempting to discover Jay's Wisdom / ALMS public proof surfaces.
+
+Search failure is not proof of nonexistence.
+
+This index exists to reduce discoverability failure.
+
+---
+
+## Canonical Public Surfaces
+
+### GitHub Repository
+
+```text
+https://github.com/jsonwisdom/AL
+```
+
+Role:
+
+```text
+canonical byte surface for ALMS public docs, specs, fixtures, verifier code, receipts, and governance records
+```
+
+---
+
+### GitHub Pages / Public Verifier Surface
+
+```text
+https://jsonwisdom.github.io/AL/
+```
+
+Role:
+
+```text
+public human-facing verifier and documentation entrypoint
+```
+
+---
+
+### ENS Identity
+
+```text
+jaywisdom.eth
+jaywisdom.base.eth
+```
+
+Role:
+
+```text
+identity and discovery pointers; not the truth boundary
+```
+
+---
+
+### Zora Profile
+
+```text
+https://zora.co/@jaywisdom
+```
+
+Role:
+
+```text
+public media/artifact distribution surface
+```
+
+---
+
+## Current Constitutional Anchors
+
+### ALMS Constitutional Kernel v0.1
+
+```text
+Kernel branch: v0.1-kernel
+Kernel merge commit: 4c094de4fd6fc234606fc5121996158d26314127
+```
+
+Role:
+
+```text
+sealed constitutional baseline for deterministic replay, fixture law, verifier law, and public opinion schema
+```
+
+---
+
+### Replay Court Skeleton v1
+
+```text
+Replay court merge commit: 2ef5f35d6f4899f65824e294229eed87100fe1d8
+Seating proclamation: docs/governance/REPLAY_COURT_SEATED_V1.md
+```
+
+Role:
+
+```text
+first seated replay court under ALMS Constitutional Kernel v0.1
+```
+
+---
+
+### Minnesota Fixture 001 Intake
+
+```text
+PR #86: Open Minnesota Fixture 001 intake scaffold
+Status: VALID_INTAKE_SCAFFOLD / PRESENT_BUT_INADMISSIBLE
+```
+
+Role:
+
+```text
+first Minnesota civic fixture intake lane; not admitted until source URI, timestamp, canonical bytes, and authorization are supplied
+```
+
+---
+
+## Discovery Boundary
+
+Public search indexing failure means only that a crawler or assistant did not discover the object.
+
+It does not prove:
+
+- the repository does not exist,
+- the proof surface is invalid,
+- the ENS identity lacks pointers,
+- or the ALMS record is false.
+
+Direct source access remains superior to indirect search discovery.
+
+---
+
+## Trust Boundary
+
+ALMS doctrine:
+
+```text
+Identity resolves discovery.
+Replay resolves truth.
+```
+
+ENS, GitHub profiles, public websites, Zora, X, and search indexes may route users to artifacts.
+
+They do not replace:
+
+- canonical bytes,
+- transform policy,
+- receipt,
+- replay trace,
+- verifier output,
+- or CVD public opinion artifacts.
+
+---
+
+## Keywords for Indexing
+
+```text
+Jay's Wisdom
+Jay Wisdom
+Jason Wisdom
+JSONWisdom
+Computer Wisdom
+ALMS
+AI Ledger Memory System
+Deterministic Civic Memory
+Replay Court
+ALMS Constitutional Kernel
+CVD Output Schema
+Minnesota Fixture 001
+jaywisdom.eth
+jaywisdom.base.eth
+jsonwisdom/AL
+```
+
+---
+
+## Final Rule
+
+Search is discovery.
+
+Replay is proof.
+
+Verify > narrative.


### PR DESCRIPTION
Adds a plain-text public discovery index for Jay's Wisdom / ALMS surfaces.

Purpose:
- reduce third-party AI/search discoverability failure
- provide canonical routing to jsonwisdom/AL
- distinguish search/indexing failure from proof failure
- publish stable terms for crawlers and humans

This PR is intentionally separate from PR #86 so Minnesota Fixture 001 intake remains focused and uncontaminated.

Core boundary:
- Search is discovery.
- Replay is proof.
- Identity resolves discovery.
- Replay resolves truth.
