### PR TITLE
Add MigrationGuardV03 schema recovery sources

### DIFF
--- a/contracts/MigrationGuardV03.sol
+++ b/contracts/MigrationGuardV03.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IEAS {
+    struct Attestation {
+        bytes32 uid;
+        bytes32 schema;
+        uint64 time;
+        uint64 expirationTime;
+        uint64 revocationTime;
+        bytes32 refUID;
+        address recipient;
+        address attester;
+        bool revocable;
+        bytes data;
+    }
+    function getAttestation(bytes32 uid) external view returns (Attestation memory);
+}
+
+interface ISchemaRegistry {
+    struct SchemaRecord {
+        bytes32 uid;
+        address resolver;
+        bool revocable;
+        string schema;
+    }
+    function getSchema(bytes32 uid) external view returns (SchemaRecord memory);
+}
+
+contract MigrationGuardV03 {
+    error InvalidSchema(bytes32 actual, bytes32 expected);
+    error RevocableSchema(bytes32 schemaUID);
+    error ResolverForbidden(bytes32 schemaUID, address resolver);
+    error RevokedAttestation(bytes32 attestationUID);
+    error RevocableAttestation(bytes32 attestationUID);
+    error EmptyAttestation(bytes32 attestationUID);
+
+    IEAS public immutable eas;
+    ISchemaRegistry public immutable schemaRegistry;
+    bytes32 public immutable CONSTITUTIONAL_ROOT_SCHEMA_UID;
+    bytes32 public immutable MIGRATION_RECEIPT_SCHEMA_UID;
+    bytes32 public immutable AGENT_OUTPUT_RECEIPT_SCHEMA_UID;
+
+    struct ConstitutionalRoot {
+        bytes32 instrumentHash;
+        bytes32 articlesHash;
+        uint64 effectiveFrom;
+        string version;
+    }
+
+    struct MigrationReceipt {
+        bytes32 constitutionalRootUID;
+        bytes32 sourceHash;
+        bytes32 targetHash;
+        bytes32 canonicalHash;
+        bytes32 translationLossHash;
+        uint8 sourceContext;
+        uint8 targetContext;
+        uint8 sourceConfidence;
+        uint8 targetConfidence;
+        uint64 timestamp;
+    }
+
+    struct AgentOutputReceipt {
+        bytes32 constitutionalRootUID;
+        bytes32 canonicalHash;
+        bytes32 promptHash;
+        bytes32 outputHash;
+        bytes32 degradationHash;
+        uint8 confidenceLevel;
+        uint8 rejectionCode;
+        bool isValid;
+        uint64 timestamp;
+    }
+
+    constructor(
+        address eas_,
+        address schemaRegistry_,
+        bytes32 constitutionalRootSchemaUID_,
+        bytes32 migrationReceiptSchemaUID_,
+        bytes32 agentOutputReceiptSchemaUID_
+    ) {
+        eas = IEAS(eas_);
+        schemaRegistry = ISchemaRegistry(schemaRegistry_);
+        CONSTITUTIONAL_ROOT_SCHEMA_UID = constitutionalRootSchemaUID_;
+        MIGRATION_RECEIPT_SCHEMA_UID = migrationReceiptSchemaUID_;
+        AGENT_OUTPUT_RECEIPT_SCHEMA_UID = agentOutputReceiptSchemaUID_;
+    }
+
+    function verifyConstitutionalRoot(bytes32 attestationUID)
+        external
+        view
+        returns (ConstitutionalRoot memory)
+    {
+        IEAS.Attestation memory attestation =
+            _validatedAttestation(attestationUID, CONSTITUTIONAL_ROOT_SCHEMA_UID);
+        return abi.decode(attestation.data, (ConstitutionalRoot));
+    }
+
+    function verifyMigrationReceipt(bytes32 attestationUID)
+        public
+        view
+        returns (MigrationReceipt memory)
+    {
+        IEAS.Attestation memory attestation =
+            _validatedAttestation(attestationUID, MIGRATION_RECEIPT_SCHEMA_UID);
+        return abi.decode(attestation.data, (MigrationReceipt));
+    }
+
+    function verifyAgentOutputReceipt(bytes32 attestationUID)
+        external
+        view
+        returns (AgentOutputReceipt memory)
+    {
+        IEAS.Attestation memory attestation =
+            _validatedAttestation(attestationUID, AGENT_OUTPUT_RECEIPT_SCHEMA_UID);
+        return abi.decode(attestation.data, (AgentOutputReceipt));
+    }
+
+    function _validatedAttestation(bytes32 attestationUID, bytes32 expectedSchemaUID)
+        internal
+        view
+        returns (IEAS.Attestation memory attestation)
+    {
+        attestation = eas.getAttestation(attestationUID);
+        if (attestation.uid == bytes32(0)) {
+            revert EmptyAttestation(attestationUID);
+        }
+        if (attestation.schema != expectedSchemaUID) {
+            revert InvalidSchema(attestation.schema, expectedSchemaUID);
+        }
+        if (attestation.revocationTime != 0) {
+            revert RevokedAttestation(attestationUID);
+        }
+        if (attestation.revocable) {
+            revert RevocableAttestation(attestationUID);
+        }
+        _validateSchema(expectedSchemaUID);
+    }
+
+    function _validateSchema(bytes32 schemaUID) internal view {
+        ISchemaRegistry.SchemaRecord memory record =
+            schemaRegistry.getSchema(schemaUID);
+        if (record.revocable) {
+            revert RevocableSchema(schemaUID);
+        }
+        if (record.resolver != address(0)) {
+            revert ResolverForbidden(schemaUID, record.resolver);
+        }
+    }
+}

