### PR TITLE
Add Chapter 216E power plant and transmission siting civic index

### DIFF
--- a/docs/public/minnesota/MN_STATUTES_216E_POWER_PLANT_TRANSMISSION_SITING_INDEX.md
+++ b/docs/public/minnesota/MN_STATUTES_216E_POWER_PLANT_TRANSMISSION_SITING_INDEX.md
@@ -1,0 +1,230 @@
+# Minnesota Statutes Chapter 216E — Power Plant and Transmission Siting Civic Index
+
+## Status
+
+`MN_STATUTES_216E_POWER_PLANT_TRANSMISSION_SITING_INDEX_V1`
+
+---
+
+## Purpose
+
+Provide a citizen-facing navigation aid for Minnesota Statutes Chapter 216E, Power Plant and Transmission Siting.
+
+This document points readers to official Revisor sources and major topic areas.
+
+It does not reproduce statutory text.
+
+It is not legal advice.
+
+It is not financial advice.
+
+It is not fixture admission.
+
+It is not replay proof.
+
+---
+
+## Canonical Source
+
+Office of the Revisor of Statutes:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216E
+```
+
+Full chapter view:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216E/full
+```
+
+The Revisor source is the authoritative public navigation source for statutory chapter, section, and official text lookup.
+
+---
+
+## Scope
+
+Chapter 216E covers Minnesota power plant and transmission line siting.
+
+Citizen-facing topics include:
+
+- definitions and scope for large electric power facilities,
+- siting authority,
+- site designation,
+- large electric power facility review,
+- high-voltage transmission line route permits,
+- alternative review procedures,
+- public participation,
+- hearing and process entry points,
+- interaction with local ordinances.
+
+---
+
+## Key Section Pointers
+
+These are navigation pointers only. Readers should confirm all statutory text directly with the Revisor.
+
+| Section | Topic |
+|---|---|
+| 216E.01 | Definitions and scope |
+| 216E.02 | Site designation and plant siting |
+| 216E.03 | Siting of large electric power facilities |
+| 216E.04 | Alternative review / route permits |
+| 216E.08 | Public participation |
+| 216E.10 | Local ordinances |
+
+---
+
+## Definitions and Scope
+
+Definitions and scope:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216E.01
+```
+
+Citizen relevance:
+
+- defines key infrastructure terms,
+- helps identify which facilities may fall under state siting rules,
+- gives citizens vocabulary for large electric power facility and transmission-line proceedings.
+
+Readers should confirm current statutory language directly with the Revisor.
+
+---
+
+## Site Designation and Plant Siting
+
+Site designation and plant siting:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216E.02
+```
+
+Citizen relevance:
+
+- physical placement of major energy infrastructure,
+- public interest and land-use considerations,
+- relationship between state siting policy and local impacts.
+
+---
+
+## Large Electric Power Facilities
+
+Siting of large electric power facilities:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216E.03
+```
+
+Citizen relevance:
+
+- major generation and infrastructure proceedings,
+- procedural requirements,
+- public process and review pathways.
+
+---
+
+## Transmission Lines and Route Permits
+
+Alternative review / route permits:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216E.04
+```
+
+Citizen relevance:
+
+- high-voltage transmission routes,
+- route-permit procedures,
+- infrastructure corridors,
+- community impact review.
+
+---
+
+## Public Participation
+
+Public participation:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216E.08
+```
+
+Citizen relevance:
+
+- public hearing entry points,
+- comment opportunities,
+- participation in siting decisions,
+- visibility into infrastructure placement.
+
+---
+
+## Local Ordinances
+
+Local ordinances:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216E.10
+```
+
+Citizen relevance:
+
+- boundary between state siting authority and local regulation,
+- local zoning and ordinance interaction,
+- community-level infrastructure governance.
+
+---
+
+## Energy Governance Trifecta
+
+```text
+Chapter 216B = public utility regulation, Public Utilities Commission authority, rates, renewable energy standards
+Chapter 216C = state energy policy, conservation programs, efficiency standards, emergency planning
+Chapter 216E = physical siting of power plants and transmission infrastructure
+```
+
+This relationship is a navigation aid only and should not be treated as a legal conclusion.
+
+---
+
+## Related Public Institutions
+
+Chapter 216E commonly connects to:
+
+- Minnesota Public Utilities Commission,
+- Minnesota Department of Commerce,
+- energy utilities,
+- local governments,
+- affected landowners,
+- public participants in siting processes,
+- communities near proposed facilities or transmission routes.
+
+These connections are navigation aids only and should not be treated as legal conclusions.
+
+---
+
+## ALMS Boundary
+
+This file is part of the public civic education lane.
+
+It does not create an ALMS fixture.
+
+It does not compute a digest.
+
+It does not trigger replay.
+
+It does not emit a CVD.
+
+A Revisor URL is a discovery source.
+
+Replay remains the proof boundary.
+
+---
+
+## Final Rule
+
+Use the Revisor for the statute.
+
+Use this index to find the statute.
+
+Verify > narrative.


### PR DESCRIPTION
Adds a citizen-facing navigation index for Minnesota Statutes Chapter 216E (Power Plant and Transmission Siting).

Adds:
- canonical Revisor source references
- siting and transmission overview
- large electric power facility pointers
- transmission route permit pointers
- public participation references
- local ordinance references
- relationship clarification with Chapters 216B and 216C
- statutory navigation boundary clarification

Boundaries preserved:
- no statutory text reproduction
- public discovery and education surface only
- not legal advice
- not financial advice
- not fixture admission
- not replay proof
- PR #86 remains Minnesota Fixture 001 intake only

Verify > narrative.