### PR TITLE
Add Chapter 13D open meeting law civic index

### DIFF
--- a/docs/public/minnesota/MN_STATUTES_13D_OPEN_MEETING_LAW_INDEX.md
+++ b/docs/public/minnesota/MN_STATUTES_13D_OPEN_MEETING_LAW_INDEX.md
@@ -1,0 +1,221 @@
+# Minnesota Statutes Chapter 13D — Open Meeting Law Civic Index
+
+## Status
+
+`MN_STATUTES_13D_OPEN_MEETING_LAW_INDEX_V1`
+
+---
+
+## Purpose
+
+Provide a citizen-facing navigation aid for Minnesota Statutes Chapter 13D, the Minnesota Open Meeting Law.
+
+This document points readers to official Revisor sources and major topic areas.
+
+It does not reproduce statutory text.
+
+It is not legal advice.
+
+It is not fixture admission.
+
+It is not replay proof.
+
+---
+
+## Canonical Source
+
+Office of the Revisor of Statutes:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13D
+```
+
+Full chapter view:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13D/full
+```
+
+The Revisor source is the authoritative public navigation source for statutory chapter, section, and official text lookup.
+
+---
+
+## Scope
+
+Chapter 13D governs open meetings for Minnesota public bodies, including public access, meeting notice, remote meeting formats, closed meeting limits, and penalties.
+
+Citizen-facing topics include:
+
+- meetings open to the public,
+- required meeting notices,
+- recorded votes and minutes,
+- electronic and remote meeting rules,
+- emergency electronic meetings,
+- closed meeting procedures,
+- records and recordings of closed meetings,
+- penalties for violations.
+
+---
+
+## Key Section Pointers
+
+These are navigation pointers only. Readers should confirm all statutory text directly with the Revisor.
+
+| Section | Topic |
+|---|---|
+| 13D.01 | Meetings must be open to the public; exceptions |
+| 13D.015 | State agency electronic meetings |
+| 13D.02 | Meetings by interactive technology |
+| 13D.021 | Meetings by telephone or electronic means during emergencies |
+| 13D.04 | Notice requirements |
+| 13D.05 | Meetings involving data classified as not public |
+| 13D.06 | Penalties |
+| 13D.07 | Citation as Minnesota Open Meeting Law |
+
+---
+
+## Core Requirement
+
+Meetings must be open to the public:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13D.01
+```
+
+Citizen relevance:
+
+- public bodies generally must meet openly,
+- votes are recorded in minutes,
+- before closing a meeting, a body must state the grounds for closure on the record.
+
+Readers should confirm exceptions and procedural requirements directly with the Revisor.
+
+---
+
+## Meeting Formats
+
+Interactive technology meetings:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13D.02
+```
+
+Emergency telephone or electronic meetings:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13D.021
+```
+
+State agency electronic meetings:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13D.015
+```
+
+---
+
+## Notice and Access
+
+Notice requirements:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13D.04
+```
+
+Citizen relevance:
+
+- meeting notice rules affect whether residents can know when public bodies meet,
+- different meeting types may have different notice requirements,
+- readers should confirm exact timing, posting, and notice rules directly with the Revisor.
+
+---
+
+## Closed Meetings
+
+Meetings involving data classified as not public:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13D.05
+```
+
+Citizen relevance:
+
+- public bodies may close meetings only under defined circumstances,
+- closed meeting rules are closely tied to nonpublic data,
+- readers should confirm recording, preservation, and public-access rules directly with the Revisor.
+
+---
+
+## Enforcement
+
+Penalties:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13D.06
+```
+
+Citation as Minnesota Open Meeting Law:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/13D.07
+```
+
+---
+
+## Transparency Pairing
+
+Chapter 13D pairs naturally with Chapter 13:
+
+```text
+Chapter 13  = Government Data Practices Act
+Chapter 13D = Open Meeting Law
+```
+
+Public data access and open meeting rules are two major civic transparency surfaces in Minnesota.
+
+This pairing is a citizen navigation aid, not a legal conclusion.
+
+---
+
+## Related Public Institutions
+
+Chapter 13D commonly connects to:
+
+- state agencies,
+- boards,
+- commissions,
+- local governing bodies,
+- school boards,
+- city councils,
+- county boards,
+- public bodies subject to open meeting requirements.
+
+These connections are navigation aids only and should not be treated as legal conclusions.
+
+---
+
+## ALMS Boundary
+
+This file is part of the public civic education lane.
+
+It does not create an ALMS fixture.
+
+It does not compute a digest.
+
+It does not trigger replay.
+
+It does not emit a CVD.
+
+A Revisor URL is a discovery source.
+
+Replay remains the proof boundary.
+
+---
+
+## Final Rule
+
+Use the Revisor for the statute.
+
+Use this index to find the statute.
+
+Verify > narrative.


### PR DESCRIPTION
Adds a citizen-facing navigation index for Minnesota Statutes Chapter 13D (Minnesota Open Meeting Law).

Adds:
- canonical Revisor source references
- open meeting law overview
- meeting notice and access pointers
- electronic meeting pointers
- closed meeting and recording pointers
- enforcement and penalties pointers
- transparency-law pairing clarification with Chapter 13
- statutory navigation boundary clarification

Boundaries preserved:
- no statutory text reproduction
- public discovery and education surface only
- not legal advice
- not fixture admission
- not replay proof
- PR #86 remains Minnesota Fixture 001 intake only

Verify > narrative.