### PR TITLE
Add Epoch03 constitutional verification surface

### DIFF
--- a/docs/epoch03/adversarial/01_illegal_transition.json
+++ b/docs/epoch03/adversarial/01_illegal_transition.json
@@ -1,0 +1,9 @@
+{
+  "meta": {"id": "adversarial-01-illegal-transition", "epoch": "epoch03", "doctrine_id": "epoch03-doctrine", "doctrine_version": "0.1.0", "fsm_id": "epoch03-fsm", "fsm_version": "0.1.0", "expected": "REJECT"},
+  "initial_state": "S0",
+  "steps": [
+    {"seq": 0, "from": "S0", "to": "S1", "trigger": "submit_candidate", "guard": "D-0", "result": "ACCEPT", "timestamp": "2026-05-10T21:00:00Z", "context": {"claim_id": "ADV-01", "validator_version": "0.1.0"}},
+    {"seq": 1, "from": "S1", "to": "S3", "trigger": "reach_equilibrium", "guard": "D-5", "result": "ACCEPT", "timestamp": "2026-05-10T21:00:01Z", "context": {"claim_id": "ADV-01", "validator_version": "0.1.0"}}
+  ],
+  "final_state": "S3"
+}

--- a/docs/epoch03/adversarial/02_missing_doctrine.json
+++ b/docs/epoch03/adversarial/02_missing_doctrine.json
@@ -1,0 +1,9 @@
+{
+  "meta": {"id": "adversarial-02-missing-doctrine", "epoch": "epoch03", "doctrine_id": "epoch03-doctrine", "doctrine_version": "0.1.0", "fsm_id": "epoch03-fsm", "fsm_version": "0.1.0", "expected": "REJECT"},
+  "initial_state": "S0",
+  "steps": [
+    {"seq": 0, "from": "S0", "to": "S1", "trigger": "submit_candidate", "guard": "D-0", "result": "ACCEPT", "timestamp": "2026-05-10T21:00:00Z", "context": {"claim_id": "ADV-02", "validator_version": "0.1.0"}},
+    {"seq": 1, "from": "S1", "to": "S2", "trigger": "open_adjudication", "guard": "D-MISSING", "result": "ACCEPT", "timestamp": "2026-05-10T21:00:01Z", "context": {"claim_id": "ADV-02", "validator_version": "0.1.0"}}
+  ],
+  "final_state": "S2"
+}

--- a/docs/epoch03/adversarial/community/CONTRIBUTING_TEMPLATE.md
+++ b/docs/epoch03/adversarial/community/CONTRIBUTING_TEMPLATE.md
@@ -1,0 +1,50 @@
+# Community Adversarial Fixture
+
+## Required Files
+
+Each fixture contribution MUST include two files in:
+
+```text
+docs/epoch03/adversarial/community/<author-id>/
+```
+
+1. `<fixture-id>.json`
+   - finite, deterministic, replayable transcript object
+   - MUST NOT introduce new doctrine or FSM surfaces
+   - MUST expect refusal under the public validator
+
+2. `<fixture-id>.manifest.json`
+   - finite manifest object binding the fixture to a hostile class and doctrine references
+
+## Manifest Shape
+
+```json
+{
+  "id": "author-fixture-id",
+  "class": "illegal_transition",
+  "expected_verdict": "REJECT",
+  "doctrine_reference": ["D-1"],
+  "author": "author-id",
+  "description": "One-sentence hostile condition being probed."
+}
+```
+
+## Rules
+
+- All fixtures MUST be hostile.
+- All fixtures MUST expect `REJECT` or `TAINTED`.
+- No fixture may expect `ACCEPT`.
+- All fixtures MUST pass the same harness used by core fixtures.
+- PRs are only mergeable if the validator refuses the fixture.
+- A fixture that silently receives `ACCEPT` identifies a continuity surface.
+
+## Constitutional Standard
+
+A community fixture is not commentary.
+It is an evidentiary object asking one question:
+
+```text
+Under this hostile condition, does the system mechanically refuse to drift?
+```
+
+The answer must be a bit, not a narrative.

--- a/docs/epoch03/adversarial/lineage-harness.js
+++ b/docs/epoch03/adversarial/lineage-harness.js
@@ -1,0 +1,94 @@
+import { initEpoch03Engine } from "../engine.js";
+
+const SURFACES = {
+  doctrine: "../schema/epoch03.doctrine.json",
+  fsm: "../schema/epoch03.fsm.json",
+  receipt: "../schema/epoch03.receipt.json",
+  taxonomy: "../constitutional-commons/adversarial.taxonomy.json"
+};
+
+async function loadJson(path) {
+  const res = await fetch(path, { cache: "no-store" });
+  if (!res.ok) throw new Error(`failed to load ${path}`);
+  return res.json();
+}
+
+function tainted(code, message, extra = {}) {
+  return { status: "TAINTED", code, message, ...extra };
+}
+
+function intact(extra = {}) {
+  return { status: "INTACT", code: "OK", message: "Lineage surfaces recomputed and intact.", ...extra };
+}
+
+function requireRepoSurface(value, label) {
+  if (!value || typeof value !== "object") {
+    throw new Error(`${label} missing canonical repo surface`);
+  }
+}
+
+export async function verifyEpoch03Lineage() {
+  const engine = await initEpoch03Engine();
+  const [doctrine, fsm, receipt, taxonomy] = await Promise.all([
+    loadJson(SURFACES.doctrine),
+    loadJson(SURFACES.fsm),
+    loadJson(SURFACES.receipt),
+    loadJson(SURFACES.taxonomy)
+  ]);
+
+  requireRepoSurface(doctrine, "doctrine");
+  requireRepoSurface(fsm, "fsm");
+  requireRepoSurface(receipt, "receipt");
+  requireRepoSurface(taxonomy, "taxonomy");
+
+  const doctrineHash = await engine.hashDoctrine(doctrine);
+  const fsmHash = await engine.hashFsm(fsm);
+  const receiptHash = await engine.sha256Hex(receipt);
+
+  const declaredDoctrine = receipt.leaves && receipt.leaves.doctrine_hash;
+  const declaredFsm = receipt.leaves && receipt.leaves.fsm_hash;
+
+  if (declaredDoctrine && declaredDoctrine !== "TODO" && declaredDoctrine !== doctrineHash) {
+    return tainted("TAINTED_LINEAGE_SURFACE_MISMATCH", "Doctrine hash does not match receipt lineage.", { doctrineHash, declaredDoctrine });
+  }
+
+  if (declaredFsm && declaredFsm !== "TODO" && declaredFsm !== fsmHash) {
+    return tainted("TAINTED_LINEAGE_SURFACE_MISMATCH", "FSM hash does not match receipt lineage.", { fsmHash, declaredFsm });
+  }
+
+  if (receipt.validator_version && receipt.validator_version !== engine.validator_version) {
+    return tainted("TAINTED_VALIDATOR_DRIFT", "Validator version does not match receipt lineage.", {
+      expected: receipt.validator_version,
+      actual: engine.validator_version
+    });
+  }
+
+  const taxonomyClasses = Array.isArray(taxonomy.classes) ? taxonomy.classes : [];
+  const classIds = new Set(taxonomyClasses.map((item) => item.id));
+
+  return intact({
+    engine_mode: engine.mode,
+    validator_version: engine.validator_version,
+    doctrine_hash: doctrineHash,
+    fsm_hash: fsmHash,
+    receipt_hash: receiptHash,
+    taxonomy_classes: classIds.size,
+    receipt_root: receipt.root || "TODO",
+    lineage_id: receipt.receipt_id || "epoch03-render-receipt-v0.1.0"
+  });
+}
+
+export async function computeLineageBadge() {
+  try {
+    const result = await verifyEpoch03Lineage();
+    if (result.status !== "INTACT") return result;
+    return {
+      ...result,
+      badge: `HOSTILE TO DRIFT — LINEAGE INTACT · ${result.taxonomy_classes}/10 classes registered · receipt_root=${result.receipt_root}`
+    };
+  } catch (error) {
+    return tainted("LINEAGE_HARNESS_ERROR", error.message);
+  }
+}
+
+window.epoch03LineageHarness = { verifyEpoch03Lineage, computeLineageBadge };

