### PR TITLE
package(alms): add zk receipt verifier module v1

### DIFF
--- a/alms/modules/zk_receipt_verifier/.gitignore
+++ b/alms/modules/zk_receipt_verifier/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/alms/modules/zk_receipt_verifier/MODULE.json
+++ b/alms/modules/zk_receipt_verifier/MODULE.json
@@ -1,0 +1,21 @@
+{
+  "module_id": "alms.zk_receipt_verifier.v1",
+  "status": "REPO_TEST_GREEN",
+  "source_path": "runtime_lattice",
+  "test_command": "python3 -m pytest runtime_lattice/tests/test_zk_adversarial.py -v --tb=short",
+  "test_result": "5 passed, 0 failed",
+  "verified_commit": "80fe507c880519868535d35afc3fae0b080b6e10",
+  "verified_at": "2025-05-10T22:18:00Z",
+  "invariants": [
+    "nullifier reserve before proof verification",
+    "bad proof consumes nullifier",
+    "revoked key consumes nullifier",
+    "missing public input does not reserve nullifier",
+    "no packaging before repo-green"
+  ],
+  "dependencies": [],
+  "entry_points": {
+    "zk_verifier": "present_zk_visa",
+    "validator": "enforce_runtime_legality"
+  }
+}

--- a/alms/modules/zk_receipt_verifier/__init__.py
+++ b/alms/modules/zk_receipt_verifier/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime lattice package."""

--- a/alms/modules/zk_receipt_verifier/tests/mocks/mock_noir.py
+++ b/alms/modules/zk_receipt_verifier/tests/mocks/mock_noir.py
@@ -1,0 +1,6 @@
+class MockNoirVerifier:
+    def __init__(self, always_valid=True):
+        self.always_valid = always_valid
+
+    def verify(self, proof_bytes, public_inputs):
+        return self.always_valid

--- a/alms/modules/zk_receipt_verifier/tests/test_zk_adversarial.py
+++ b/alms/modules/zk_receipt_verifier/tests/test_zk_adversarial.py
@@ -1,0 +1,175 @@
+import sqlite3
+from datetime import datetime, timedelta
+
+import pytest
+
+from runtime_lattice.zk_verifier import (
+    present_zk_visa,
+    get_hybrid_time,
+)
+
+
+class MockProof:
+    def __init__(
+        self,
+        metadata_valid=True,
+        revoked=False,
+        corrupt_bytes=False,
+    ):
+        self.proof_bytes = b"mock_proof"
+        if corrupt_bytes:
+            self.proof_bytes = b"corrupt"
+
+        self.metadata = {
+            "signature_valid": metadata_valid,
+            "key_revoked": revoked,
+            "roles_ok": not revoked,
+        }
+
+
+class MockVerifier:
+    def __init__(self, valid=True):
+        self.valid = valid
+
+    def verify(self, proof_bytes, public_inputs):
+        return self.valid
+
+
+@pytest.fixture
+
+def registry():
+    conn = sqlite3.connect(":memory:")
+
+    conn.execute(
+        """
+        CREATE TABLE consumption_registry (
+            promotion_id TEXT PRIMARY KEY,
+            consumed BOOLEAN DEFAULT FALSE,
+            nullifier_hash TEXT UNIQUE,
+            consumption_type TEXT,
+            attempt_status TEXT,
+            reason_code TEXT,
+            metadata TEXT,
+            last_attempt_at_unix_ms INTEGER
+        )
+        """
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE attempt_log (
+            attempt_id TEXT,
+            promotion_id TEXT,
+            timestamp_unix_ms INTEGER,
+            result TEXT,
+            reason_code TEXT,
+            verifier_identity_hash TEXT,
+            metadata_json TEXT
+        )
+        """
+    )
+
+    return conn
+
+
+
+def test_nullifier_replay(registry):
+    nullifier = "0xdeadbeef"
+
+    registry.execute(
+        """
+        INSERT INTO consumption_registry
+        (promotion_id, consumed, nullifier_hash, attempt_status)
+        VALUES (?, ?, ?, ?)
+        """,
+        ("promo_replay", 1, nullifier, "SUCCESS"),
+    )
+    registry.commit()
+
+    result = present_zk_visa(
+        zk_proof=MockProof(),
+        public_inputs={
+            "nullifier_hash": nullifier,
+            "promotion_id": "promo_replay_2",
+        },
+        requested_primitive="TRANSFER",
+        registry_conn=registry,
+        noir_verifier=MockVerifier(valid=True),
+    )
+
+    assert result["reason_code"] == "E001"
+
+
+
+def test_bad_proof_bytes(registry):
+    nullifier = "0xbadproof"
+
+    result = present_zk_visa(
+        zk_proof=MockProof(corrupt_bytes=True),
+        public_inputs={
+            "nullifier_hash": nullifier,
+            "promotion_id": "promo_badproof",
+            "authorized_primitive": "TRANSFER",
+        },
+        requested_primitive="TRANSFER",
+        registry_conn=registry,
+        noir_verifier=MockVerifier(valid=False),
+    )
+
+    assert result["reason_code"] == "E002_BAD_PROOF"
+
+
+
+def test_expired_proof_consumes(registry):
+    nullifier = "0xexpired"
+    past_time = int((datetime.now() - timedelta(days=1)).timestamp() * 1000)
+
+    result = present_zk_visa(
+        zk_proof=MockProof(),
+        public_inputs={
+            "nullifier_hash": nullifier,
+            "promotion_id": "promo_expired",
+            "authorized_primitive": "TRANSFER",
+            "valid_until": past_time,
+            "valid_from": 0,
+        },
+        requested_primitive="TRANSFER",
+        registry_conn=registry,
+        noir_verifier=MockVerifier(valid=True),
+    )
+
+    assert result["reason_code"] == "E005"
+
+
+
+def test_missing_public_input(registry):
+    result = present_zk_visa(
+        zk_proof=MockProof(),
+        public_inputs={
+            "nullifier_hash": "0xmissing",
+        },
+        requested_primitive="TRANSFER",
+        registry_conn=registry,
+        noir_verifier=MockVerifier(valid=True),
+    )
+
+    assert result["reason_code"] == "E009"
+
+
+
+def test_revoked_key_metadata_fail(registry):
+    nullifier = "0xrevoked"
+
+    result = present_zk_visa(
+        zk_proof=MockProof(revoked=True),
+        public_inputs={
+            "nullifier_hash": nullifier,
+            "promotion_id": "promo_revoked",
+            "authorized_primitive": "TRANSFER",
+        },
+        requested_primitive="TRANSFER",
+        registry_conn=registry,
+        noir_verifier=MockVerifier(valid=True),
+    )
+
+    assert result["reason_code"] == "E007"

