### PR TITLE
fix(scripts): replace deprecated utcnow with timezone-aware UTC

### DIFF
--- a/alms/modules/zk_receipt_verifier/circuit/compile_and_hash.py
+++ b/alms/modules/zk_receipt_verifier/circuit/compile_and_hash.py
@@ -52,7 +52,7 @@ def main():
     receipt_parts = {
         "circuit_hash": circuit_hash,
         "noir_version": noir_version,
-        "timestamp": datetime.utcnow().isoformat()
+        "timestamp": datetime.now(timezone.utc).isoformat()
     }
     build_receipt_hash = sha256_json(receipt_parts)
     result["build_receipt_hash"] = build_receipt_hash


### PR DESCRIPTION
## Summary
Remove deprecation warning from `compile_and_hash.py` by using timezone-aware UTC timestamp.

## Changes
- Replace `datetime.utcnow()` with `datetime.now(timezone.utc)`
- No functional change, only future-proofing

## Before
```
DeprecationWarning: datetime.datetime.utcnow() is deprecated
```

## After
```
✅ No deprecation warning
```

## Related
- PR #159 (script improvements)