### PR TITLE
Add Minnesota Cold Weather Rule citizen guide

### DIFF
--- a/docs/public/minnesota/guides/energy/cold-weather-rule.md
+++ b/docs/public/minnesota/guides/energy/cold-weather-rule.md
@@ -1,0 +1,169 @@
+# Cold Weather Rule: Shut-off Protection for Minnesota Homes
+
+## Status
+
+`MINNESOTA_COLD_WEATHER_RULE_GUIDE_V1`
+
+---
+
+## 1. What It Is
+
+The Cold Weather Rule is a Minnesota utility protection that limits when gas and electric utilities can shut off heat for residential customers during the cold weather period.
+
+It applies to residential heating service.
+
+It does not erase or pay the bill.
+
+It helps protect service while a customer works with the utility on a payment plan.
+
+---
+
+## 2. Why It Matters
+
+If a household is behind on heating bills, winter disconnection can create an immediate safety risk.
+
+The Cold Weather Rule gives residential customers a process to:
+
+- request protection from shutoff,
+- set up a payment agreement,
+- seek reconnection if service was disconnected,
+- dispute payment-plan issues through the proper utility or regulatory channel.
+
+---
+
+## 3. Official Statute and Source Links
+
+Public utility Cold Weather Rule:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216B.096
+```
+
+Cooperative or municipal utility Cold Weather Rule:
+
+```text
+https://www.revisor.mn.gov/statutes/cite/216B.097
+```
+
+Minnesota Public Utilities Commission shut-off protection overview:
+
+```text
+https://mn.gov/puc/consumers/shut-off-protection/
+```
+
+---
+
+## 4. Citizen Checklist
+
+Use this checklist if you received a shut-off notice or your heating service was disconnected during the cold weather period.
+
+- [ ] Contact your utility immediately.
+- [ ] Say you want to apply for Cold Weather Rule protection.
+- [ ] Ask for the Cold Weather Rule payment-plan forms.
+- [ ] Ask what income verification is required.
+- [ ] Ask whether Energy Assistance or Weatherization referrals are available.
+- [ ] Ask for the payment agreement in writing.
+- [ ] If you cannot agree on a plan, ask about the utility appeal process.
+- [ ] If your service has already been disconnected, ask what is required for reconnection.
+
+---
+
+## 5. Important Dates and Rules
+
+Cold weather period:
+
+```text
+October 1 through April 30
+```
+
+Citizen notes:
+
+- Minnesota law currently uses October 1 through April 30 for the cold weather period.
+- Some older materials may cite October 15 through April 15.
+- Confirm current dates directly with the Revisor and the Public Utilities Commission.
+- All natural gas and electric utilities should offer Cold Weather Rule protection.
+- Delivered fuels such as propane, fuel oil, and wood are not covered by the Cold Weather Rule, but related electric service may matter if electricity runs the furnace.
+
+---
+
+## 6. Where To Get Help
+
+Your utility:
+
+```text
+First contact point for payment plans, notices, and reconnection steps.
+```
+
+Minnesota Public Utilities Commission Consumer Affairs Office:
+
+```text
+651-296-0406
+800-657-3782
+consumer.puc@state.mn.us
+```
+
+Energy Assistance Program:
+
+```text
+800-657-3710
+```
+
+LawHelpMN:
+
+```text
+https://www.lawhelpmn.org/
+```
+
+---
+
+## 7. What This Guide Is Not
+
+This guide is a public navigation aid.
+
+It is not legal advice.
+
+It is not financial advice.
+
+It does not decide eligibility.
+
+It does not replace the statute, the utility process, the Public Utilities Commission, or legal counsel.
+
+Readers should confirm all rights, dates, forms, and deadlines with official sources.
+
+---
+
+## Related Minnesota Civic Pages
+
+Chapter 216B Public Utilities index:
+
+```text
+../..//MN_STATUTES_216B_PUBLIC_UTILITIES_INDEX.md
+```
+
+Minnesota civic resource index:
+
+```text
+../../MINNESOTA_CIVIC_RESOURCE_INDEX.md
+```
+
+---
+
+## Official Sources
+
+Minnesota Revisor of Statutes:
+
+```text
+https://www.revisor.mn.gov/
+```
+
+Minnesota Public Utilities Commission:
+
+```text
+https://mn.gov/puc/
+```
+
+---
+
+## Navigation
+
+[Back to Minnesota Civic Hub](../../README.md)


### PR DESCRIPTION
Adds a citizen-facing Minnesota Cold Weather Rule guide focused on utility shut-off protection during the cold weather period.

Purpose:
- provide plain-language navigation to Minnesota utility shut-off protections,
- link directly to official statute and PUC sources,
- provide practical citizen checklists,
- extend the public education layer without reproducing statutory text.

Added:
- docs/public/minnesota/guides/energy/cold-weather-rule.md

Sources:
- Minnesota Statutes §§216B.096 and 216B.097
- Minnesota Public Utilities Commission shut-off protection resources

Boundaries preserved:
- public civic education only,
- no statutory text reproduction,
- not legal advice,
- not fixture admission,
- not replay proof,
- PR #86 remains isolated.