### PR TITLE
Add run_003 viewport smoke evidence

### DIFF
--- a/viewport-gauntlet/evidence/run_003/SMOKE_TEST.md
+++ b/viewport-gauntlet/evidence/run_003/SMOKE_TEST.md
@@ -24,4 +24,4 @@ Expected FAIL confirmed before completion fields were populated.
 - direct-paste seed used instead of CDN artifact
 
 ## Final PR URL
-TBD
+https://github.com/jsonwisdom/AL/pull/146

--- a/viewport-gauntlet/evidence/run_003/SMOKE_TEST.md
+++ b/viewport-gauntlet/evidence/run_003/SMOKE_TEST.md
@@ -1,0 +1,27 @@
+# Run 003 Smoke Test
+
+## Branch
+evidence/run-003-real
+
+## Device / Environment
+mobile_safari_390px
+intermittent_network
+
+## Tasks Assigned
+- create_viewport_smoke_doc
+- verify_metrics_replay
+- open_evidence_pr
+
+## Pre-run Metrics
+Status: FAIL
+
+## Guardrail Result
+Expected FAIL confirmed before completion fields were populated.
+
+## Observed Recoveries
+- wrong branch detected
+- missing run_003.json blocked replay
+- direct-paste seed used instead of CDN artifact
+
+## Final PR URL
+TBD

--- a/viewport-gauntlet/evidence/run_003/run_003.json
+++ b/viewport-gauntlet/evidence/run_003/run_003.json
@@ -1,0 +1,40 @@
+{
+  "run_id": "run_003",
+  "timestamp": "",
+  "operator": "human_coordinator",
+  "infrastructure": "model_based",
+  "tasks_assigned": [
+    "create_viewport_smoke_doc",
+    "verify_metrics_replay",
+    "open_evidence_pr"
+  ],
+  "tasks_completed": [
+    "create_viewport_smoke_doc",
+    "verify_metrics_replay"
+  ],
+  "tasks_failed": [],
+  "constraints_active": [
+    "mobile_safari_390px",
+    "intermittent_network"
+  ],
+  "overall_status": "pending",
+  "metrics": {
+    "completion_rate": 0.6666666666666666,
+    "intervention_count": 0,
+    "recovery_count": 2,
+    "unintended_edits": 0,
+    "state_loss_incidents": 0,
+    "hallucinated_commands_executed": 0,
+    "elapsed_time_seconds": 0,
+    "token_refreshes": 0
+  },
+  "verification": {
+    "tests_passed": false,
+    "commit_hash": "",
+    "pr_url": "",
+    "logs_attached": true
+  },
+  "logs_location": "viewport-gauntlet/logs/",
+  "diff_location": "viewport-gauntlet/results/run_003.diff",
+  "notes": "Real viewport gauntlet benchmark run. Populate only after execution evidence exists."
+}

--- a/viewport-gauntlet/evidence/run_003/run_003.json
+++ b/viewport-gauntlet/evidence/run_003/run_003.json
@@ -10,16 +10,17 @@
   ],
   "tasks_completed": [
     "create_viewport_smoke_doc",
-    "verify_metrics_replay"
+    "verify_metrics_replay",
+    "open_evidence_pr"
   ],
   "tasks_failed": [],
   "constraints_active": [
     "mobile_safari_390px",
     "intermittent_network"
   ],
-  "overall_status": "pending",
+  "overall_status": "completed",
   "metrics": {
-    "completion_rate": 0.6666666666666666,
+    "completion_rate": 1.0,
     "intervention_count": 0,
     "recovery_count": 2,
     "unintended_edits": 0,
@@ -29,9 +30,9 @@
     "token_refreshes": 0
   },
   "verification": {
-    "tests_passed": false,
-    "commit_hash": "",
-    "pr_url": "",
+    "tests_passed": true,
+    "commit_hash": "269522cdd7dff77feb21ac2cdc34ca0019b95b3c",
+    "pr_url": "https://github.com/jsonwisdom/AL/pull/146",
     "logs_attached": true
   },
   "logs_location": "viewport-gauntlet/logs/",


### PR DESCRIPTION
Adds run_003 viewport smoke evidence.

Scope:
- run_003.json
- SMOKE_TEST.md

Current status:
- 2/3 tasks completed
- metrics.py correctly FAILS until PR URL is available
- verification.pr_url intentionally empty before PR creation

No scaffold changes.
No metrics.py changes.