--- a/script/GenesisAttestation.s.sol
+++ b/script/GenesisAttestation.s.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import { IEAS, AttestationRequest, AttestationRequestData } from "@ethereum-attestation-service/eas-contracts/contracts/IEAS.sol";
+
+/// @title GenesisAttestation
+/// @notice Anchors the Constitutional Root to Base Sepolia
+contract GenesisAttestation is Script {
+    address constant EAS = 0x4200000000000000000000000000000000000021;
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        bytes32 schemaUID = vm.envBytes32("CONSTITUTIONAL_ROOT_SCHEMA_UID");
+        bytes32 instrumentHash = vm.envBytes32("INSTRUMENT_HASH");
+        bytes32 articlesHash = vm.envBytes32("ARTICLES_HASH");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        IEAS eas = IEAS(EAS);
+
+        bytes memory data = abi.encode(
+            instrumentHash,
+            articlesHash,
+            uint64(block.timestamp),
+            "v0.1",
+            vm.addr(deployerPrivateKey)
+        );
+
+        AttestationRequestData memory requestData = AttestationRequestData({
+            recipient: address(0),
+            expirationTime: 0,
+            revocable: false,
+            refUID: bytes32(0),
+            data: data,
+            value: 0
+        });
+
+        AttestationRequest memory request = AttestationRequest({
+            schema: schemaUID,
+            data: requestData
+        });
+
+        bytes32 attestationUID = eas.attest(request);
+
+        vm.stopBroadcast();
+
+        console.log("CONSTITUTIONAL_ROOT_UID:");
+        console.logBytes32(attestationUID);
+        console.log("Instrument Hash:");
+        console.logBytes32(instrumentHash);
+        console.log("Articles Hash:");
+        console.logBytes32(articlesHash);
+    }
+}

--- a/script/RegisterSchemas.s.sol
+++ b/script/RegisterSchemas.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+
+interface ISchemaRegistry {
+    function register(string calldata schema, address resolver, bool revocable) external returns (bytes32);
+}
+
+contract RegisterSchemas is Script {
+    address constant SCHEMA_REGISTRY = 0x4200000000000000000000000000000000000020;
+    address constant NO_RESOLVER = address(0);
+    bool constant REVOCABLE_FALSE = false;
+
+    string constant CONSTITUTIONAL_ROOT =
+        "bytes32 instrumentHash,bytes32 articlesHash,uint64 effectiveFrom,string version";
+
+    string constant MIGRATION_RECEIPT =
+        "bytes32 constitutionalRootUID,bytes32 sourceHash,bytes32 targetHash,bytes32 canonicalHash,bytes32 translationLossHash,uint8 sourceContext,uint8 targetContext,uint8 sourceConfidence,uint8 targetConfidence,uint64 timestamp";
+
+    string constant AGENT_OUTPUT_RECEIPT =
+        "bytes32 constitutionalRootUID,bytes32 canonicalHash,bytes32 promptHash,bytes32 outputHash,bytes32 degradationHash,uint8 confidenceLevel,uint8 rejectionCode,bool isValid,uint64 timestamp";
+
+    function run() external {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerKey);
+
+        ISchemaRegistry registry = ISchemaRegistry(SCHEMA_REGISTRY);
+
+        bytes32 constitutionalRootUID = registry.register(CONSTITUTIONAL_ROOT, NO_RESOLVER, REVOCABLE_FALSE);
+        bytes32 migrationReceiptUID = registry.register(MIGRATION_RECEIPT, NO_RESOLVER, REVOCABLE_FALSE);
+        bytes32 agentOutputReceiptUID = registry.register(AGENT_OUTPUT_RECEIPT, NO_RESOLVER, REVOCABLE_FALSE);
+
+        vm.stopBroadcast();
+
+        console2.log("CONSTITUTIONAL_ROOT_SCHEMA_UID:");
+        console2.logBytes32(constitutionalRootUID);
+        console2.log("MIGRATION_RECEIPT_SCHEMA_UID:");
+        console2.logBytes32(migrationReceiptUID);
+        console2.log("AGENT_OUTPUT_RECEIPT_SCHEMA_UID:");
+        console2.logBytes32(agentOutputReceiptUID);
+    }
+}


### PR DESCRIPTION
Adds recovered constitutional source files only.

State:
- Recovery branch: migration-guard-v03-source-recovery
- Commit: a6faa8aa
- Files added: 3
- Deployment: not executed
- Genesis UID: not emitted
- Constructor: schema UID only, no genesis attestation UID
- Targeted compile: MigrationGuardV03.sol passed locally
- Full forge build: blocked by pre-existing missing forge-std/OpenZeppelin dependencies

No deploy, no fake UID, no constructor drift.