### PR TITLE
docs: lock Hermes ALMS uptime vs legitimacy visual canon

### DIFF
--- a/docs/visuals/hermes_alms_uptime_vs_legitimacy/README.md
+++ b/docs/visuals/hermes_alms_uptime_vs_legitimacy/README.md
@@ -1,0 +1,8 @@
+# Hermes + ALMS: Uptime vs Legitimacy
+Hermes is the uptime layer for autonomous agents.
+ALMS is the legitimacy layer.
+The future agent stack does not choose between them.
+It wraps uptime with proof.
+Hermes keeps agents alive. ALMS keeps agents legitimate.
+Canon line:
+Uptime gets you through the night. Legitimacy gets you through the audit.

--- a/docs/visuals/hermes_alms_uptime_vs_legitimacy/hermes_alms_uptime_vs_legitimacy.svg
+++ b/docs/visuals/hermes_alms_uptime_vs_legitimacy/hermes_alms_uptime_vs_legitimacy.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+<rect width="1600" height="900" fill="#f7f7f4"/>
+<text x="800" y="90" text-anchor="middle" font-family="Arial" font-size="46" font-weight="700">Hermes Keeps Agents Alive. ALMS Keeps Agents Legitimate.</text>
+<rect x="90" y="160" width="580" height="540" rx="28" fill="#fff" stroke="#111" stroke-width="4"/>
+<rect x="930" y="160" width="580" height="540" rx="28" fill="#fff" stroke="#111" stroke-width="4"/>
+<text x="380" y="225" text-anchor="middle" font-family="Arial" font-size="34" font-weight="700">Hermes / Operator Stack</text>
+<text x="1220" y="225" text-anchor="middle" font-family="Arial" font-size="34" font-weight="700">ALMS / Constitutional Stack</text>
+<text x="380" y="275" text-anchor="middle" font-family="Arial" font-size="26">Can it keep working?</text>
+<text x="1220" y="275" text-anchor="middle" font-family="Arial" font-size="26">Can it prove lawful action?</text>
+<text x="140" y="350" font-family="Arial" font-size="28">• Runtime</text>
+<text x="140" y="405" font-family="Arial" font-size="28">• Interface</text>
+<text x="140" y="460" font-family="Arial" font-size="28">• Persistence</text>
+<text x="140" y="515" font-family="Arial" font-size="28">• Coordination</text>
+<text x="140" y="570" font-family="Arial" font-size="28">• Automation</text>
+<text x="980" y="350" font-family="Arial" font-size="28">• Authority Scope</text>
+<text x="980" y="405" font-family="Arial" font-size="28">• Receipt Memory</text>
+<text x="980" y="460" font-family="Arial" font-size="28">• Mutation Legality</text>
+<text x="980" y="515" font-family="Arial" font-size="28">• Replayability</text>
+<text x="980" y="570" font-family="Arial" font-size="28">• Constitutional Runtime</text>
+<text x="380" y="645" text-anchor="middle" font-family="Arial" font-size="24">Failure: agent dies, stalls, loops, forgets.</text>
+<text x="1220" y="645" text-anchor="middle" font-family="Arial" font-size="24">Failure: agent acts, but cannot justify.</text>
+<text x="800" y="405" text-anchor="middle" font-family="Arial" font-size="30" font-weight="700">Wrap uptime</text>
+<text x="800" y="445" text-anchor="middle" font-family="Arial" font-size="30" font-weight="700">with proof →</text>
+<text x="800" y="800" text-anchor="middle" font-family="Arial" font-size="34" font-weight="700">Uptime gets you through the night. Legitimacy gets you through the audit.</text>
+</svg>