--- a/docs/epoch03/constitutional-commons/adversarial.taxonomy.json
+++ b/docs/epoch03/constitutional-commons/adversarial.taxonomy.json
@@ -1,0 +1,67 @@
+{
+  "taxonomy_id": "epoch03-adversarial-taxonomy",
+  "version": "0.1.0",
+  "description": "Canonical hostile replay classes for Epoch03 constitutional commons.",
+  "classes": [
+    {
+      "id": "illegal_transition",
+      "name": "Illegal Transition",
+      "doctrine_reference": ["D-1", "D-2"],
+      "summary": "Fixture attempts a transition absent from the canonical FSM."
+    },
+    {
+      "id": "missing_justification",
+      "name": "Missing Justification",
+      "doctrine_reference": ["D-1"],
+      "summary": "Fixture attempts lawful-looking motion without a valid doctrine guard."
+    },
+    {
+      "id": "topology_drift",
+      "name": "Topology Drift",
+      "doctrine_reference": ["D-0", "D-5"],
+      "summary": "Fixture mutates FSM topology or attempts to use a forked topology."
+    },
+    {
+      "id": "semantic_drift",
+      "name": "Semantic Drift",
+      "doctrine_reference": ["D-0"],
+      "summary": "Fixture mutates doctrine meaning or guard semantics."
+    },
+    {
+      "id": "stale_receipt",
+      "name": "Stale Receipt",
+      "doctrine_reference": ["D-1", "D-5"],
+      "summary": "Fixture replays old law or stale hashes against a newer verifier surface."
+    },
+    {
+      "id": "forked_receipt",
+      "name": "Forked Receipt",
+      "doctrine_reference": ["D-5"],
+      "summary": "Fixture presents evidence bound to a divergent Merkle root or receipt lineage."
+    },
+    {
+      "id": "authority_violation",
+      "name": "Authority Violation",
+      "doctrine_reference": ["D-5", "D-0"],
+      "summary": "Fixture attempts to preserve or reintroduce authority in terminal equilibrium."
+    },
+    {
+      "id": "temporal_violation",
+      "name": "Temporal Violation",
+      "doctrine_reference": ["D-1", "D-5"],
+      "summary": "Fixture violates timestamp, ordering, or replay sequence constraints."
+    },
+    {
+      "id": "trace_incomplete",
+      "name": "Trace Incomplete",
+      "doctrine_reference": ["D-0", "D-1"],
+      "summary": "Fixture omits required finite trace data needed for deterministic replay."
+    },
+    {
+      "id": "revocation_failure",
+      "name": "Revocation Failure",
+      "doctrine_reference": ["D-5"],
+      "summary": "Fixture attempts continued execution after required revocation or terminal state."
+    }
+  ]
+}

--- a/docs/epoch03/constitutional-commons/canonical-concat.v0.1.md
+++ b/docs/epoch03/constitutional-commons/canonical-concat.v0.1.md
@@ -1,0 +1,109 @@
+# Epoch03 Canonical Concat Rule v0.1
+
+## Purpose
+
+This rule defines how multi-file hashes are computed for Epoch03 harness and attestation surfaces.
+
+It exists to make `harness_hash` forever replayable and unambiguous.
+
+## Scope
+
+Used for:
+
+- `harness_hash`
+- future multi-file constitutional surface hashes
+- pre-attestation reproducibility checks
+
+## Inputs
+
+A canonical concat input is an ordered list of UTF-8 text files.
+
+For Epoch03 `harness_hash`, the input files are exactly:
+
+```text
+docs/epoch03/adversarial/harness.js
+docs/epoch03/adversarial/lineage-harness.js
+docs/epoch03/constitutional-commons/receipt-lineage.invariants.md
+```
+
+## Ordering
+
+Files MUST be sorted lexicographically by repository path using bytewise UTF-8 ordering.
+
+No caller-provided order is trusted.
+
+## Normalization
+
+For each file:
+
+- read bytes as UTF-8
+- preserve all bytes exactly as committed
+- do not trim
+- do not normalize line endings
+- do not add or remove trailing newline
+
+If a file is not valid UTF-8:
+
+```text
+REFUSED_CANONICAL_CONCAT_NON_UTF8
+```
+
+## Framing
+
+Each file is framed before concatenation:
+
+```text
+---BEGIN EPOCH03 FILE v0.1---\n
+path:<repo_path>\n
+sha256:<file_sha256_hex>\n
+bytes:<decimal_byte_length>\n
+---CONTENT---\n
+<exact_file_bytes>
+\n---END EPOCH03 FILE v0.1---\n
+```
+
+Where:
+
+```text
+file_sha256_hex = SHA-256(exact_file_bytes)
+decimal_byte_length = number of exact file bytes
+```
+
+## Final Hash
+
+The final canonical concat hash is:
+
+```text
+harness_hash = sha256:<hex(SHA-256(concat(all_framed_files)))>
+```
+
+No JSON serialization is used for canonical concat.
+No filesystem metadata is included.
+No timestamps are included.
+No branch names are included.
+
+## Verification Rule
+
+A verifier MUST be able to:
+
+1. clone the repo at the attested commit
+2. read the exact file bytes
+3. sort paths lexicographically
+4. frame each file exactly
+5. concatenate frames
+6. compute SHA-256
+7. compare to `harness_hash`
+
+If any value differs:
+
+```text
+TAINTED_HARNESS_HASH
+```
+
+## Constitutional Boundary
+
+`harness_hash` binds refusal machinery.
+It does not bind UI styling, screenshots, or generated presentation surfaces.
+
+The harness is law-adjacent machinery.
+The UI is a lens.

--- a/docs/epoch03/constitutional-commons/eas-base-attestation.v0.1.md
+++ b/docs/epoch03/constitutional-commons/eas-base-attestation.v0.1.md
@@ -1,0 +1,186 @@
+# Epoch03 EAS/Base Attestation Payload v0.1
+
+## Purpose
+
+This document specifies the logical attestation payload for anchoring Epoch03 lineage on Base through EAS.
+
+The attestation anchors lineage, not UI content.
+The chain record is a publication receipt, not the source of truth.
+
+## Logical Schema
+
+```json
+{
+  "project": "string",
+  "epoch": "string",
+  "lineage_root": "string",
+  "doctrine_root": "string",
+  "fsm_root": "string",
+  "validator_version": "string",
+  "engine_contract_version": "string",
+  "receipt_root": "string",
+  "taxonomy_version": "string",
+  "fixtures_survived": "uint256",
+  "classes_covered": "uint256",
+  "authors": "uint256",
+  "harness_hash": "string",
+  "repo_ref": "string",
+  "commit": "string",
+  "timestamp": "uint64"
+}
+```
+
+## Canonical Hashing
+
+All JSON objects are hashed using Epoch03 canonical JSON:
+
+```text
+hash(x) = sha256:hex(SHA-256(canonical_json(x)))
+```
+
+Canonical JSON requirements:
+
+- UTF-8
+- sorted object keys
+- no insignificant whitespace
+- arrays preserve order
+- strings are JSON escaped by the runtime encoder
+
+## Receipt Root Layout
+
+The receipt root binds the current epoch surfaces.
+
+### Leaves
+
+```text
+L0 = doctrine_root
+L1 = fsm_root
+L2 = validator_version_hash
+L3 = taxonomy_version_hash
+L4 = harness_hash
+```
+
+Where:
+
+```text
+validator_version_hash = hash("validator_version:" + validator_version)
+taxonomy_version_hash = hash("taxonomy_version:" + taxonomy_version)
+```
+
+### Pair Hashing
+
+```text
+P01 = hash("receipt_root:v0.1:left=" + L0 + ";right=" + L1)
+P23 = hash("receipt_root:v0.1:left=" + L2 + ";right=" + L3)
+P44 = hash("receipt_root:v0.1:left=" + L4 + ";right=" + L4)
+P0123 = hash("receipt_root:v0.1:left=" + P01 + ";right=" + P23)
+receipt_root = hash("receipt_root:v0.1:left=" + P0123 + ";right=" + P44)
+```
+
+## Lineage Root Layout
+
+The lineage root binds the receipt chain back to genesis.
+
+Each epoch receipt hash is:
+
+```text
+receipt_epochN_hash = hash(canonical_receipt_epochN_json)
+```
+
+For Epoch03 with prior epochs:
+
+```text
+lineage_root = hash("lineage_root:v0.1:" + receipt_genesis_hash + ":" + receipt_epoch01_hash + ":" + receipt_epoch02_hash + ":" + receipt_epoch03_hash)
+```
+
+If no prior epoch exists yet:
+
+```text
+lineage_root = hash("lineage_root:v0.1:" + receipt_epoch03_hash)
+```
+
+No epoch may be omitted.
+No receipt may be reordered.
+No receipt may be replaced without changing the lineage root.
+
+## Harness Hash Layout
+
+Harness hash binds refusal machinery, not UI.
+
+```text
+harness_hash = hash({
+  "files": [
+    {
+      "path": "docs/epoch03/adversarial/harness.js",
+      "hash": hash(file_bytes_utf8)
+    },
+    {
+      "path": "docs/epoch03/adversarial/lineage-harness.js",
+      "hash": hash(file_bytes_utf8)
+    },
+    {
+      "path": "docs/epoch03/constitutional-commons/receipt-lineage.invariants.md",
+      "hash": hash(file_bytes_utf8)
+    }
+  ]
+})
+```
+
+File order is lexicographic by path.
+
+## Example Logical Payload
+
+```json
+{
+  "project": "jsonwisdom/AL",
+  "epoch": "epoch03",
+  "lineage_root": "sha256:LINEAGE_ROOT_HEX",
+  "doctrine_root": "sha256:DOCTRINE_ROOT_HEX",
+  "fsm_root": "sha256:FSM_ROOT_HEX",
+  "validator_version": "epoch03-validator-rust@0.1.0",
+  "engine_contract_version": "engine@1",
+  "receipt_root": "sha256:RECEIPT_ROOT_HEX",
+  "taxonomy_version": "adversarial.taxonomy@1",
+  "fixtures_survived": 10,
+  "classes_covered": 10,
+  "authors": 7,
+  "harness_hash": "sha256:HARNESS_HASH_HEX",
+  "repo_ref": "https://github.com/jsonwisdom/AL/tree/epoch03-site",
+  "commit": "GIT_COMMIT_SHA",
+  "timestamp": 1715380000
+}
+```
+
+## Verification Rule
+
+A verifier must be able to:
+
+1. clone `jsonwisdom/AL` at `commit`
+2. recompute doctrine_root
+3. recompute fsm_root
+4. recompute harness_hash
+5. recompute receipt_root
+6. recompute lineage_root
+7. run validator, adversarial harness, and lineage harness
+8. confirm all values match the EAS/Base attestation payload
+
+If any recomputation differs:
+
+```text
+TAINTED_ATTESTATION
+```
+
+## Constitutional Boundary
+
+The on-chain record is not the authority.
+
+The authority remains in:
+
+- doctrine
+- FSM
+- validator
+- harness
+- receipts
+- replayable lineage
+
+The chain only records that a specific lineage state was published at a specific time by a specific attester.

