### PR TITLE
ALMS threshold awareness doctrine v1

### DIFF
--- a/_truth/receipts/boundary/schema.json
+++ b/_truth/receipts/boundary/schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ALMS Boundary Receipt",
+  "type": "object",
+  "required": [
+    "claim_id",
+    "timestamp_utc",
+    "actor",
+    "nonce",
+    "inputs",
+    "outputs",
+    "verdict",
+    "receipt_status",
+    "threshold",
+    "remainder"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "claim_id": { "type": "string" },
+    "timestamp_utc": { "type": "string" },
+    "actor": { "type": "string" },
+    "nonce": { "type": "string" },
+    "inputs": { "type": "object" },
+    "outputs": { "type": "object" },
+    "verdict": { "type": "string" },
+    "receipt_status": { "enum": ["COMPLETE", "PARTIAL"] },
+    "upstream_status": { "enum": ["COMPLETE", "PARTIAL", "NONE"] },
+    "inherited_latent": {
+      "type": "object",
+      "properties": {
+        "present": { "type": "boolean" },
+        "origin_receipt": { "type": "string" },
+        "origin_hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" }
+      },
+      "required": ["present"]
+    },
+    "latent": {
+      "type": "object",
+      "properties": {
+        "state": { "enum": ["present", "possible", "none"] },
+        "kind": { "enum": ["known", "possible"] },
+        "items": { "type": "array" },
+        "temporality": { "type": "string" }
+      },
+      "required": ["state"]
+    },
+    "threshold": {
+      "type": "object",
+      "required": ["declared", "cycle_id"],
+      "properties": {
+        "declared": { "type": "boolean" },
+        "cycle_id": { "type": "string" },
+        "policy_id": { "type": "string" }
+      }
+    },
+    "remainder": {
+      "type": "object",
+      "required": ["guaranteed", "correspondence_outside_scope"],
+      "properties": {
+        "guaranteed": { "const": true },
+        "correspondence_outside_scope": { "const": "NOT_CLAIMED" }
+      }
+    },
+    "conversion_receipt": { "type": "string" }
+  }
+}

--- a/docs/doctrine/ALMS_THRESHOLD_AWARENESS_V1.md
+++ b/docs/doctrine/ALMS_THRESHOLD_AWARENESS_V1.md
@@ -81,6 +81,12 @@ It is compatible-but-unconverted remainder.
 
 The receipt must not silently collapse latent material into either captured truth or irrelevant noise.
 
+Latent status applies only at cycle completion.
+
+Do not set latent status retroactively from later absence of receipts.
+
+Absence of a receipt is not evidence that a phenomenon was latent, irrelevant, false, or nonexistent.
+
 ---
 
 ## 4. Threshold Awareness

--- a/docs/doctrine/ALMS_THRESHOLD_AWARENESS_V1.md
+++ b/docs/doctrine/ALMS_THRESHOLD_AWARENESS_V1.md
@@ -73,19 +73,19 @@ No correspondence claim is made.
 
 ### 3.3 Latent / Unconverted
 
-Phenomena materially or operationally compatible with possible receipt conversion, but not converted during this intake cycle.
+Definition: Compatible with capture, present near the system, not yet transformed, not irrelevant, not claimed.
 
-Latent material is neither failure nor irrelevance.
+Purpose: Preserve the boundary between what the system has processed and what exists outside processing. This category carries no payload, only position.
 
-It is compatible-but-unconverted remainder.
+Failure mode prevented: Calibration drift under internal coherence. Without this state, a ledger of accurate receipts will over time be read as a complete account of the world. Silence accumulates as implicit confirmation.
+
+Invariant: Completeness of records is not completeness of world. Absence of a receipt is not evidence of irrelevance or nonexistence.
+
+Temporality: Latent status applies only at cycle completion. Do not set retroactively from later absence. Status reflects what the system knew at the intake boundary, not what can be inferred afterward.
+
+Usage: Set when a phenomenon is detected as proximate and compatible but not converted to a receipt in this cycle. Do not use for errors, rejections, out-of-scope data, or any state inferred after cycle completion.
 
 The receipt must not silently collapse latent material into either captured truth or irrelevant noise.
-
-Latent status applies only at cycle completion.
-
-Do not set latent status retroactively from later absence of receipts.
-
-Absence of a receipt is not evidence that a phenomenon was latent, irrelevant, false, or nonexistent.
 
 ---
 