--- a/alms/modules/zk_receipt_verifier/zk_verifier.py
+++ b/alms/modules/zk_receipt_verifier/zk_verifier.py
@@ -1,0 +1,281 @@
+import hashlib
+import json
+import sqlite3
+import time
+from typing import Dict, Any, Optional
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def get_hybrid_time(block_timestamp: Optional[int] = None) -> int:
+    if block_timestamp is not None:
+        return block_timestamp
+    return now_ms()
+
+
+def sha256(data: str) -> str:
+    return hashlib.sha256(data.encode()).hexdigest()
+
+
+def external_signature_checks(metadata: Dict[str, Any]) -> bool:
+    return metadata.get("signature_valid", True)
+
+
+def external_role_revocation_checks(metadata: Dict[str, Any]) -> bool:
+    return not metadata.get("key_revoked", False)
+
+
+def execute_primitive(primitive: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "status": "executed",
+        "primitive": primitive,
+        "context": context,
+    }
+
+
+def _update_attempt_status(
+    conn,
+    nullifier: str,
+    status: str,
+    reason_code: Optional[str],
+    metadata: Optional[Dict[str, Any]] = None,
+):
+    consumed = 1 if status in ("SUCCESS", "REJECTED") else 0
+
+    conn.execute(
+        """
+        UPDATE consumption_registry
+        SET consumed = ?,
+            consumption_type = ?,
+            attempt_status = ?,
+            reason_code = ?,
+            metadata = ?
+        WHERE nullifier_hash = ?
+        """,
+        (
+            consumed,
+            f"zk_v1_{status.lower()}",
+            status,
+            reason_code,
+            json.dumps(metadata or {}),
+            nullifier,
+        ),
+    )
+    conn.commit()
+
+
+
+def log_zk_attempt(
+    nullifier: str,
+    result: str,
+    reason_code: Optional[str],
+    conn,
+    metadata: Optional[Dict[str, Any]] = None,
+):
+    attempt_id = sha256(f"{nullifier}:{now_ms()}:{result}")
+
+    conn.execute(
+        """
+        INSERT INTO attempt_log
+        (attempt_id, promotion_id, timestamp_unix_ms, result,
+         reason_code, verifier_identity_hash, metadata_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            attempt_id,
+            f"zk_{nullifier[:16]}",
+            now_ms(),
+            result,
+            reason_code,
+            "zk_verifier_v1",
+            json.dumps(metadata or {}),
+        ),
+    )
+    conn.commit()
+    return attempt_id
+
+
+class ZKVerificationError(Exception):
+    pass
+
+
+
+def present_zk_visa(
+    zk_proof,
+    public_inputs,
+    requested_primitive,
+    registry_conn,
+    noir_verifier,
+):
+    required_minimal = ["nullifier_hash", "promotion_id"]
+
+    for field in required_minimal:
+        if field not in public_inputs:
+            return {
+                "result": "REJECTED",
+                "reason_code": "E009",
+                "reason_text": f"MISSING_PUBLIC_INPUT_{field}",
+            }
+
+    nullifier = public_inputs["nullifier_hash"]
+
+    try:
+        registry_conn.execute(
+            """
+            INSERT INTO consumption_registry
+            (promotion_id, consumed, nullifier_hash,
+             consumption_type, last_attempt_at_unix_ms, attempt_status)
+            VALUES (?, FALSE, ?, 'zk_pending', ?, 'reserved')
+            """,
+            (
+                public_inputs["promotion_id"],
+                nullifier,
+                now_ms(),
+            ),
+        )
+        registry_conn.commit()
+
+    except sqlite3.IntegrityError:
+        status = registry_conn.execute(
+            "SELECT consumed, attempt_status FROM consumption_registry WHERE nullifier_hash = ?",
+            (nullifier,),
+        ).fetchone()
+
+        if status and status[0]:
+            log_zk_attempt(nullifier, "REJECTED", "E001", registry_conn)
+            return {
+                "result": "REJECTED",
+                "reason_code": "E001",
+                "reason_text": "ALREADY_CONSUMED",
+            }
+
+        log_zk_attempt(nullifier, "REJECTED", "E010", registry_conn)
+        return {
+            "result": "REJECTED",
+            "reason_code": "E010",
+            "reason_text": "ALREADY_RESERVED",
+        }
+
+    log_zk_attempt(nullifier, "ATTEMPT_STARTED", None, registry_conn)
+
+    try:
+        if not external_signature_checks(zk_proof.metadata):
+            _update_attempt_status(
+                registry_conn,
+                nullifier,
+                "REJECTED",
+                "E002_BAD_SIGNATURE",
+            )
+            return {
+                "result": "REJECTED",
+                "reason_code": "E002_BAD_SIGNATURE",
+                "reason_text": "Invalid signatures",
+            }
+
+        if not external_role_revocation_checks(zk_proof.metadata):
+            _update_attempt_status(
+                registry_conn,
+                nullifier,
+                "REJECTED",
+                "E007",
+            )
+            return {
+                "result": "REJECTED",
+                "reason_code": "E007",
+                "reason_text": "Revoked or invalid key",
+            }
+
+        proof_valid = noir_verifier.verify(
+            zk_proof.proof_bytes,
+            public_inputs,
+        )
+
+        if not proof_valid:
+            _update_attempt_status(
+                registry_conn,
+                nullifier,
+                "REJECTED",
+                "E002_BAD_PROOF",
+            )
+            return {
+                "result": "REJECTED",
+                "reason_code": "E002_BAD_PROOF",
+                "reason_text": "ZK proof invalid",
+            }
+
+        if requested_primitive != public_inputs.get("authorized_primitive"):
+            _update_attempt_status(
+                registry_conn,
+                nullifier,
+                "REJECTED",
+                "E006",
+            )
+            return {
+                "result": "REJECTED",
+                "reason_code": "E006",
+                "reason_text": "SCOPE_VIOLATION",
+            }
+
+        now = get_hybrid_time()
+
+        if now < public_inputs.get("valid_from", 0):
+            _update_attempt_status(
+                registry_conn,
+                nullifier,
+                "REJECTED",
+                "E005",
+            )
+            return {
+                "result": "REJECTED",
+                "reason_code": "E005",
+                "reason_text": "NOT_YET_VALID",
+            }
+
+        if now > public_inputs.get("valid_until", float("inf")):
+            _update_attempt_status(
+                registry_conn,
+                nullifier,
+                "REJECTED",
+                "E005",
+            )
+            return {
+                "result": "REJECTED",
+                "reason_code": "E005",
+                "reason_text": "EXPIRED",
+            }
+
+        execution_result = execute_primitive(
+            requested_primitive,
+            {"nullifier": nullifier},
+        )
+
+        _update_attempt_status(
+            registry_conn,
+            nullifier,
+            "SUCCESS",
+            None,
+        )
+
+        return {
+            "result": execution_result,
+            "promotion_receipt_status": "CONSUMED",
+            "nullifier_hash": nullifier,
+            "consumption_type": "zk_v1",
+        }
+
+    except Exception as exc:
+        _update_attempt_status(
+            registry_conn,
+            nullifier,
+            "REJECTED",
+            "E099",
+            {"error": str(exc)},
+        )
+
+        return {
+            "result": "REJECTED",
+            "reason_code": "E099",
+            "reason_text": f"Internal error: {exc}",
+        }


### PR DESCRIPTION
## Module Information
- **Module ID:** `alms.zk_receipt_verifier.v1`
- **Source:** `runtime_lattice/`
- **Verified Commit:** `80fe507c880519868535d35afc3fae0b080b6e10`
- **Test Result:** 5 passed, 0 failed

## Invariants Enforced
- nullifier reserve before proof verification
- bad proof consumes nullifier
- revoked key consumes nullifier
- missing public input does not reserve nullifier
- no packaging before repo-green

## Files
- `MODULE.json` - Proof anchor and metadata
- `zk_verifier.py` - `present_zk_visa` with reserve-first pattern
- `tests/test_zk_adversarial.py` - adversarial test coverage
- `tests/mocks/mock_noir.py` - mock verifier for testing
- `.gitignore` - excludes `__pycache__`

## Test Command
```bash
python3 -m pytest runtime_lattice/tests/test_zk_adversarial.py -v --tb=short
```

## Status
✅ REPO_TEST_GREEN  
✅ Remote branch verified  
✅ Ready for review

No ghost-green. Only receipts.