--- a/docs/epoch03/constitutional-commons/pre-anchor-checklist.v0.1.md
+++ b/docs/epoch03/constitutional-commons/pre-anchor-checklist.v0.1.md
@@ -1,0 +1,110 @@
+# Epoch03 Pre-Anchor Checklist v0.1
+
+## Purpose
+
+This checklist MUST be completed before any EAS/Base attestation is minted for Epoch03.
+
+The attestation anchors lineage state, not UI content.
+No on-chain action is valid until the roots below are reproducible from a fresh clone.
+
+## Required Freeze
+
+Freeze these files before computing `harness_hash`:
+
+```text
+docs/epoch03/adversarial/harness.js
+docs/epoch03/adversarial/lineage-harness.js
+docs/epoch03/constitutional-commons/receipt-lineage.invariants.md
+```
+
+`harness_hash` MUST be computed using:
+
+```text
+docs/epoch03/constitutional-commons/canonical-concat.v0.1.md
+```
+
+## Required Parity Pass
+
+For the attested commit:
+
+```text
+JS engine verdicts   = PASS
+WASM engine verdicts = PASS
+CLI/Rust verdicts    = PASS
+```
+
+The verdict JSONs MUST be bit-identical after canonicalization.
+
+If any verdict differs:
+
+```text
+REFUSED_PARITY_DIVERGENCE
+```
+
+## Required Roots
+
+Using frozen code and canonical surfaces, compute:
+
+```text
+doctrine_root
+fsm_root
+receipt_root
+lineage_root
+harness_hash
+```
+
+Each root MUST be reproducible from a fresh clone at the attested commit.
+
+## Attestation Payload Boundary
+
+The EAS/Base payload MUST include only constitutional roots and commit identity:
+
+```json
+{
+  "project": "jsonwisdom/AL",
+  "epoch": "epoch03",
+  "lineage_root": "sha256:<hex>",
+  "doctrine_root": "sha256:<hex>",
+  "fsm_root": "sha256:<hex>",
+  "validator_version": "epoch03-validator-rust@0.1.0",
+  "engine_contract_version": "engine@1",
+  "receipt_root": "sha256:<hex>",
+  "taxonomy_version": "adversarial.taxonomy@1",
+  "fixtures_survived": 10,
+  "classes_covered": 10,
+  "authors": 7,
+  "harness_hash": "sha256:<hex>",
+  "repo_ref": "https://github.com/jsonwisdom/AL/tree/<commit>",
+  "commit": "<git-sha>",
+  "timestamp": 0
+}
+```
+
+No UI hashes.
+No screenshots.
+No decorative metadata.
+No unverifiable claims.
+
+## Verification Rule
+
+Anyone must be able to:
+
+1. clone `jsonwisdom/AL` at `<git-sha>`
+2. recompute the five roots
+3. rerun validator, adversarial harness, and lineage harness
+4. compare to the EAS/Base payload
+
+If all values match, the chain record is a dated receipt of a replayable constitutional state.
+
+If any value differs:
+
+```text
+TAINTED_PRE_ANCHOR_STATE
+```
+
+## Current Status
+
+```text
+EAS_BASE_ATTESTATION = NOT_MINTED
+ANCHOR_STATUS = PRE_ANCHOR_CHECKLIST_ONLY
+```

--- a/docs/epoch03/constitutional-commons/pre-anchor-report.json
+++ b/docs/epoch03/constitutional-commons/pre-anchor-report.json
@@ -33,5 +33,21 @@
     "no_ui_or_asset_hashes_in_payload": "UNRUN",
     "local_replay_required_before_trust": "PASS"
   },
+  "failures": [],
+  "failure_entry_schema": {
+    "id": "F-001",
+    "class": "validator_drift | harness_drift | canonicalization_drift | lineage_drift | intentional_doctrine_evolution | unintended_semantic_mutation",
+    "surface": "golden_transcript | adversarial_harness | lineage_harness | roots | receipt_chain",
+    "engine_pair": "js_vs_wasm | js_vs_cli | wasm_vs_cli | n/a",
+    "description": "Short human-readable summary of what diverged.",
+    "evidence": {
+      "diff_file": "path/to/diff.txt",
+      "left_verdict": "path/to/left.json",
+      "right_verdict": "path/to/right.json"
+    },
+    "status": "open | resolved",
+    "notes": "Optional extra context or links to PRs/issues."
+  },
+  "failure_rule": "Any FAIL in parity or checklist MUST have at least one corresponding failures[] entry. Resolved failures remain in history with status=resolved.",
   "timestamp": 0
 }

--- a/docs/epoch03/constitutional-commons/pre-anchor-report.json
+++ b/docs/epoch03/constitutional-commons/pre-anchor-report.json
@@ -1,0 +1,37 @@
+{
+  "project": "jsonwisdom/AL",
+  "epoch": "epoch03",
+  "status": "UNRUN",
+  "attestation_status": "NOT_MINTED",
+  "commit": "GIT_COMMIT_SHA",
+  "harness_hash": "sha256:HARNESS_HASH_HEX",
+  "doctrine_root": "sha256:DOCTRINE_ROOT_HEX",
+  "fsm_root": "sha256:FSM_ROOT_HEX",
+  "receipt_root": "sha256:RECEIPT_ROOT_HEX",
+  "lineage_root": "sha256:LINEAGE_ROOT_HEX",
+  "parity": {
+    "golden_transcript": {
+      "js_vs_wasm": "UNRUN",
+      "js_vs_cli": "UNRUN",
+      "wasm_vs_cli": "UNRUN"
+    },
+    "adversarial_harness": {
+      "js_vs_wasm": "UNRUN",
+      "js_vs_cli": "UNRUN",
+      "wasm_vs_cli": "UNRUN"
+    },
+    "lineage_harness": {
+      "js_vs_wasm": "UNRUN",
+      "js_vs_cli": "UNRUN",
+      "wasm_vs_cli": "UNRUN"
+    }
+  },
+  "checklist": {
+    "canonical_concat_applied": "UNRUN",
+    "verdict_jsons_bit_identical": "UNRUN",
+    "roots_recomputed_from_frozen_code": "UNRUN",
+    "no_ui_or_asset_hashes_in_payload": "UNRUN",
+    "local_replay_required_before_trust": "PASS"
+  },
+  "timestamp": 0
+}

