### PR TITLE
Add Minnesota civic resource index

### DIFF
--- a/docs/public/minnesota/MINNESOTA_CIVIC_RESOURCE_INDEX.md
+++ b/docs/public/minnesota/MINNESOTA_CIVIC_RESOURCE_INDEX.md
@@ -1,0 +1,212 @@
+# Minnesota Civic Resource Index
+
+## Status
+
+`MINNESOTA_CIVIC_RESOURCE_INDEX_V1`
+
+---
+
+## Purpose
+
+Provide a public, citizen-facing index of Minnesota civic and constitutional resources.
+
+This document is a discovery and education surface only.
+
+It is not legal advice.
+
+It is not fixture admission.
+
+It is not replay proof.
+
+---
+
+## Trust Boundary
+
+```text
+Discovery = public readability.
+Replay = proof.
+Official sources = primary references.
+Citizen summaries = navigation aids only.
+```
+
+Readers should verify legal, constitutional, court, election, and agency information against official Minnesota sources.
+
+---
+
+## Minnesota Constitution
+
+Source:
+
+```text
+https://www.revisor.mn.gov/constitution/
+```
+
+Public summary:
+
+```text
+Adopted: 1857-10-13
+Generally revised: 1974-11-05
+Articles: 14
+```
+
+### Article Structure
+
+| Article | Topic |
+|---|---|
+| Article I | Bill of Rights |
+| Article II | Name and Boundaries |
+| Article III | Separation of Powers |
+| Article IV | Legislative Department |
+| Article V | Executive Department |
+| Article VI | Judiciary |
+| Article VII | Elective Franchise |
+| Article VIII | Impeachment and Removal from Office |
+| Article IX | Amendments to the Constitution |
+| Article X | Taxation |
+| Article XI | Appropriations and Finances |
+| Article XII | Special Legislation; Local Government |
+| Article XIII | Miscellaneous Subjects |
+| Article XIV | Public Highway System |
+
+### Citizen Navigation Notes
+
+- Article I covers core civil rights such as speech, press, religion, due process, search and seizure protections, jury trial, and related liberties.
+- Article III defines separation of powers across legislative, executive, and judicial branches.
+- Article VI covers Minnesota's judiciary.
+- Article VII covers the elective franchise and voting qualifications.
+- Article XI covers appropriations and public finance.
+
+These notes are navigation aids. The authoritative text is the Revisor source.
+
+---
+
+## Minnesota Legislature
+
+Source:
+
+```text
+https://www.leg.mn.gov/
+```
+
+Useful for:
+
+- statutes,
+- session laws,
+- bill tracking,
+- legislative history,
+- committee information.
+
+---
+
+## Minnesota Revisor of Statutes
+
+Source:
+
+```text
+https://www.revisor.mn.gov/
+```
+
+Useful for:
+
+- Minnesota Constitution,
+- Minnesota Statutes,
+- Minnesota Rules,
+- session law publication,
+- official legislative text navigation.
+
+---
+
+## Minnesota Judicial Branch
+
+Source:
+
+```text
+https://www.mncourts.gov/
+```
+
+Useful for:
+
+- court opinions,
+- court rules,
+- forms,
+- case access links,
+- judicial branch public information.
+
+---
+
+## Minnesota Secretary of State
+
+Source:
+
+```text
+https://www.sos.state.mn.us/
+```
+
+Useful for:
+
+- elections,
+- voter information,
+- business filings,
+- civic participation resources,
+- official state records.
+
+---
+
+## Minnesota Department of Labor and Industry
+
+Source:
+
+```text
+https://www.dli.mn.gov/
+```
+
+Useful for:
+
+- labor standards,
+- workplace safety,
+- apprenticeship,
+- grants,
+- worker and employer resources.
+
+Grant programs overview:
+
+```text
+https://www.dli.mn.gov/grants
+```
+
+---
+
+## Minnesota Attorney General
+
+Source:
+
+```text
+https://www.ag.state.mn.us/
+```
+
+Useful for:
+
+- consumer protection,
+- public legal resources,
+- official attorney general publications,
+- opinions and guidance where published.
+
+---
+
+## ALMS Boundary
+
+This civic resource index may later point to replayable fixtures or CVD outputs.
+
+Until then, it remains a public navigation surface.
+
+A source being listed here does not mean it has been admitted as an ALMS fixture.
+
+---
+
+## Final Rule
+
+Public resources help citizens find records.
+
+Replay verifies claims about records.
+
+Verify > narrative.


### PR DESCRIPTION
Adds a citizen-facing Minnesota civic resource index under docs/public/minnesota/.

Purpose:
- provide a public discovery and education surface for Minnesota civic resources
- link to official primary sources such as the Revisor, Legislature, Judicial Branch, Secretary of State, DLI, and Attorney General
- summarize the Minnesota Constitution article structure using the public Revisor source

Boundaries preserved:
- not legal advice
- not fixture admission
- not replay proof
- not a CVD output
- PR #86 remains Minnesota Fixture 001 intake only

Core rule:
- Public resources help citizens find records.
- Replay verifies claims about records.

Verify > narrative.