--- a/docs/doctrine/ALMS_THRESHOLD_AWARENESS_V1.md
+++ b/docs/doctrine/ALMS_THRESHOLD_AWARENESS_V1.md
@@ -1,0 +1,204 @@
+# ALMS Threshold Awareness Doctrine V1
+
+Status: `CANONICAL_DRAFT`
+
+Binding principle:
+
+```text
+Correctly scoped. Remainder guaranteed.
+```
+
+Core ledger rule:
+
+```text
+The ledger records the transformation, not the world.
+```
+
+---
+
+## 1. Purpose
+
+This doctrine defines the receipt boundary rule for ALMS receipts and replay artifacts.
+
+A receipt is not an oracle, a total event record, or a proof that the world was exhaustively captured.
+
+A valid ALMS receipt records a scoped transformation that crossed a declared intake threshold under a declared policy, tolerance, and transform procedure.
+
+The receipt must preserve evidence of its own boundary.
+
+---
+
+## 2. Constitutional Problem
+
+Receipts can drift toward false totality even when every individual receipt is honest.
+
+This happens when a receipt system repeatedly records outputs without preserving threshold awareness.
+
+Over time, users and downstream systems may begin to assume:
+
+- anything not receipted did not happen,
+- anything receipted was fully captured,
+- conversion into receipt state was frictionless,
+- and the ledger represents the world rather than the scoped transformation.
+
+This is calibration drift at the attestation layer.
+
+ALMS rejects that drift.
+
+---
+
+## 3. Three Receipt Territories
+
+Every ALMS receipt must distinguish or acknowledge three territories.
+
+### 3.1 Inside Scope
+
+Phenomena explicitly converted into receipt state.
+
+Inside-scope material is:
+
+- declared,
+- transformed,
+- hashed,
+- replayable,
+- and governed by the receipt policy.
+
+### 3.2 Outside Scope
+
+Phenomena not addressed by the receipt system or transform policy.
+
+Outside-scope material is not invalidated by the receipt.
+
+No correspondence claim is made.
+
+### 3.3 Latent / Unconverted
+
+Phenomena materially or operationally compatible with possible receipt conversion, but not converted during this intake cycle.
+
+Latent material is neither failure nor irrelevance.
+
+It is compatible-but-unconverted remainder.
+
+The receipt must not silently collapse latent material into either captured truth or irrelevant noise.
+
+---
+
+## 4. Threshold Awareness
+
+A valid ALMS receipt must acknowledge that conversion into receipt state is an event.
+
+Conversion requires contact with an intake mechanism.
+
+The intake mechanism has:
+
+- boundaries,
+- rate limits,
+- policy limits,
+- transform limits,
+- observer limits,
+- and temporal placement.
+
+The threshold existed.
+
+Some phenomena may not have crossed it.
+
+Their status remains ambient unless and until separately converted.
+
+---
+
+## 5. Minimum Receipt Boundary Fields
+
+Future ALMS receipt schemas SHOULD include explicit boundary fields equivalent to:
+
+```text
+SCOPE: [defined]
+TRANSFORMED: [explicit]
+TOLERANCE: [stated]
+THRESHOLD: [declared]
+LATENT: [acknowledged / unresolved]
+REMAINDER: [guaranteed / unaddressed]
+CORRESPONDENCE_OUTSIDE_SCOPE: [not claimed]
+```
+
+These fields are not bureaucratic overhead.
+
+They are constitutional hygiene.
+
+They prevent the receipt from becoming the thing ALMS was built to avoid: an oracle surface.
+
+---
+
+## 6. Required Anti-Oracle Language
+
+Receipt language MUST NOT imply:
+
+```text
+This receipt captures the whole event.
+This receipt proves the world state.
+Unreceipted phenomena are irrelevant.
+Unreceipted phenomena did not happen.
+Receipted output exhausts correspondence.
+```
+
+Preferred receipt language:
+
+```text
+This receipt records a scoped transformation.
+The threshold existed.
+Some phenomena did not cross it.
+Their status remains ambient.
+Correspondence outside scope is not claimed.
+```
+
+---
+
+## 7. Relationship to Sparse Proofs
+
+Sparse coverage is not a defect when honestly declared.
+
+For sparse ALMS surfaces, receipts must preserve the distinction between:
+
+- covered entities,
+- uncovered entities,
+- and latent or pending entities that may be compatible with future conversion but were not converted in the current cycle.
+
+No interpolation, simulation, or implied coverage may replace this boundary.
+
+---
+
+## 8. Replay Boundary
+
+Replay resolves the transformation.
+
+Replay does not resolve the world.
+
+A successful replay means:
+
+```text
+Given declared inputs, declared policy, declared threshold, and declared transform, the output is reproducible within tolerance.
+```
+
+It does not mean:
+
+```text
+All relevant reality was captured.
+All ambient phenomena were converted.
+No latent material existed.
+The receipt is a total truth object.
+```
+
+---
+
+## 9. Final Rule
+
+A receipt becomes more trustworthy when it remembers what it did not convert.
+
+The hash stabilizes.
+
+The threshold is noted.
+
+Ambient phenomena continue at their own rates.
+
+The ledger records the transformation, not the world.
+
+The system continues.