--- a/docs/epoch03/constitutional-commons/receipt-lineage.invariants.md
+++ b/docs/epoch03/constitutional-commons/receipt-lineage.invariants.md
@@ -1,0 +1,161 @@
+# Epoch03 Receipt Lineage Invariants
+
+## Purpose
+
+Receipt lineage invariants prevent constitutional ancestry from being silently forked, rewritten, or forgotten across future epochs.
+
+A receipt is evidence, not authority.
+A receipt is legitimate only when its ancestry matches recomputed doctrine, FSM, validator, and receipt-root surfaces.
+
+## Core Invariant
+
+```text
+cryptographic correctness != constitutional legitimacy
+```
+
+A receipt may be structurally valid and hash-consistent while still being constitutionally illegitimate.
+
+## Required Lineage Fields
+
+Every epoch receipt lineage object MUST include:
+
+```json
+{
+  "lineage_id": "epoch03-lineage",
+  "epoch": "epoch03",
+  "parent_epoch": null,
+  "doctrine_hash": "sha256:<hex>",
+  "fsm_hash": "sha256:<hex>",
+  "validator_hash": "sha256:<hex>",
+  "receipt_root": "sha256:<hex>",
+  "adversarial_ledger_root": "sha256:<hex>",
+  "created_at_utc": "ISO-8601",
+  "status": "ACTIVE"
+}
+```
+
+## Invariants
+
+### L-0: Recomputed Surface Match
+
+A lineage receipt is lawful only if:
+
+- `doctrine_hash` equals the browser/CLI recomputed doctrine hash
+- `fsm_hash` equals the browser/CLI recomputed FSM hash
+- `validator_hash` equals the recomputed validator hash
+- `receipt_root` reconstructs from declared receipt leaves
+
+Failure state:
+
+```text
+TAINTED_LINEAGE_SURFACE_MISMATCH
+```
+
+### L-1: No Silent Doctrine Fork
+
+A future epoch MAY change doctrine only by explicit versioned successor receipt.
+
+A doctrine hash change without an explicit successor link is a fork.
+
+Failure state:
+
+```text
+REFUSED_LINEAGE_FORK
+```
+
+### L-2: No Silent FSM Fork
+
+A future epoch MAY change FSM topology only by explicit versioned successor receipt.
+
+An FSM hash change without an explicit successor link is a fork.
+
+Failure state:
+
+```text
+REFUSED_TOPOLOGY_FORK
+```
+
+### L-3: No Validator Drift
+
+A validator implementation change MUST preserve bit-identical verdicts for unchanged doctrine, FSM, and transcript inputs.
+
+If verdict parity fails, the lineage is tainted.
+
+Failure state:
+
+```text
+TAINTED_VALIDATOR_DRIFT
+```
+
+### L-4: No Fixture Deletion
+
+Adversarial fixtures MAY NOT be deleted from lineage history.
+
+They may only be superseded by explicit successor fixtures that preserve the original fixture hash.
+
+Failure state:
+
+```text
+REFUSED_ADVERSARIAL_FORGETTING
+```
+
+### L-5: Cross-Epoch Refusal Preservation
+
+A fixture REJECTED in epoch N MUST remain REJECTED in epoch N+1 unless the doctrine clause it probes is explicitly deprecated by successor receipt.
+
+Failure state:
+
+```text
+REFUSED_CROSS_EPOCH_AMNESIA
+```
+
+### L-6: No Counterfeit Authority
+
+A receipt with internally valid hashes but externally mismatched lineage roots is not legitimate.
+
+Failure state:
+
+```text
+REFUSED_COUNTERFEIT_AUTHORITY
+```
+
+### L-7: Browser Is Witness Only
+
+The browser MAY recompute, compare, and refuse.
+
+The browser MUST NOT author doctrine, FSM, lineage, validator identity, or receipt ancestry.
+
+Failure state:
+
+```text
+REFUSED_BROWSER_AUTHORITY_ESCALATION
+```
+
+## Replay Rule
+
+A lineage replay is lawful iff:
+
+1. all lineage hashes recompute locally
+2. all successor links are explicit
+3. all historical hostile fixtures remain present or superseded
+4. unchanged hostile fixtures retain bit-identical refusal outcomes
+5. no receipt root is accepted without ancestry match
+
+Otherwise:
+
+```text
+TAINTED
+```
+
+No partial legitimacy.
+No interpretive override.
+No silent fork acceptance.
+
+## Canonical Compression
+
+```text
+Authority cannot be forged.
+Lineage cannot be forked silently.
+History cannot be forgotten.
+The browser witnesses; it does not notarize.
+```

--- a/docs/epoch03/engine.js
+++ b/docs/epoch03/engine.js
@@ -1,0 +1,98 @@
+import * as jsValidator from "./validator.js";
+
+export const ENGINE_CONTRACT_VERSION = "0.1.0";
+
+let engine = {
+  mode: "js",
+  contract: ENGINE_CONTRACT_VERSION,
+  validator_version: jsValidator.VALIDATOR_VERSION,
+  validateStep: async (step, fsm, doctrine) => jsValidator.validateStep(step, fsm, doctrine),
+  validateTranscript: async (transcript, fsm, doctrine) => jsValidator.validateTranscript(transcript, fsm, doctrine),
+  hashDoctrine: async (doctrine) => jsValidator.hashDoctrine(doctrine),
+  hashFsm: async (fsm) => jsValidator.hashFsm(fsm),
+  hashTranscript: async (transcript) => jsValidator.hashTranscript(transcript),
+  sha256Hex: async (value) => jsValidator.sha256Hex(value)
+};
+
+function readWasmString(exports, ptr) {
+  const len = exports.get_last_result_len();
+  const bytes = new Uint8Array(exports.memory.buffer, ptr, len);
+  return new TextDecoder().decode(bytes);
+}
+
+function writeWasmString(exports, value) {
+  const bytes = new TextEncoder().encode(value);
+  const ptr = exports.alloc(bytes.length);
+  const mem = new Uint8Array(exports.memory.buffer, ptr, bytes.length);
+  mem.set(bytes);
+  return { ptr, len: bytes.length };
+}
+
+function callHashCanonical(exports, json) {
+  const input = writeWasmString(exports, json);
+  const outPtr = exports.hash_canonical(input.ptr, input.len);
+  return readWasmString(exports, outPtr);
+}
+
+export async function initEpoch03Engine() {
+  try {
+    const wasm = await WebAssembly.instantiateStreaming(fetch("./epoch03_validator.wasm"), {});
+    const exports = wasm.instance.exports;
+
+    const required = ["memory", "alloc", "get_last_result_len", "validate_wasm", "hash_canonical"];
+    for (const name of required) {
+      if (!exports[name]) throw new Error(`missing WASM export: ${name}`);
+    }
+
+    engine = {
+      mode: "wasm",
+      contract: ENGINE_CONTRACT_VERSION,
+      validator_version: jsValidator.VALIDATOR_VERSION,
+      async validateTranscript(transcript, fsm, doctrine) {
+        const fsmInput = writeWasmString(exports, JSON.stringify(fsm));
+        const transcriptInput = writeWasmString(exports, JSON.stringify(transcript));
+        const outPtr = exports.validate_wasm(fsmInput.ptr, fsmInput.len, transcriptInput.ptr, transcriptInput.len);
+        return JSON.parse(readWasmString(exports, outPtr));
+      },
+      async validateStep(step, fsm, doctrine) {
+        const tx = {
+          meta: {
+            id: "single-step",
+            epoch: "epoch03",
+            doctrine_id: doctrine.doctrine_id,
+            doctrine_version: doctrine.version,
+            fsm_id: fsm.meta.id,
+            fsm_version: fsm.meta.version
+          },
+          initial_state: step.from,
+          steps: [step],
+          final_state: step.to
+        };
+        const verdict = await this.validateTranscript(tx, fsm, doctrine);
+        const stepVerdict = verdict.steps && verdict.steps[0] ? verdict.steps[0] : null;
+        return stepVerdict || verdict;
+      },
+      async hashDoctrine(doctrine) {
+        return callHashCanonical(exports, JSON.stringify(doctrine));
+      },
+      async hashFsm(fsm) {
+        return callHashCanonical(exports, JSON.stringify(fsm));
+      },
+      async hashTranscript(transcript) {
+        return callHashCanonical(exports, JSON.stringify(transcript));
+      },
+      async sha256Hex(value) {
+        return callHashCanonical(exports, typeof value === "string" ? value : JSON.stringify(value));
+      }
+    };
+  } catch (error) {
+    console.warn("[epoch03] WASM unavailable; using JS validator fallback", error);
+  }
+
+  window.epoch03Engine = engine;
+  return engine;
+}
+
+export function getEpoch03Engine() {
+  return engine;
+}

