### PR TITLE
Add Chapter 216B public utilities civic index

### DIFF
--- a/docs/public/minnesota/MN_STATUTES_216B_PUBLIC_UTILITIES_INDEX.md
+++ b/docs/public/minnesota/MN_STATUTES_216B_PUBLIC_UTILITIES_INDEX.md
@@ -1,0 +1,130 @@
+# Minnesota Statutes Chapter 216B — Public Utilities Civic Index
+
+## Status
+
+`MN_STATUTES_216B_PUBLIC_UTILITIES_INDEX_V1`
+
+---
+
+## Purpose
+
+Provide a citizen-facing navigation aid for Minnesota Statutes Chapter 216B, Public Utilities.
+
+This document points readers to official sources and major topic areas.
+
+It does not reproduce statutory text.
+
+It is not legal advice.
+
+It is not fixture admission.
+
+It is not replay proof.
+
+---
+
+## Canonical Source
+
+Office of the Revisor of Statutes:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216B
+```
+
+The Revisor source is the authoritative public navigation source for statutory chapter, section, and official text lookup.
+
+---
+
+## Scope
+
+Chapter 216B is Minnesota's Public Utilities chapter.
+
+Citizen-facing topics include:
+
+- public utility definitions,
+- Public Utilities Commission authority,
+- just and reasonable rates,
+- consumer protections,
+- tenant and landlord utility billing,
+- renewable and carbon-free electricity standards,
+- utility rate cases,
+- rehearing procedures,
+- resource planning,
+- certificates of need,
+- utility service and reliability issues.
+
+---
+
+## Key Section Pointers
+
+These are navigation pointers only. Readers should confirm all statutory text directly with the Revisor.
+
+| Section | Topic |
+|---|---|
+| 216B.02 | Definitions |
+| 216B.03 | Just and reasonable rates |
+| 216B.08 | Public Utilities Commission regulatory authority |
+| 216B.096 | Cold Weather Rule protections |
+| 216B.097 | Additional cold weather / utility disconnection protections |
+| 216B.0975 | Extreme heat disconnection limits |
+| 216B.16 | Rate change proceedings |
+| 216B.1691 | Renewable energy and carbon-free electricity standards |
+| 216B.2422 | Resource planning |
+| 216B.243 | Certificate of need |
+| 216B.27 | Rehearing procedures |
+
+---
+
+## Citizen Landmark: Carbon-Free Electricity Standard
+
+Section 216B.1691 is a major citizen-relevant section because it includes Minnesota's renewable and carbon-free electricity standards.
+
+The 2023 amendments are a significant public policy landmark.
+
+Readers should confirm the current statutory language, percentages, definitions, exceptions, and compliance timelines directly with the Revisor:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216B.1691
+```
+
+---
+
+## Related Public Institutions
+
+Chapter 216B commonly connects to public utility and energy oversight involving:
+
+- Minnesota Public Utilities Commission,
+- Minnesota Department of Commerce,
+- electric utilities,
+- natural gas utilities,
+- retail utility customers,
+- energy planning and infrastructure proceedings.
+
+These connections are navigation aids only and should not be treated as legal conclusions.
+
+---
+
+## ALMS Boundary
+
+This file is part of the public civic education lane.
+
+It does not create an ALMS fixture.
+
+It does not compute a digest.
+
+It does not trigger replay.
+
+It does not emit a CVD.
+
+A Revisor URL is a discovery source.
+
+Replay remains the proof boundary.
+
+---
+
+## Final Rule
+
+Use the Revisor for the statute.
+
+Use this index to find the statute.
+
+Verify > narrative.


### PR DESCRIPTION
Adds a citizen-facing navigation index for Minnesota Statutes Chapter 216B (Public Utilities).

Adds:
- canonical Revisor source reference
- public utilities chapter overview
- key section navigation pointers
- consumer protection references
- renewable and carbon-free electricity standards pointer
- resource planning and certificate-of-need pointers
- statutory navigation boundary clarification

Boundaries preserved:
- no statutory text reproduction
- public discovery and education surface only
- not legal advice
- not fixture admission
- not replay proof
- PR #86 remains Minnesota Fixture 001 intake only

Verify > narrative.