--- a/policies/alms_receipt_boundary_v1.json
+++ b/policies/alms_receipt_boundary_v1.json
@@ -6,12 +6,14 @@
   "receipt_boundary": {
     "inside_scope": "explicitly transformed and replayable material",
     "outside_scope": "material for which no correspondence claim is made",
-    "latent": "compatible-but-unconverted phenomena remaining ambient during this intake cycle",
-    "latent_constraints": [
-      "latent status applies only at cycle completion",
-      "do not infer latent status retroactively from missing receipts",
-      "absence of receipts is not evidence of irrelevance or nonexistence"
-    ]
+    "latent": {
+      "definition": "Compatible with capture, present near the system, not yet transformed, not irrelevant, not claimed.",
+      "purpose": "Preserve the boundary between what the system has processed and what exists outside processing. This category carries no payload, only position.",
+      "failure_mode_prevented": "Calibration drift under internal coherence. Without this state, a ledger of accurate receipts will over time be read as a complete account of the world. Silence accumulates as implicit confirmation.",
+      "invariant": "Completeness of records is not completeness of world. Absence of a receipt is not evidence of irrelevance or nonexistence.",
+      "temporality": "Latent status applies only at cycle completion. Do not set retroactively from later absence. Status reflects what the system knew at the intake boundary, not what can be inferred afterward.",
+      "usage": "Set when a phenomenon is detected as proximate and compatible but not converted to a receipt in this cycle. Do not use for errors, rejections, out-of-scope data, or any state inferred after cycle completion."
+    }
   },
   "required_fields": [
     "scope",

--- a/policies/alms_receipt_boundary_v1.json
+++ b/policies/alms_receipt_boundary_v1.json
@@ -1,0 +1,27 @@
+{
+  "policy": "ALMS_RECEIPT_BOUNDARY_V1",
+  "status": "CANONICAL_DRAFT",
+  "constitutional_rule": "Correctly scoped. Remainder guaranteed.",
+  "ledger_rule": "The ledger records the transformation, not the world.",
+  "receipt_boundary": {
+    "inside_scope": "explicitly transformed and replayable material",
+    "outside_scope": "material for which no correspondence claim is made",
+    "latent": "compatible-but-unconverted phenomena remaining ambient during this intake cycle"
+  },
+  "required_fields": [
+    "scope",
+    "transformed",
+    "tolerance",
+    "threshold",
+    "latent",
+    "remainder",
+    "correspondence_outside_scope"
+  ],
+  "forbidden_implications": [
+    "receipt captures whole event",
+    "unreceipted phenomena are irrelevant",
+    "receipt exhausts correspondence",
+    "ledger equals world state"
+  ],
+  "preferred_statement": "This receipt records a scoped transformation. The threshold existed. Some phenomena did not cross it. Their status remains ambient. Correspondence outside scope is not claimed."
+}

--- a/policies/alms_receipt_boundary_v1.json
+++ b/policies/alms_receipt_boundary_v1.json
@@ -6,7 +6,12 @@
   "receipt_boundary": {
     "inside_scope": "explicitly transformed and replayable material",
     "outside_scope": "material for which no correspondence claim is made",
-    "latent": "compatible-but-unconverted phenomena remaining ambient during this intake cycle"
+    "latent": "compatible-but-unconverted phenomena remaining ambient during this intake cycle",
+    "latent_constraints": [
+      "latent status applies only at cycle completion",
+      "do not infer latent status retroactively from missing receipts",
+      "absence of receipts is not evidence of irrelevance or nonexistence"
+    ]
   },
   "required_fields": [
     "scope",

--- a/scripts/verify_receipt_boundary.py
+++ b/scripts/verify_receipt_boundary.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+ALMS Receipt Boundary Verifier v1
+
+Minimal consumption-layer gate for threshold-aware receipts.
+
+First enforceable rules:
+- FAIL if PARTIAL input produces COMPLETE output without conversion receipt.
+- FAIL if inherited_latent is stripped when upstream is PARTIAL.
+
+This verifier intentionally does not infer latent status from missing receipts.
+It only checks declared receipt-boundary fields.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+PASS_MESSAGE = "PASS: receipt boundary checks clean"
+
+
+def load_receipt(path: Path) -> Dict[str, Any]:
+    if not path.exists() or not path.is_file():
+        raise ValueError(f"input file not found: {path}")
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_output_status(receipt: Dict[str, Any]) -> Optional[str]:
+    nested = receipt.get("receipt")
+    if isinstance(nested, dict):
+        status = nested.get("status") or nested.get("receipt_status")
+        if status is not None:
+            return str(status)
+    status = receipt.get("status") or receipt.get("receipt_status")
+    return str(status) if status is not None else None
+
+
+def get_upstream_status(receipt: Dict[str, Any]) -> Optional[str]:
+    status = receipt.get("upstream_status")
+    if status is not None:
+        return str(status)
+    upstream = receipt.get("upstream")
+    if isinstance(upstream, dict):
+        status = upstream.get("status") or upstream.get("receipt_status")
+        return str(status) if status is not None else None
+    return None
+
+
+def has_conversion_receipt(receipt: Dict[str, Any]) -> bool:
+    conversion = receipt.get("conversion_receipt")
+    if conversion:
+        return True
+    conversion = receipt.get("conversion")
+    if isinstance(conversion, dict):
+        return bool(conversion.get("receipt") or conversion.get("receipt_id") or conversion.get("receipt_hash"))
+    return False
+
+
+def check_partial_not_laundered(receipt: Dict[str, Any]) -> Optional[str]:
+    """FAIL if PARTIAL input produces COMPLETE output without conversion receipt."""
+    upstream = get_upstream_status(receipt)
+    output_status = get_output_status(receipt)
+
+    if upstream == "PARTIAL" and output_status == "COMPLETE" and not has_conversion_receipt(receipt):
+        return "FAIL: PARTIAL input produces COMPLETE output without conversion receipt"
+    return None
+
+
+def check_inherited_latent_preserved(receipt: Dict[str, Any]) -> Optional[str]:
+    """FAIL if inherited_latent is stripped when upstream is PARTIAL."""
+    upstream = get_upstream_status(receipt)
+
+    if upstream == "PARTIAL" and "inherited_latent" not in receipt:
+        return "FAIL: inherited_latent missing from PARTIAL chain descendant"
+    return None
+
+
+def verify(path: Path) -> List[str]:
+    receipt = load_receipt(path)
+    failures: List[str] = []
+
+    for check in [check_partial_not_laundered, check_inherited_latent_preserved]:
+        result = check(receipt)
+        if result:
+            failures.append(result)
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="ALMS receipt boundary verifier v1")
+    parser.add_argument("input", help="local receipt or replay JSON file")
+    args = parser.parse_args()
+
+    try:
+        failures = verify(Path(args.input))
+    except Exception as exc:
+        print(f"INVALID_INPUT: {exc}", file=sys.stderr)
+        return 64
+
+    if failures:
+        for failure in failures:
+            print(failure)
+        return 1
+
+    print(PASS_MESSAGE)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_receipt_boundary.py
+++ b/scripts/verify_receipt_boundary.py
@@ -2,9 +2,13 @@
 """
 ALMS Receipt Boundary Verifier v1
 
-Minimal consumption-layer gate for threshold-aware receipts.
+Dependency-free consumption-layer gate for threshold-aware receipts.
 
-First enforceable rules:
+Rules enforced:
+- Required boundary receipt fields are present.
+- receipt_status is COMPLETE or PARTIAL.
+- upstream_status, when present, is COMPLETE, PARTIAL, or NONE.
+- remainder is explicit and fixed: guaranteed=true and correspondence_outside_scope=NOT_CLAIMED.
 - FAIL if PARTIAL input produces COMPLETE output without conversion receipt.
 - FAIL if inherited_latent is stripped when upstream is PARTIAL.
 
@@ -16,94 +20,120 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
 PASS_MESSAGE = "PASS: receipt boundary checks clean"
 
+REQUIRED_FIELDS = [
+    "claim_id",
+    "timestamp_utc",
+    "actor",
+    "nonce",
+    "inputs",
+    "outputs",
+    "verdict",
+    "receipt_status",
+    "threshold",
+    "remainder",
+]
+
+VALID_RECEIPT_STATUS = {"COMPLETE", "PARTIAL"}
+VALID_UPSTREAM_STATUS = {"COMPLETE", "PARTIAL", "NONE"}
+
 
 def load_receipt(path: Path) -> Dict[str, Any]:
     if not path.exists() or not path.is_file():
-        raise ValueError(f"input file not found: {path}")
+        raise FileNotFoundError(str(path))
     with path.open("r", encoding="utf-8") as f:
         return json.load(f)
 
 
-def get_output_status(receipt: Dict[str, Any]) -> Optional[str]:
-    nested = receipt.get("receipt")
-    if isinstance(nested, dict):
-        status = nested.get("status") or nested.get("receipt_status")
-        if status is not None:
-            return str(status)
-    status = receipt.get("status") or receipt.get("receipt_status")
-    return str(status) if status is not None else None
-
-
-def get_upstream_status(receipt: Dict[str, Any]) -> Optional[str]:
-    status = receipt.get("upstream_status")
-    if status is not None:
-        return str(status)
-    upstream = receipt.get("upstream")
-    if isinstance(upstream, dict):
-        status = upstream.get("status") or upstream.get("receipt_status")
-        return str(status) if status is not None else None
+def check_required_fields(receipt: Dict[str, Any]) -> Optional[str]:
+    missing = [field for field in REQUIRED_FIELDS if field not in receipt]
+    if missing:
+        return f"FAIL: missing required fields: {missing}"
     return None
 
 
-def has_conversion_receipt(receipt: Dict[str, Any]) -> bool:
-    conversion = receipt.get("conversion_receipt")
-    if conversion:
-        return True
-    conversion = receipt.get("conversion")
-    if isinstance(conversion, dict):
-        return bool(conversion.get("receipt") or conversion.get("receipt_id") or conversion.get("receipt_hash"))
-    return False
+def check_receipt_status(receipt: Dict[str, Any]) -> Optional[str]:
+    status = receipt.get("receipt_status")
+    if status not in VALID_RECEIPT_STATUS:
+        return f"FAIL: receipt_status must be COMPLETE or PARTIAL, got {status!r}"
+    return None
+
+
+def check_upstream_status(receipt: Dict[str, Any]) -> Optional[str]:
+    upstream = receipt.get("upstream_status")
+    if upstream is not None and upstream not in VALID_UPSTREAM_STATUS:
+        return f"FAIL: upstream_status must be COMPLETE, PARTIAL, or NONE, got {upstream!r}"
+    return None
+
+
+def check_remainder(receipt: Dict[str, Any]) -> Optional[str]:
+    remainder = receipt.get("remainder", {})
+    if not isinstance(remainder, dict):
+        return "FAIL: remainder must be an object"
+    if remainder.get("guaranteed") is not True:
+        return "FAIL: remainder.guaranteed must be true"
+    if remainder.get("correspondence_outside_scope") != "NOT_CLAIMED":
+        return "FAIL: remainder.correspondence_outside_scope must be NOT_CLAIMED"
+    return None
 
 
 def check_partial_not_laundered(receipt: Dict[str, Any]) -> Optional[str]:
-    """FAIL if PARTIAL input produces COMPLETE output without conversion receipt."""
-    upstream = get_upstream_status(receipt)
-    output_status = get_output_status(receipt)
-
-    if upstream == "PARTIAL" and output_status == "COMPLETE" and not has_conversion_receipt(receipt):
-        return "FAIL: PARTIAL input produces COMPLETE output without conversion receipt"
+    upstream = receipt.get("upstream_status")
+    if upstream == "PARTIAL":
+        status = receipt.get("receipt_status")
+        if status == "COMPLETE" and not receipt.get("conversion_receipt"):
+            return "FAIL: PARTIAL input produces COMPLETE output without conversion receipt"
     return None
 
 
 def check_inherited_latent_preserved(receipt: Dict[str, Any]) -> Optional[str]:
-    """FAIL if inherited_latent is stripped when upstream is PARTIAL."""
-    upstream = get_upstream_status(receipt)
-
-    if upstream == "PARTIAL" and "inherited_latent" not in receipt:
-        return "FAIL: inherited_latent missing from PARTIAL chain descendant"
+    upstream = receipt.get("upstream_status")
+    if upstream == "PARTIAL":
+        inherited = receipt.get("inherited_latent")
+        if inherited is None:
+            return "FAIL: inherited_latent missing from PARTIAL chain descendant"
+        if not isinstance(inherited, dict) or "present" not in inherited:
+            return "FAIL: inherited_latent must be object with 'present' field"
     return None
 
 
-def verify(path: Path) -> List[str]:
-    receipt = load_receipt(path)
-    failures: List[str] = []
+CHECKS = [
+    check_required_fields,
+    check_receipt_status,
+    check_upstream_status,
+    check_remainder,
+    check_partial_not_laundered,
+    check_inherited_latent_preserved,
+]
 
-    for check in [check_partial_not_laundered, check_inherited_latent_preserved]:
+
+def verify(path: Path) -> List[str]:
+    try:
+        receipt = load_receipt(path)
+    except json.JSONDecodeError as exc:
+        return [f"FAIL: invalid JSON: {exc}"]
+    except FileNotFoundError:
+        return [f"FAIL: file not found: {path}"]
+
+    failures: List[str] = []
+    for check in CHECKS:
         result = check(receipt)
         if result:
             failures.append(result)
-
     return failures
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="ALMS receipt boundary verifier v1")
-    parser.add_argument("input", help="local receipt or replay JSON file")
+    parser.add_argument("input", help="local boundary receipt JSON file")
     args = parser.parse_args()
 
-    try:
-        failures = verify(Path(args.input))
-    except Exception as exc:
-        print(f"INVALID_INPUT: {exc}", file=sys.stderr)
-        return 64
-
+    failures = verify(Path(args.input))
     if failures:
         for failure in failures:
             print(failure)

--- a/tests/fixtures/fail_inherited_latent_stripped/fixture.json
+++ b/tests/fixtures/fail_inherited_latent_stripped/fixture.json
@@ -1,0 +1,14 @@
+{
+  "fixture_spec": "FIXTURE_SPEC_V1",
+  "fixture_id": "fixture:receipt-boundary:fail-inherited-latent-stripped:001",
+  "upstream_status": "PARTIAL",
+  "receipt": {
+    "receipt_spec": "ALMS_RECEIPT_V1",
+    "status": "PARTIAL",
+    "digest": "sha256:failfixture"
+  },
+  "replay": {
+    "replay_spec": "REPLAY_SPEC_V1",
+    "expected_verdict": "FAIL"
+  }
+}

--- a/tests/fixtures/fail_partial_laundered/fixture.json
+++ b/tests/fixtures/fail_partial_laundered/fixture.json
@@ -1,0 +1,14 @@
+{
+  "fixture_spec": "FIXTURE_SPEC_V1",
+  "fixture_id": "fixture:receipt-boundary:fail-partial-laundered:001",
+  "upstream_status": "PARTIAL",
+  "receipt": {
+    "receipt_spec": "ALMS_RECEIPT_V1",
+    "status": "COMPLETE",
+    "digest": "sha256:failfixture"
+  },
+  "replay": {
+    "replay_spec": "REPLAY_SPEC_V1",
+    "expected_verdict": "FAIL"
+  }
+}

--- a/tests/fixtures/pass_partial_chain_preserved/fixture.json
+++ b/tests/fixtures/pass_partial_chain_preserved/fixture.json
@@ -1,0 +1,15 @@
+{
+  "fixture_spec": "FIXTURE_SPEC_V1",
+  "fixture_id": "fixture:receipt-boundary:pass-partial-preserved:001",
+  "upstream_status": "PARTIAL",
+  "inherited_latent": true,
+  "receipt": {
+    "receipt_spec": "ALMS_RECEIPT_V1",
+    "status": "PARTIAL",
+    "digest": "sha256:passfixture"
+  },
+  "replay": {
+    "replay_spec": "REPLAY_SPEC_V1",
+    "expected_verdict": "PASS"
+  }
+}


### PR DESCRIPTION
Adds formal threshold-awareness doctrine for ALMS receipts.

Core additions:
- latent / unconverted category
- threshold awareness as receipt boundary rule
- anti-oracle receipt language
- explicit remainder preservation
- constitutional distinction between transformation and world-state

Key constitutional rule:

> Correctly scoped. Remainder guaranteed.

Key ledger rule:

> The ledger records the transformation, not the world.

Artifacts added:
- docs/doctrine/ALMS_THRESHOLD_AWARENESS_V1.md
- policies/alms_receipt_boundary_v1.json

This PR hardens receipt systems against silent oracle drift caused by omission of threshold acknowledgment over time.