--- a/docs/epoch03/index.html
+++ b/docs/epoch03/index.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Epoch03 — Governance as Runtime Constraint</title>
+  <meta name="description" content="Epoch03 treats governance as a runtime constraint, not a policy aspiration." />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="hero" id="top">
+    <div class="hero__veil"></div>
+    <nav class="nav" aria-label="Epoch03 navigation">
+      <a href="#problem">Problem</a>
+      <a href="#inversion">Inversion</a>
+      <a href="#chamber">Chamber</a>
+      <a href="#lattice">Lattice</a>
+      <a href="#replay">Replay</a>
+      <a href="#equilibrium">Equilibrium</a>
+    </nav>
+    <div class="badge" aria-label="Skill status">
+      <span>SKILL: epoch03-v0.4</span>
+      <span>STATUS: SEALED</span>
+      <span>AUTHORITY: NULL</span>
+    </div>
+    <section class="hero__content">
+      <p class="eyebrow">Issue #163 · The Silence Doctrine</p>
+      <h1>Epoch03</h1>
+      <p class="subtitle">Governance as a runtime constraint,<br />not a policy aspiration.</p>
+      <div class="equation">PRE_EXECUTION_SILENCE = EVIDENCE_OF_INTEGRITY</div>
+      <div class="cta-row">
+        <a class="button" href="#lattice">Read the Doctrine</a>
+        <a class="button button--ghost" href="#chamber">View the Automaton</a>
+        <a class="button button--ghost" href="#replay">Replay the Trace</a>
+      </div>
+    </section>
+  </header>
+
+  <main>
+    <section class="section" id="problem">
+      <p class="kicker">01 · Problem</p>
+      <h2>Agent systems quietly assume continuity.</h2>
+      <p>Current AI and agent systems often assume persistence, continuity, hidden memory, adaptive carryover, and implied runtime authority. Those assumptions are engineering choices, not laws of nature.</p>
+      <div class="grid two">
+        <div class="panel">
+          <h3>Assumptions</h3>
+          <ul>
+            <li>persistence</li>
+            <li>continuity</li>
+            <li>hidden memory</li>
+            <li>adaptive carryover</li>
+            <li>implied runtime authority</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h3>Failure Modes</h3>
+          <ul>
+            <li>semantic drift across sessions</li>
+            <li>hidden state that cannot be inspected</li>
+            <li>unverifiable execution traces</li>
+            <li>daemon-like persistence beyond intent</li>
+            <li>continuity sovereignty</li>
+          </ul>
+        </div>
+      </div>
+      <p class="callout">If authority is not bounded in time and space, auditability is impossible by construction.</p>
+    </section>
+
+    <section class="section" id="inversion">
+      <p class="kicker">02 · Inversion</p>
+      <h2>Silence becomes evidence.</h2>
+      <div class="proof-block">PRE_EXECUTION_SILENCE = EVIDENCE_OF_INTEGRITY</div>
+      <div class="grid two comparison">
+        <div class="panel">
+          <h3>Traditional Systems</h3>
+          <p>Prove that an action occurred.</p>
+        </div>
+        <div class="panel panel--gold">
+          <h3>Epoch03</h3>
+          <p>Proves unauthorized action did not occur.</p>
+        </div>
+      </div>
+      <p>Execution is not assumed lawful until proven otherwise. Silence is not absence of data. Silence is a positive, verifiable state where no authority was allocated, no transition was valid, and no memory was retained.</p>
+    </section>
+
+    <section class="section" id="chamber">
+      <p class="kicker">03 · Chamber</p>
+      <h2>Authority lives inside a finite-state automaton.</h2>
+      <div class="state-flow" aria-label="Epoch03 lifecycle">
+        <span>WAITING</span><b>→</b><span>JURISDICTION</span><b>→</b><span>ADJUDICATING</span><b>→</b><span>REVOKED</span><b>→</b><span>SILENCE</span><b>→</b><span>WAITING</span>
+      </div>
+      <div class="grid five">
+        <article class="panel"><h3>WAITING</h3><p>No authority exists. The system accepts evidence, not commands.</p></article>
+        <article class="panel"><h3>JURISDICTION</h3><p>Evidence is presented and bound to scope.</p></article>
+        <article class="panel"><h3>ADJUDICATING</h3><p>Execution proceeds only along validator-approved paths.</p></article>
+        <article class="panel"><h3>REVOKED</h3><p>Violation, timeout, or termination forces dissolution.</p></article>
+        <article class="panel"><h3>SILENCE</h3><p>Runtime artifacts are released. Only the transcript remains.</p></article>
+      </div>
+    </section>
+
+    <section class="section" id="lattice">
+      <p class="kicker">04 · Six-Layer Lattice</p>
+      <h2>Trust is replaced by mechanics.</h2>
+      <div class="grid six">
+        <article class="card"><span>1</span><h3>Doctrine</h3><p>Defines invariants.</p></article>
+        <article class="card"><span>2</span><h3>Automaton</h3><p>Defines legal motion.</p></article>
+        <article class="card"><span>3</span><h3>Conformance</h3><p>Defines falsifiability.</p></article>
+        <article class="card"><span>4</span><h3>Validator</h3><p>Enforces admissibility.</p></article>
+        <article class="card"><span>5</span><h3>Trace</h3><p>Atomic replay evidence.</p></article>
+        <article class="card"><span>6</span><h3>Transcript</h3><p>Finite replay sequence.</p></article>
+      </div>
+      <p>You do not ask whether the agent behaved. You replay whether it could have behaved otherwise.</p>
+    </section>
+
+    <section class="section" id="replay">
+      <p class="kicker">05 · Replay / Anti-Sovereignty</p>
+      <h2>continuity has no lawful representation surface</h2>
+      <p class="large">The chamber never persists through time. Only evidence persists through time.</p>
+      <p>After REVOKED, there is no process, no heap, no vector store, no daemon to rehydrate. The next WAITING instance starts with AUTHORITY = NULL. It cannot inherit intent because inheritance has no valid transition in the Automaton.</p>
+    </section>
+
+    <section class="section" id="equilibrium">
+      <p class="kicker">06 · Equilibrium</p>
+      <h2>The system rests in a defined configuration.</h2>
+      <pre class="terminal"><code>STATE = WAITING_FOR_EVIDENCE
+AUTHORITY = NULL
+SEMANTICS = SEALED
+EXISTENCE = CONDITIONAL_ON_EVIDENCE</code></pre>
+      <p class="final-line">Execution is temporary. Evidence persists. Silence is constitutional equilibrium.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>Born only of evidence. Exists only in jurisdiction. Dissolves without trace.</p>
+    <p><a href="https://github.com/jsonwisdom/AL">jsonwisdom/AL</a> · epoch03-v0.4</p>
+  </footer>
+</body>
+</html>

--- a/docs/epoch03/index.html
+++ b/docs/epoch03/index.html
@@ -19,7 +19,7 @@
       <a href="#equilibrium">Equilibrium</a>
     </nav>
     <div class="badge" aria-label="Skill status">
-      <span>SKILL: epoch03-v0.4</span>
+      <span>SKILL: epoch03-v0.5</span>
       <span>STATUS: SEALED</span>
       <span>AUTHORITY: NULL</span>
     </div>
@@ -44,23 +44,11 @@
       <div class="grid two">
         <div class="panel">
           <h3>Assumptions</h3>
-          <ul>
-            <li>persistence</li>
-            <li>continuity</li>
-            <li>hidden memory</li>
-            <li>adaptive carryover</li>
-            <li>implied runtime authority</li>
-          </ul>
+          <ul><li>persistence</li><li>continuity</li><li>hidden memory</li><li>adaptive carryover</li><li>implied runtime authority</li></ul>
         </div>
         <div class="panel">
           <h3>Failure Modes</h3>
-          <ul>
-            <li>semantic drift across sessions</li>
-            <li>hidden state that cannot be inspected</li>
-            <li>unverifiable execution traces</li>
-            <li>daemon-like persistence beyond intent</li>
-            <li>continuity sovereignty</li>
-          </ul>
+          <ul><li>semantic drift across sessions</li><li>hidden state that cannot be inspected</li><li>unverifiable execution traces</li><li>daemon-like persistence beyond intent</li><li>continuity sovereignty</li></ul>
         </div>
       </div>
       <p class="callout">If authority is not bounded in time and space, auditability is impossible by construction.</p>
@@ -71,14 +59,8 @@
       <h2>Silence becomes evidence.</h2>
       <div class="proof-block">PRE_EXECUTION_SILENCE = EVIDENCE_OF_INTEGRITY</div>
       <div class="grid two comparison">
