### PR TITLE
Add Minnesota civic resource hub

### DIFF
--- a/docs/public/minnesota/README.md
+++ b/docs/public/minnesota/README.md
@@ -1,0 +1,170 @@
+# Jay's Wisdom — Minnesota Civic Resource Hub
+
+## Status
+
+`MINNESOTA_CIVIC_HUB_V1`
+
+---
+
+## Purpose
+
+Provide a simple starting point for Minnesota civic resources published in this repository.
+
+This hub helps citizens, agents, and crawlers find public Minnesota civic navigation pages.
+
+It is a discovery and education surface only.
+
+It is not legal advice.
+
+It is not medical advice.
+
+It is not financial advice.
+
+It is not fixture admission.
+
+It is not replay proof.
+
+---
+
+## Start Here
+
+Primary Minnesota civic resource index:
+
+```text
+./MINNESOTA_CIVIC_RESOURCE_INDEX.md
+```
+
+Chapter 216B public utilities index:
+
+```text
+./MN_STATUTES_216B_PUBLIC_UTILITIES_INDEX.md
+```
+
+---
+
+## Citizen Navigation
+
+### Core Minnesota Government Sources
+
+Use the civic resource index to find official public sources for:
+
+- Minnesota Constitution,
+- Minnesota Legislature,
+- Office of the Revisor of Statutes,
+- Minnesota Judicial Branch,
+- Minnesota Secretary of State,
+- Minnesota Attorney General,
+- Minnesota Department of Labor and Industry,
+- Minnesota Department of Health,
+- Minnesota Housing Finance Agency,
+- LawHelpMN.
+
+File:
+
+```text
+./MINNESOTA_CIVIC_RESOURCE_INDEX.md
+```
+
+### Statutory Navigation
+
+Chapter 216B Public Utilities index:
+
+```text
+./MN_STATUTES_216B_PUBLIC_UTILITIES_INDEX.md
+```
+
+Official Revisor source:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216B
+```
+
+---
+
+## Agency Grouping
+
+### Elections and Civic Records
+
+- Minnesota Secretary of State
+- Minnesota Legislature
+- Office of the Revisor of Statutes
+
+### Courts and Legal Help
+
+- Minnesota Judicial Branch
+- Minnesota State Law Library
+- LawHelpMN
+- Minnesota Attorney General
+
+### Health, Housing, Labor, and Public Services
+
+- Minnesota Department of Health
+- Minnesota Housing Finance Agency
+- Minnesota Department of Labor and Industry
+
+### Utilities, Energy, and Infrastructure
+
+- Minnesota Statutes Chapter 216B
+- Minnesota Public Utilities Commission references where linked from official sources
+- Minnesota Department of Commerce references where linked from official sources
+
+---
+
+## Statute Queue
+
+Future statute navigation candidates:
+
+```text
+Chapter 13  = Minnesota Government Data Practices Act
+Chapter 13D = Open Meeting Law
+Chapter 216C = Energy conservation and state energy policy
+Chapter 216E = Power plant and transmission siting
+```
+
+These are candidates only.
+
+They are not yet added as navigation pages.
+
+---
+
+## Official Source Marker
+
+Official source links should be treated as primary references.
+
+Repo summaries are navigation aids.
+
+Always confirm legal, health, housing, election, court, agency, or public-program details directly with the official source.
+
+---
+
+## ALMS Boundary
+
+This hub belongs to Lane 2:
+
+```text
+public civic education and discovery
+```
+
+It does not belong to Lane 1:
+
+```text
+proof / replay / fixture admission
+```
+
+A resource listed here is not automatically admitted as an ALMS fixture.
+
+A public link is discovery.
+
+Replay remains proof.
+
+---
+
+## Final Rule
+
+Start here to find records.
+
+Use official sources to read records.
+
+Use replay only to prove claims about records.
+
+Verify > narrative.


### PR DESCRIPTION
Adds a top-level Minnesota civic resource hub and navigation entry point.

Adds:
- start-here navigation
- cross-links to existing Minnesota civic pages
- agency grouping
- statute grouping
- official source markers
- statute queue references
- Lane 1 / Lane 2 boundary clarification

Boundaries preserved:
- public discovery and education surface only
- not legal advice
- not medical advice
- not financial advice
- not fixture admission
- not replay proof
- PR #86 remains Minnesota Fixture 001 intake only

Verify > narrative.