--- a/docs/visuals/hermes_alms_uptime_vs_legitimacy/index.html
+++ b/docs/visuals/hermes_alms_uptime_vs_legitimacy/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Hermes + ALMS: Uptime vs Legitimacy</title>
+<style>
+body{font-family:Arial,sans-serif;background:#f7f7f4;color:#111;margin:40px}
+.wrap{max-width:1100px;margin:auto}
+h1{text-align:center}
+.grid{display:grid;grid-template-columns:1fr 160px 1fr;gap:24px;align-items:center}
+.card{border:2px solid #111;border-radius:18px;padding:24px;background:white}
+.bridge{text-align:center;font-weight:bold}
+li{margin:10px 0}
+.footer{text-align:center;margin-top:30px;font-size:22px;font-weight:bold}
+</style>
+</head>
+<body>
+<div class="wrap">
+<h1>Hermes Keeps Agents Alive. ALMS Keeps Agents Legitimate.</h1>
+<div class="grid">
+<section class="card">
+<h2>Hermes / Operator Stack</h2>
+<h3>Can it keep working?</h3>
+<ul>
+<li>Runtime</li><li>Interface</li><li>Persistence</li><li>Coordination</li><li>Automation</li>
+</ul>
+<p><b>Failure:</b> agent dies, stalls, loops, forgets.</p>
+<p><b>Metaphor:</b> uptime army</p>
+</section>
+<div class="bridge">wrap uptime<br>with proof →</div>
+<section class="card">
+<h2>ALMS / Constitutional Stack</h2>
+<h3>Can it prove lawful action?</h3>
+<ul>
+<li>Authority Scope</li><li>Receipt Memory</li><li>Mutation Legality</li><li>Replayability</li><li>Constitutional Runtime</li>
+</ul>
+<p><b>Failure:</b> agent acts, but cannot justify.</p>
+<p><b>Metaphor:</b> replay court</p>
+</section>
+</div>
+<div class="footer">Uptime gets you through the night. Legitimacy gets you through the audit.</div>
+</div>
+</body>
+</html>

--- a/docs/visuals/hermes_alms_uptime_vs_legitimacy/receipt.json
+++ b/docs/visuals/hermes_alms_uptime_vs_legitimacy/receipt.json
@@ -1,0 +1,15 @@
+{
+  "artifact_id": "hermes_alms_uptime_vs_legitimacy",
+  "repo": "jsonwisdom/AL",
+  "branch": "master",
+  "title": "Hermes Keeps Agents Alive. ALMS Keeps Agents Legitimate.",
+  "status": "CANON_VISUAL_LOCKED",
+  "decision": "KEEP_SINGLE_CANON_VISUAL",
+  "placeholder_receipt": "canon-510ce7cd5a33",
+  "placeholder_warning": "Placeholder is not a Git commit SHA. Final anchor requires actual_git_commit_sha_from_master.",
+  "variant_policy": "NO_VARIANTS_UNTIL_MASTER_RECEIPT_EXISTS",
+  "exports": ["html", "svg", "png"],
+  "claim": "Hermes provides uptime primitives for autonomous agents; ALMS provides legitimacy primitives for replay-safe governance.",
+  "canon_line": "Uptime gets you through the night. Legitimacy gets you through the audit.",
+  "tree_state": "pending_commit"
+}


### PR DESCRIPTION
## Summary

Locks the Hermes + ALMS Uptime vs Legitimacy visual canon as a single-source visual artifact.

## Canon status

- Artifact: `docs/visuals/hermes_alms_uptime_vs_legitimacy/`
- Branch evidence SHA: `123e4024ba90752ec6b44488b2b78fcd10e1e8fc`
- Status: `CANON_VISUAL_LOCKED`
- Decision: `KEEP_SINGLE_CANON_VISUAL`
- Variant policy: `NO_VARIANTS_UNTIL_MASTER_RECEIPT_EXISTS`

## Included files

- `index.html`
- `hermes_alms_uptime_vs_legitimacy.svg`
- `hermes_alms_uptime_vs_legitimacy.png`
- `README.md`
- `receipt.json`

## Canon line

> Uptime gets you through the night. Legitimacy gets you through the audit.

## Receipt note

This PR should merge cleanly because the visual path is new. Final anchor requires the post-merge commit SHA on `master`; the branch SHA is not the final master anchor.