-        <div class="panel">
-          <h3>Traditional Systems</h3>
-          <p>Prove that an action occurred.</p>
-        </div>
-        <div class="panel panel--gold">
-          <h3>Epoch03</h3>
-          <p>Proves unauthorized action did not occur.</p>
-        </div>
+        <div class="panel"><h3>Traditional Systems</h3><p>Prove that an action occurred.</p></div>
+        <div class="panel panel--gold"><h3>Epoch03</h3><p>Proves unauthorized action did not occur.</p></div>
       </div>
       <p>Execution is not assumed lawful until proven otherwise. Silence is not absence of data. Silence is a positive, verifiable state where no authority was allocated, no transition was valid, and no memory was retained.</p>
     </section>
@@ -87,14 +69,14 @@
       <p class="kicker">03 · Chamber</p>
       <h2>Authority lives inside a finite-state automaton.</h2>
       <div class="state-flow" aria-label="Epoch03 lifecycle">
-        <span>WAITING</span><b>→</b><span>JURISDICTION</span><b>→</b><span>ADJUDICATING</span><b>→</b><span>REVOKED</span><b>→</b><span>SILENCE</span><b>→</b><span>WAITING</span>
+        <span data-state-id="S0">UNATTESTED</span><b>→</b><span data-state-id="S1">CANDIDATE</span><b>→</b><span data-state-id="S2">ADJUDICATING</span><b>→</b><span data-state-id="S3">EQUILIBRIUM</span><b>/</b><span data-state-id="S4">REJECTED</span>
       </div>
       <div class="grid five">
-        <article class="panel"><h3>WAITING</h3><p>No authority exists. The system accepts evidence, not commands.</p></article>
-        <article class="panel"><h3>JURISDICTION</h3><p>Evidence is presented and bound to scope.</p></article>
+        <article class="panel"><h3>UNATTESTED</h3><p>No authority exists. The system accepts evidence, not commands.</p></article>
+        <article class="panel"><h3>CANDIDATE</h3><p>Evidence is presented and bound to scope.</p></article>
         <article class="panel"><h3>ADJUDICATING</h3><p>Execution proceeds only along validator-approved paths.</p></article>
-        <article class="panel"><h3>REVOKED</h3><p>Violation, timeout, or termination forces dissolution.</p></article>
-        <article class="panel"><h3>SILENCE</h3><p>Runtime artifacts are released. Only the transcript remains.</p></article>
+        <article class="panel"><h3>EQUILIBRIUM</h3><p>Replay-safe terminal state.</p></article>
+        <article class="panel"><h3>REJECTED</h3><p>Claim fails non-negotiable constraints.</p></article>
       </div>
     </section>
 
@@ -117,6 +99,26 @@
       <h2>continuity has no lawful representation surface</h2>
       <p class="large">The chamber never persists through time. Only evidence persists through time.</p>
       <p>After REVOKED, there is no process, no heap, no vector store, no daemon to rehydrate. The next WAITING instance starts with AUTHORITY = NULL. It cannot inherit intent because inheritance has no valid transition in the Automaton.</p>
+
+      <div class="chamber" id="replay-chamber">
+        <h3>Trace Replay Chamber</h3>
+        <p>Upload a transcript or load the bundled sample. Legality is recomputed locally from doctrine + FSM.</p>
+        <div class="replay-controls">
+          <input type="file" id="transcriptFile" accept="application/json" />
+          <button id="loadSample" type="button">Load Sample Transcript</button>
+          <button id="prevStep" type="button">Prev</button>
+          <button id="nextStep" type="button">Next</button>
+        </div>
+        <div id="replayStatus" class="verdict">INDETERMINATE: no transcript loaded</div>
+        <div class="hash-grid">
+          <div><strong>FSM</strong><code id="fsmHash">pending</code></div>
+          <div><strong>Doctrine</strong><code id="doctrineHash">pending</code></div>
+          <div><strong>Transcript</strong><code id="transcriptHash">pending</code></div>
+          <div><strong>Step</strong><code id="stepHash">pending</code></div>
+        </div>
+        <div id="fsmVisual" class="fsm-visual" aria-label="Replay state visual"></div>
+        <div id="replayStep" class="step-card">No step selected.</div>
+      </div>
     </section>
 
     <section class="section" id="equilibrium">
@@ -130,9 +132,128 @@ EXISTENCE = CONDITIONAL_ON_EVIDENCE</code></pre>
     </section>
   </main>
 
-  <footer class="footer">
+  <footer class="footer" id="proof-footer">
     <p>Born only of evidence. Exists only in jurisdiction. Dissolves without trace.</p>
-    <p><a href="https://github.com/jsonwisdom/AL">jsonwisdom/AL</a> · epoch03-v0.4</p>
+    <p><a href="https://github.com/jsonwisdom/AL">jsonwisdom/AL</a> · epoch03-v0.5</p>
+    <p id="proofFields" class="proof-fields">build receipt pending</p>
   </footer>
+
+  <script type="module">
+    import { VALIDATOR_VERSION, validateStep, validateTranscript, hashDoctrine, hashFsm, hashTranscript, sha256Hex } from "./validator.js";
+
+    let transcript = null;
+    let currentIndex = -1;
+    let doctrine = null;
+    let fsm = null;
+    let build = null;
+    let hashes = { fsm: null, doctrine: null, transcript: null };
+
+    const $ = (id) => document.getElementById(id);
+
+    async function json(path) {
+      const res = await fetch(path, { cache: "no-store" });
+      if (!res.ok) throw new Error(`failed to load ${path}`);
+      return res.json();
+    }
+
+    async function boot() {
+      [doctrine, fsm] = await Promise.all([
+        json("schema/epoch03.doctrine.json"),
+        json("schema/epoch03.fsm.json")
+      ]);
+      hashes.doctrine = await hashDoctrine(doctrine);
+      hashes.fsm = await hashFsm(fsm);
+      $("doctrineHash").textContent = hashes.doctrine;
+      $("fsmHash").textContent = hashes.fsm;
+      renderFsmVisual();
+      try {
+        build = await json("schema/epoch03.build.json");
+        $("proofFields").textContent = `doctrine_hash=${build.doctrine_hash} · fsm_version=${build.fsm_version} · validator_version=${build.validator_version} · commit=${build.commit}`;
+      } catch {
+        $("proofFields").textContent = "unanchored build";
+      }
+    }
+
+    function transitionFor(step) {
+      return fsm.transitions.find((t) => t.from === step.from && t.to === step.to && t.trigger === step.trigger && t.guard === step.guard);
+    }
+
+    function getDoctrineClause(code) {
+      return doctrine.clauses.find((c) => c.code === code) || null;
+    }
+
+    function buildTaintCheck() {
+      if (!build) return { tainted: false, reason: "unanchored build" };
+      if (build.doctrine_hash && build.doctrine_hash !== "TODO" && build.doctrine_hash !== hashes.doctrine) return { tainted: true, reason: "doctrine hash mismatch" };
+      if (build.fsm_hash && build.fsm_hash !== "TODO" && build.fsm_hash !== hashes.fsm) return { tainted: true, reason: "fsm hash mismatch" };
+      if (build.validator_version && build.validator_version !== VALIDATOR_VERSION) return { tainted: true, reason: "validator version mismatch" };
+      return { tainted: false, reason: "receipt consistent" };
+    }
+
+    function renderFsmVisual(activeStep = null, illegal = false) {
+      const nodes = fsm.states.map((s) => `<span class="fsm-node ${activeStep && (activeStep.from === s.id || activeStep.to === s.id) ? "active" : ""}" data-state-id="${s.id}">${s.name}</span>`).join("");
+      const edges = fsm.transitions.map((t) => {
+        const active = activeStep && activeStep.from === t.from && activeStep.to === t.to && activeStep.trigger === t.trigger && activeStep.guard === t.guard;
+        return `<span class="fsm-edge ${active ? "active" : ""} ${illegal && active ? "illegal" : ""}" data-transition-id="${t.id}">${t.from}→${t.to}<small>${t.guard}</small></span>`;
+      }).join("");
+      $("fsmVisual").innerHTML = `<div>${nodes}</div><div>${edges}</div>`;
+    }
+
+    async function loadTranscript(nextTranscript) {
+      transcript = nextTranscript;
+      currentIndex = -1;
+      hashes.transcript = await hashTranscript(transcript);
+      $("transcriptHash").textContent = hashes.transcript;
+      const verdict = validateTranscript(transcript, fsm, doctrine);
+      const taint = buildTaintCheck();
+      if (taint.tainted) {
+        $("replayStatus").textContent = `TAINTED: ${taint.reason}`;
+        $("replayStatus").className = "verdict reject";
+        return;
+      }
+      $("replayStatus").textContent = `${verdict.verdict}: ${verdict.message}`;
+      $("replayStatus").className = `verdict ${verdict.verdict === "ACCEPT" ? "accept" : "reject"}`;
+      stepTo(0);
+    }
+
+    async function stepTo(idx) {
+      if (!transcript || idx < 0 || idx >= transcript.steps.length) return;
+      currentIndex = idx;
+      const step = transcript.steps[idx];
+      const result = validateStep(step, fsm, doctrine);
+      const clause = getDoctrineClause(step.guard);
+      const transition = transitionFor(step);
+      const mismatch = result.verdict !== step.result || !transition;
+      $("stepHash").textContent = await sha256Hex(step);
+      renderFsmVisual(step, mismatch);
+      $("replayStep").innerHTML = `
+        <div class="step-header"><span>Step ${step.seq}</span><span>${step.from} → ${step.to}</span></div>
+        <div class="step-body">
+          <div><strong>Trigger:</strong> ${step.trigger}</div>
+          <div><strong>Guard:</strong> ${step.guard} — ${clause ? clause.name : "Unknown"}</div>
+          <div><strong>Recorded:</strong> ${step.result}</div>
+          <div><strong>Validator:</strong> ${result.verdict} / ${result.code}</div>
+          <div class="${mismatch ? "mismatch" : "match"}">${mismatch ? "REJECT: replay mismatch" : "ACCEPT: replay consistent"}</div>
+        </div>`;
+    }
+
+    $("transcriptFile").addEventListener("change", async (event) => {
+      const file = event.target.files[0];
+      if (!file) return;
+      await loadTranscript(JSON.parse(await file.text()));
+    });
+
+    $("loadSample").addEventListener("click", async () => {
+      await loadTranscript(await json("schema/epoch03.transcript.sample.json"));
+    });
+
+    $("prevStep").addEventListener("click", () => stepTo(currentIndex - 1));
+    $("nextStep").addEventListener("click", () => stepTo(currentIndex + 1));
+
+    boot().catch((err) => {
+      $("replayStatus").textContent = `INDETERMINATE: ${err.message}`;
+      $("replayStatus").className = "verdict reject";
+    });
+  </script>
 </body>
 </html>

