### PR TITLE
Add Chapter 216C energy planning civic index

### DIFF
--- a/docs/public/minnesota/MN_STATUTES_216C_ENERGY_PLANNING_CONSERVATION_INDEX.md
+++ b/docs/public/minnesota/MN_STATUTES_216C_ENERGY_PLANNING_CONSERVATION_INDEX.md
@@ -1,0 +1,228 @@
+# Minnesota Statutes Chapter 216C — Energy Planning and Conservation Civic Index
+
+## Status
+
+`MN_STATUTES_216C_ENERGY_PLANNING_CONSERVATION_INDEX_V1`
+
+---
+
+## Purpose
+
+Provide a citizen-facing navigation aid for Minnesota Statutes Chapter 216C, Energy Planning and Conservation.
+
+This document points readers to official Revisor sources and major topic areas.
+
+It does not reproduce statutory text.
+
+It is not legal advice.
+
+It is not financial advice.
+
+It is not fixture admission.
+
+It is not replay proof.
+
+---
+
+## Canonical Source
+
+Office of the Revisor of Statutes:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216C
+```
+
+Full chapter view:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216C/full
+```
+
+The Revisor source is the authoritative public navigation source for statutory chapter, section, and official text lookup.
+
+---
+
+## Scope
+
+Chapter 216C covers Minnesota energy planning, conservation programs, efficiency standards, emergency energy planning, and renewable energy development.
+
+Citizen-facing topics include:
+
+- state energy policy,
+- Department of Commerce / State Energy Office duties,
+- energy trend and data assessment,
+- emergency energy allocation planning,
+- public-building energy conservation,
+- energy benchmarking,
+- community energy planning partnerships,
+- appliance and equipment efficiency standards.
+
+---
+
+## Key Section Pointers
+
+These are navigation pointers only. Readers should confirm all statutory text directly with the Revisor.
+
+| Section | Topic |
+|---|---|
+| 216C.05 | Findings and purpose |
+| 216C.09 | Commissioner duties |
+| 216C.10 | Commissioner powers |
+| 216C.20 | Energy conservation in public buildings |
+| 216C.331 | Energy benchmarking |
+| 216C.385 | Clean Energy Resource Teams |
+
+---
+
+## Policy and Purpose
+
+Findings and purpose:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216C.05
+```
+
+Citizen relevance:
+
+- state energy planning,
+- conservation policy,
+- renewable energy development,
+- long-term public energy goals.
+
+Readers should confirm current statutory language directly with the Revisor.
+
+---
+
+## Commissioner Duties and Powers
+
+Commissioner duties:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216C.09
+```
+
+Commissioner powers:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216C.10
+```
+
+Citizen relevance:
+
+- energy data collection,
+- emergency allocation planning,
+- energy trend assessment,
+- federal program administration,
+- state energy investment planning.
+
+---
+
+## Conservation Programs
+
+Energy conservation in public buildings:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216C.20
+```
+
+Energy benchmarking:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216C.331
+```
+
+Clean Energy Resource Teams:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216C.385
+```
+
+Citizen relevance:
+
+- public-sector energy conservation,
+- building energy use visibility,
+- local clean-energy planning,
+- community energy projects.
+
+---
+
+## Emergency Energy Planning
+
+Chapter 216C includes emergency energy planning and allocation concepts.
+
+Citizen relevance:
+
+- energy supply emergencies,
+- conservation planning,
+- state response during disruption,
+- emergency energy allocation procedures.
+
+Readers should confirm the controlling sections and current requirements directly with the Revisor.
+
+---
+
+## Efficiency Standards
+
+Chapter 216C includes energy efficiency standards and related public purchasing concepts.
+
+Citizen relevance:
+
+- appliance and equipment efficiency,
+- state purchasing energy standards,
+- energy conservation policy.
+
+Readers should confirm current statutory language and covered products directly with the Revisor.
+
+---
+
+## Relationship to Chapter 216B
+
+```text
+Chapter 216B = public utility regulation, Public Utilities Commission authority, rates, renewable energy standards
+Chapter 216C = state energy policy, conservation programs, efficiency standards, emergency planning
+```
+
+This relationship is a navigation aid only and should not be treated as a legal conclusion.
+
+---
+
+## Related Public Institutions
+
+Chapter 216C commonly connects to:
+
+- Minnesota Department of Commerce,
+- State Energy Office,
+- public building owners,
+- local governments,
+- utilities and energy-program administrators,
+- community clean-energy partnerships.
+
+These connections are navigation aids only and should not be treated as legal conclusions.
+
+---
+
+## ALMS Boundary
+
+This file is part of the public civic education lane.
+
+It does not create an ALMS fixture.
+
+It does not compute a digest.
+
+It does not trigger replay.
+
+It does not emit a CVD.
+
+A Revisor URL is a discovery source.
+
+Replay remains the proof boundary.
+
+---
+
+## Final Rule
+
+Use the Revisor for the statute.
+
+Use this index to find the statute.
+
+Verify > narrative.


### PR DESCRIPTION
Adds a citizen-facing navigation index for Minnesota Statutes Chapter 216C (Energy Planning and Conservation).

Adds:
- canonical Revisor source references
- energy planning and conservation overview
- commissioner duties and powers pointers
- conservation program pointers
- emergency energy planning references
- energy efficiency standards references
- relationship clarification with Chapter 216B
- statutory navigation boundary clarification

Boundaries preserved:
- no statutory text reproduction
- public discovery and education surface only
- not legal advice
- not financial advice
- not fixture admission
- not replay proof
- PR #86 remains Minnesota Fixture 001 intake only

Verify > narrative.