### PR TITLE
Add Chapter 13 government data practices civic index

### DIFF
--- a/docs/public/minnesota/MN_STATUTES_13_GOVERNMENT_DATA_PRACTICES_INDEX.md
+++ b/docs/public/minnesota/MN_STATUTES_13_GOVERNMENT_DATA_PRACTICES_INDEX.md
@@ -1,0 +1,271 @@
+# Minnesota Statutes Chapter 13 — Government Data Practices Civic Index
+
+## Status
+
+`MN_STATUTES_13_GOVERNMENT_DATA_PRACTICES_INDEX_V1`
+
+---
+
+## Purpose
+
+Provide a citizen-facing navigation aid for Minnesota Statutes Chapter 13, the Government Data Practices Act.
+
+This document points readers to official Revisor sources and major topic areas.
+
+It does not reproduce statutory text.
+
+It is not legal advice.
+
+It is not fixture admission.
+
+It is not replay proof.
+
+---
+
+## Canonical Source
+
+Office of the Revisor of Statutes:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13
+```
+
+Full chapter view:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13/full
+```
+
+The Revisor source is the authoritative public navigation source for statutory chapter, section, and official text lookup.
+
+---
+
+## Scope
+
+Chapter 13 governs how Minnesota government entities collect, classify, store, access, and share government data.
+
+Citizen-facing topics include:
+
+- public access to government data,
+- data classifications,
+- rights of individuals who are the subject of government data,
+- agency obligations,
+- remedies and penalties,
+- commissioner advisory opinions,
+- personnel data,
+- law enforcement data,
+- educational data,
+- medical data,
+- welfare data,
+- social security number protections,
+- security breach notification,
+- Safe at Home participant data.
+
+---
+
+## Key Section Pointers
+
+These are navigation pointers only. Readers should confirm all statutory text directly with the Revisor.
+
+| Section | Topic |
+|---|---|
+| 13.01 | Policy and scope |
+| 13.02 | Definitions |
+| 13.025 | Government entity obligations |
+| 13.03 | Access to government data |
+| 13.04 | Rights of subjects of data |
+| 13.05 | Duties of responsible authority |
+| 13.055 | Security breach notification |
+| 13.072 | Commissioner advisory opinions |
+| 13.08 | Civil remedies |
+| 13.085 | Administrative remedy |
+| 13.09 | Penalties |
+| 13.32 | Educational data |
+| 13.355 | Social security numbers |
+| 13.384 | Medical data |
+| 13.43 | Personnel data |
+| 13.46 | Welfare data |
+| 13.82 | Comprehensive law enforcement data |
+
+---
+
+## Core Framework
+
+Policy and scope:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.01
+```
+
+Definitions:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.02
+```
+
+Government entity obligations:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.025
+```
+
+---
+
+## Access and Individual Rights
+
+Access to government data:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.03
+```
+
+Rights of subjects of data:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.04
+```
+
+Duties of responsible authority:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.05
+```
+
+---
+
+## Enforcement and Opinions
+
+Civil remedies:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.08
+```
+
+Administrative remedy:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.085
+```
+
+Penalties:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.09
+```
+
+Commissioner opinions:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.072
+```
+
+For data practices guidance and opinions, readers may also consult the Minnesota Department of Administration.
+
+---
+
+## Data Category Pointers
+
+Personnel data:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.43
+```
+
+Law enforcement data:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.82
+```
+
+Educational data:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.32
+```
+
+Medical data:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.384
+```
+
+Welfare data:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.46
+```
+
+Social security numbers:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.355
+```
+
+Security breach notification:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.055
+```
+
+Safe at Home participant data:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.045
+```
+
+---
+
+## Citizen Landmark: Public Data Access
+
+Section 13.03 is a major citizen-relevant section because it points to access rules for government data.
+
+Readers should confirm the current statutory language, exceptions, timelines, classifications, and agency duties directly with the Revisor:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13.03
+```
+
+---
+
+## Related Public Institutions
+
+Chapter 13 commonly connects to:
+
+- Minnesota Department of Administration,
+- government responsible authorities,
+- state agencies,
+- counties,
+- cities,
+- school districts,
+- law enforcement agencies,
+- public bodies that collect or maintain government data.
+
+These connections are navigation aids only and should not be treated as legal conclusions.
+
+---
+
+## ALMS Boundary
+
+This file is part of the public civic education lane.
+
+It does not create an ALMS fixture.
+
+It does not compute a digest.
+
+It does not trigger replay.
+
+It does not emit a CVD.
+
+A Revisor URL is a discovery source.
+
+Replay remains the proof boundary.
+
+---
+
+## Final Rule
+
+Use the Revisor for the statute.
+
+Use this index to find the statute.
+
+Verify > narrative.


### PR DESCRIPTION
Adds a citizen-facing navigation index for Minnesota Statutes Chapter 13 (Government Data Practices Act).

Adds:
- canonical Revisor source references
- government data practices overview
- public data access pointers
- individual rights pointers
- enforcement and remedies pointers
- major data category pointers
- statutory navigation boundary clarification

Boundaries preserved:
- no statutory text reproduction
- public discovery and education surface only
- not legal advice
- not fixture admission
- not replay proof
- PR #86 remains Minnesota Fixture 001 intake only

Verify > narrative.