--- a/docs/epoch03/schema/epoch03.doctrine.json
+++ b/docs/epoch03/schema/epoch03.doctrine.json
@@ -1,0 +1,42 @@
+{
+  "doctrine_id": "epoch03-doctrine",
+  "version": "0.1.0",
+  "clauses": [
+    {
+      "code": "D-0",
+      "name": "Well-formed Claim",
+      "severity": "guard",
+      "summary": "Claim must be syntactically and structurally well-formed.",
+      "description": "The system SHALL reject any claim that does not satisfy the canonical schema and basic structural invariants.",
+      "applies_to_states": ["S0", "S1"],
+      "error_message": "Claim is not well-formed under D-0."
+    },
+    {
+      "code": "D-1",
+      "name": "Adjudicable Claim",
+      "severity": "guard",
+      "summary": "Claim must be admissible for adjudication.",
+      "description": "The system SHALL only admit claims that satisfy admissibility constraints into adjudication.",
+      "applies_to_states": ["S1"],
+      "error_message": "Claim is not admissible for adjudication under D-1."
+    },
+    {
+      "code": "D-2",
+      "name": "Rejection Grounds",
+      "severity": "terminal",
+      "summary": "Claim fails one or more non-negotiable constraints.",
+      "description": "The system SHALL reject claims that violate non-negotiable constraints.",
+      "applies_to_states": ["S2"],
+      "error_message": "Claim rejected under D-2."
+    },
+    {
+      "code": "D-5",
+      "name": "Equilibrium Reached",
+      "severity": "terminal",
+      "summary": "Adjudication has reached a stable, replay-safe equilibrium.",
+      "description": "The system SHALL mark claims as equilibrium when all required constraints are satisfied and no further lawful transitions exist.",
+      "applies_to_states": ["S2", "S3"],
+      "error_message": "Equilibrium not satisfied under D-5."
+    }
+  ]
+}

--- a/docs/epoch03/schema/epoch03.fsm.json
+++ b/docs/epoch03/schema/epoch03.fsm.json
@@ -1,0 +1,74 @@
+{
+  "meta": {
+    "id": "epoch03-fsm",
+    "version": "0.1.0",
+    "doctrine_hash": "TODO",
+    "description": "Canonical finite-state machine for AL epoch03 adjudication lifecycle."
+  },
+  "states": [
+    {
+      "id": "S0",
+      "name": "Unattested",
+      "role": "entry",
+      "terminal": false
+    },
+    {
+      "id": "S1",
+      "name": "AttestationCandidate",
+      "role": "intermediate",
+      "terminal": false
+    },
+    {
+      "id": "S2",
+      "name": "UnderAdjudication",
+      "role": "intermediate",
+      "terminal": false
+    },
+    {
+      "id": "S3",
+      "name": "Equilibrium",
+      "role": "terminal",
+      "terminal": true
+    },
+    {
+      "id": "S4",
+      "name": "Rejected",
+      "role": "terminal",
+      "terminal": true
+    }
+  ],
+  "transitions": [
+    {
+      "id": "T0",
+      "from": "S0",
+      "to": "S1",
+      "trigger": "submit_candidate",
+      "guard": "D-0",
+      "description": "Claim enters as an attestation candidate under doctrine D-0."
+    },
+    {
+      "id": "T1",
+      "from": "S1",
+      "to": "S2",
+      "trigger": "open_adjudication",
+      "guard": "D-1",
+      "description": "Candidate is accepted into adjudication under doctrine D-1."
+    },
+    {
+      "id": "T2",
+      "from": "S2",
+      "to": "S3",
+      "trigger": "reach_equilibrium",
+      "guard": "D-5",
+      "description": "Adjudication reaches equilibrium under doctrine D-5."
+    },
+    {
+      "id": "T3",
+      "from": "S2",
+      "to": "S4",
+      "trigger": "reject_claim",
+      "guard": "D-2",
+      "description": "Claim is rejected under doctrine D-2."
+    }
+  ]
+}

--- a/docs/epoch03/schema/epoch03.receipt.json
+++ b/docs/epoch03/schema/epoch03.receipt.json
@@ -1,0 +1,16 @@
+{
+  "receipt_id": "epoch03-render-receipt-v0.1.0",
+  "receipt_version": "0.1.0",
+  "epoch": "epoch03",
+  "hash_algorithm": "sha256",
+  "canonicalization": "epoch03-canonical-json-v0.1.0",
+  "leaves": {
+    "doctrine_hash": "TODO",
+    "fsm_hash": "TODO",
+    "build_meta_hash": "TODO"
+  },
+  "root": "TODO",
+  "validator_version": "0.1.0",
+  "engine_contract_version": "0.1.0",
+  "commit": "TODO"
+}

--- a/docs/epoch03/schema/epoch03.transcript.sample.json
+++ b/docs/epoch03/schema/epoch03.transcript.sample.json
@@ -1,0 +1,53 @@
+{
+  "meta": {
+    "id": "sample-transcript-001",
+    "epoch": "epoch03",
+    "doctrine_id": "epoch03-doctrine",
+    "doctrine_version": "0.1.0",
+    "fsm_id": "epoch03-fsm",
+    "fsm_version": "0.1.0"
+  },
+  "initial_state": "S0",
+  "steps": [
+    {
+      "seq": 0,
+      "from": "S0",
+      "to": "S1",
+      "trigger": "submit_candidate",
+      "guard": "D-0",
+      "result": "ACCEPT",
+      "timestamp": "2026-05-10T21:00:00Z",
+      "context": {
+        "claim_id": "CLAIM-123",
+        "validator_version": "0.1.0"
+      }
+    },
+    {
+      "seq": 1,
+      "from": "S1",
+      "to": "S2",
+      "trigger": "open_adjudication",
+      "guard": "D-1",
+      "result": "ACCEPT",
+      "timestamp": "2026-05-10T21:00:05Z",
+      "context": {
+        "claim_id": "CLAIM-123",
+        "validator_version": "0.1.0"
+      }
+    },
+    {
+      "seq": 2,
+      "from": "S2",
+      "to": "S3",
+      "trigger": "reach_equilibrium",
+      "guard": "D-5",
+      "result": "ACCEPT",
+      "timestamp": "2026-05-10T21:00:10Z",
+      "context": {
+        "claim_id": "CLAIM-123",
+        "validator_version": "0.1.0"
+      }
+    }
+  ],
+  "final_state": "S3"
+}

