### PR TITLE
Add recursive hub backlinks to Minnesota statute pages

### DIFF
--- a/docs/public/minnesota/MN_STATUTES_13D_OPEN_MEETING_LAW_INDEX.md
+++ b/docs/public/minnesota/MN_STATUTES_13D_OPEN_MEETING_LAW_INDEX.md
@@ -219,3 +219,9 @@ Use the Revisor for the statute.
 Use this index to find the statute.
 
 Verify > narrative.
+
+---
+
+## Navigation
+
+[Back to Minnesota Civic Hub](./README.md)

--- a/docs/public/minnesota/MN_STATUTES_13_GOVERNMENT_DATA_PRACTICES_INDEX.md
+++ b/docs/public/minnesota/MN_STATUTES_13_GOVERNMENT_DATA_PRACTICES_INDEX.md
@@ -269,3 +269,9 @@ Use the Revisor for the statute.
 Use this index to find the statute.
 
 Verify > narrative.
+
+---
+
+## Navigation
+
+[Back to Minnesota Civic Hub](./README.md)

--- a/docs/public/minnesota/MN_STATUTES_216B_PUBLIC_UTILITIES_INDEX.md
+++ b/docs/public/minnesota/MN_STATUTES_216B_PUBLIC_UTILITIES_INDEX.md
@@ -128,3 +128,9 @@ Use the Revisor for the statute.
 Use this index to find the statute.
 
 Verify > narrative.
+
+---
+
+## Navigation
+
+[Back to Minnesota Civic Hub](./README.md)

--- a/docs/public/minnesota/MN_STATUTES_216C_ENERGY_PLANNING_CONSERVATION_INDEX.md
+++ b/docs/public/minnesota/MN_STATUTES_216C_ENERGY_PLANNING_CONSERVATION_INDEX.md
@@ -226,3 +226,9 @@ Use the Revisor for the statute.
 Use this index to find the statute.
 
 Verify > narrative.
+
+---
+
+## Navigation
+
+[Back to Minnesota Civic Hub](./README.md)

--- a/docs/public/minnesota/MN_STATUTES_216E_POWER_PLANT_TRANSMISSION_SITING_INDEX.md
+++ b/docs/public/minnesota/MN_STATUTES_216E_POWER_PLANT_TRANSMISSION_SITING_INDEX.md
@@ -228,3 +228,9 @@ Use the Revisor for the statute.
 Use this index to find the statute.
 
 Verify > narrative.
+
+---
+
+## Navigation
+
+[Back to Minnesota Civic Hub](./README.md)


### PR DESCRIPTION
Adds standardized navigation footers to live Minnesota statute navigation pages.

Purpose:
- close the recursive navigation loop
- ensure statute pages link back to the Minnesota civic hub
- eliminate orphan navigation states
- improve local/web parity using relative links

Updated pages:
- Chapter 13 — Government Data Practices
- Chapter 13D — Open Meeting Law
- Chapter 216B — Public Utilities
- Chapter 216C — Energy Planning and Conservation
- Chapter 216E — Power Plant and Transmission Siting

Footer added:

```markdown
## Navigation

[Back to Minnesota Civic Hub](./README.md)
```

Boundaries preserved:
- no statutory text reproduction
- public discovery and education surface only
- not legal advice
- not fixture admission
- not replay proof
- PR #86 remains Minnesota Fixture 001 intake only

Verify > narrative.