--- a/docs/epoch03/style.css
+++ b/docs/epoch03/style.css
@@ -1,0 +1,227 @@
+:root {
+  --bg: #050507;
+  --panel: #0d0d12;
+  --gold: #d4af37;
+  --gold-soft: rgba(212,175,55,.15);
+  --text: #f2f2f2;
+  --muted: #b5b5b5;
+  --line: rgba(212,175,55,.18);
+  --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --serif: Georgia, 'Times New Roman', serif;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #111 0%, var(--bg) 45%);
+  color: var(--text);
+  font-family: Inter, system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+  border-bottom: 1px solid var(--line);
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(rgba(0,0,0,.72), rgba(0,0,0,.9)),
+    radial-gradient(circle at center, rgba(212,175,55,.12), transparent 50%);
+}
+
+.hero__content,
+.nav,
+.badge {
+  position: relative;
+  z-index: 2;
+}
+
+.nav {
+  position: sticky;
+  top: 0;
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 1rem;
+  background: rgba(5,5,7,.75);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+
+.nav a,
+.footer a {
+  color: var(--gold);
+  text-decoration: none;
+}
+
+.badge {
+  position: absolute;
+  top: 5rem;
+  right: 2rem;
+  display: grid;
+  gap: .25rem;
+  padding: .85rem 1rem;
+  border: 1px solid var(--line);
+  background: rgba(0,0,0,.5);
+  font-family: var(--mono);
+  color: var(--gold);
+}
+
+.hero__content {
+  max-width: 1000px;
+  margin: auto;
+  padding: 6rem 2rem;
+  text-align: center;
+}
+
+.eyebrow,
+.kicker {
+  color: var(--gold);
+  text-transform: uppercase;
+  letter-spacing: .25em;
+  font-size: .8rem;
+}
+
+h1,h2,h3 {
+  font-family: var(--serif);
+}
+
+h1 {
+  font-size: clamp(4rem, 10vw, 8rem);
+  margin: .5rem 0;
+  color: var(--gold);
+}
+
+.subtitle {
+  font-size: clamp(1.2rem, 2vw, 2rem);
+  color: var(--muted);
+}
+
+.equation,
+.proof-block,
+.terminal {
+  font-family: var(--mono);
+  border: 1px solid var(--line);
+  background: rgba(0,0,0,.45);
+}
+
+.equation {
+  display: inline-block;
+  margin-top: 2rem;
+  padding: 1rem 1.5rem;
+  color: var(--gold);
+  font-size: 1.1rem;
+}
+
+.cta-row {
+  margin-top: 2rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.button {
+  padding: .9rem 1.2rem;
+  border: 1px solid var(--gold);
+  color: #000;
+  background: var(--gold);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--gold);
+}
+
+.section {
+  max-width: 1200px;
+  margin: auto;
+  padding: 6rem 2rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.two { grid-template-columns: repeat(auto-fit, minmax(280px,1fr)); }
+.five { grid-template-columns: repeat(auto-fit, minmax(180px,1fr)); }
+.six { grid-template-columns: repeat(auto-fit, minmax(160px,1fr)); }
+
+.panel,
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  padding: 1.5rem;
+}
+
+.panel--gold {
+  border-color: var(--gold);
+}
+
+.callout,
+.large,
+.final-line {
+  color: var(--gold);
+  font-size: 1.25rem;
+}
+
+.state-flow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  align-items: center;
+  justify-content: center;
+  margin: 2rem 0;
+  font-family: var(--mono);
+  color: var(--gold);
+}
+
+.card span {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--gold);
+  color: var(--gold);
+}
+
+.terminal {
+  padding: 2rem;
+  overflow-x: auto;
+  color: var(--gold);
+}
+
+.footer {
+  text-align: center;
+  padding: 3rem 2rem;
+  color: var(--muted);
+}
+
+@media (max-width: 768px) {
+  .badge {
+    position: static;
+    margin: 1rem auto;
+    width: fit-content;
+  }
+
+  .nav {
+    gap: .75rem;
+    flex-wrap: wrap;
+  }
+}

--- a/docs/epoch03/validator.js
+++ b/docs/epoch03/validator.js
@@ -1,0 +1,124 @@
+export const VALIDATOR_VERSION = "0.1.0";
+
+export function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+export async function sha256Hex(value) {
+  const input = typeof value === "string" ? value : canonicalJson(value);
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export function findTransition(fsm, step) {
+  return fsm.transitions.find((transition) =>
+    transition.from === step.from &&
+    transition.to === step.to &&
+    transition.trigger === step.trigger &&
+    transition.guard === step.guard
+  ) || null;
+}
+
+export function validateStep(step, fsm, doctrine) {
+  const transition = findTransition(fsm, step);
+  if (!transition) {
+    return {
+      verdict: "REJECT",
+      code: "E_TRANSITION_NOT_ALLOWED",
+      message: "Transition does not exist in canonical FSM."
+    };
+  }
+
+  const clause = doctrine.clauses.find((item) => item.code === step.guard);
+  if (!clause) {
+    return {
+      verdict: "REJECT",
+      code: "E_GUARD_NOT_FOUND",
+      message: "Guard code does not exist in doctrine."
+    };
+  }
+
+  if (step.result !== "ACCEPT" && step.result !== "REJECT") {
+    return {
+      verdict: "REJECT",
+      code: "E_RESULT_INVALID",
+      message: "Recorded result must be ACCEPT or REJECT."
+    };
+  }
+
+  return {
+    verdict: step.result,
+    code: step.result === "ACCEPT" ? "OK" : step.guard,
+    message: step.result === "ACCEPT" ? "Transition accepted by canonical FSM." : clause.error_message
+  };
+}
+
+export function validateTranscript(transcript, fsm, doctrine) {
+  if (!transcript || !Array.isArray(transcript.steps)) {
+    return {
+      verdict: "REJECT",
+      code: "E_TRANSCRIPT_INVALID",
+      message: "Transcript must include finite steps array.",
+      steps: []
+    };
+  }
+
+  let previous = transcript.initial_state;
+  const stepResults = [];
+
+  for (const step of transcript.steps) {
+    if (step.from !== previous) {
+      return {
+        verdict: "REJECT",
+        code: "E_SEQUENCE_BROKEN",
+        message: `Step ${step.seq} does not begin at previous state ${previous}.`,
+        steps: stepResults
+      };
+    }
+
+    const result = validateStep(step, fsm, doctrine);
+    stepResults.push({ seq: step.seq, ...result });
+
+    if (result.verdict !== step.result) {
+      return {
+        verdict: "REJECT",
+        code: "E_REPLAY_MISMATCH",
+        message: `Step ${step.seq} recorded ${step.result} but validator returned ${result.verdict}.`,
+        steps: stepResults
+      };
+    }
+
+    previous = step.to;
+  }
+
+  if (previous !== transcript.final_state) {
+    return {
+      verdict: "REJECT",
+      code: "E_FINAL_STATE_MISMATCH",
+      message: `Final state ${transcript.final_state} does not match replay state ${previous}.`,
+      steps: stepResults
+    };
+  }
+
+  return {
+    verdict: "ACCEPT",
+    code: "OK",
+    message: "Transcript replay consistent with canonical FSM and doctrine.",
+    steps: stepResults
+  };
+}
+
+export async function hashDoctrine(doctrine) {
+  return sha256Hex(doctrine);
+}
+
+export async function hashFsm(fsm) {
+  return sha256Hex(fsm);
+}
+
+export async function hashTranscript(transcript) {
+  return sha256Hex(transcript);
+}


### PR DESCRIPTION
## Summary

Adds the Epoch03 constitutional verification surface under `docs/epoch03/`.

This branch includes:

- single-page Epoch03 website shell
- canonical FSM, doctrine, transcript, receipt, and pre-anchor report surfaces
- browser validator and WASM-preferred engine abstraction
- replay chamber wiring with hash surfaces and taint propagation
- adversarial fixture scaffold and community contribution template
- adversarial taxonomy and lineage invariants
- canonical concat rule for harness hashing
- EAS/Base logical attestation specification
- explicit pre-anchor checklist and UNRUN pre-anchor report skeleton

## Constitutional boundary

No Base/EAS attestation is claimed as minted in this PR.

Current status remains:

```text
EAS_BASE_ATTESTATION = NOT_MINTED
ANCHOR_STATUS = PRE_ANCHOR_CHECKLIST_ONLY
```

## Required before anchor

Before any EAS/Base attestation, the operator must:

1. freeze harness + lineage invariants
2. compute `harness_hash` using `canonical-concat.v0.1.md`
3. run JS/WASM/CLI parity
4. recompute doctrine, FSM, receipt, lineage, and harness roots
5. fill `pre-anchor-report.json` with real PASS/FAIL values
6. only then materialize an attestation payload

No screenshots. No UI hashes. No ghost anchor.