### PR TITLE
#180 phase 3 implement HALT-001 fixtures

### DIFF
--- a/.github/workflows/vclp-verify.yml
+++ b/.github/workflows/vclp-verify.yml
@@ -17,3 +17,53 @@ jobs:
 
       - name: Run VCLP ledger verification
         run: ./docs/protocols/vclp/verify.sh _truth/ledger.jsonl _truth/patterns.json
+
+      - name: Verify subset_proof_v1 HALT-001 fixtures
+        run: |
+          python - <<'PY'
+          import glob
+          import json
+          import sys
+
+          def eval_halt_001(doc):
+              proof = doc.get("proof", {})
+              if proof.get("proof_type") != "HALT":
+                  return False
+              return len(proof.get("added_capabilities", [])) == 0
+
+          failed = False
+          paths = sorted(glob.glob("fixtures/subset_proof_v1/*.json"))
+
+          if not paths:
+              print("NO_FIXTURES_FOUND")
+              sys.exit(1)
+
+          for path in paths:
+              with open(path) as f:
+                  doc = json.load(f)
+
+              md = doc.get("metadata", {})
+              cid = md.get("constraint_id")
+              expect = md.get("expect")
+
+              if not cid or expect not in ("PASS", "FAIL"):
+                  print(f"METADATA_INVALID: {path}")
+                  failed = True
+                  continue
+
+              if cid != "HALT-001":
+                  print(f"UNSUPPORTED_CONSTRAINT_FOR_THIS_STUB: {path} {cid}")
+                  failed = True
+                  continue
+
+              actual = eval_halt_001(doc)
+              expected = expect == "PASS"
+
+              if actual != expected:
+                  print(f"EXPECTATION_MISMATCH: {path} actual={actual} expected={expected}")
+                  failed = True
+              else:
+                  print(f"OK: {path}")
+
+          sys.exit(1 if failed else 0)
+          PY

--- a/alms/national/national_root_ci_latest.json
+++ b/alms/national/national_root_ci_latest.json
@@ -3,7 +3,7 @@
   "version": "US_SNAPSHOT_2026-05-03",
   "status": "INDETERMINATE",
   "national_root": "sha256:2c8bb5b8841615f5b2f9c06b299d9bf7661a597d8a7367cf4522228fe2c6dd76",
-  "generated_utc": "2026-05-03T22:08:35Z",
+  "generated_utc": "2026-05-11T08:57:24Z",
   "states": [
     {
       "state": "MN",

--- a/fixtures/subset_proof_v1/halt-001_FAIL.json
+++ b/fixtures/subset_proof_v1/halt-001_FAIL.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-001",
+    "expect": "FAIL"
+  },
+  "proof": {
+    "proof_type": "HALT",
+    "pre_capabilities": [
+      "treasury.execute"
+    ],
+    "post_capabilities": [
+      "emergency.admin"
+    ],
+    "added_capabilities": [
+      "emergency.admin"
+    ]
+  }
+}

--- a/fixtures/subset_proof_v1/halt-001_PASS.json
+++ b/fixtures/subset_proof_v1/halt-001_PASS.json
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-001",
+    "expect": "PASS"
+  },
+  "proof": {
+    "proof_type": "HALT",
+    "pre_capabilities": [
+      "treasury.execute",
+      "authority.rotate",
+      "policy.mutate"
+    ],
+    "post_capabilities": [],
+    "added_capabilities": []
+  }
+}


### PR DESCRIPTION
Implements the first Phase 3 fixture surface under RFC-1.

Added fixtures:

```text
fixtures/subset_proof_v1/halt-001_PASS.json
fixtures/subset_proof_v1/halt-001_FAIL.json
```

Updated CI:

```text
.github/workflows/vclp-verify.yml
```

The verifier now executes HALT-001 fixture evaluation:

```text
HALT proof passes iff added_capabilities == []
```

Fixture metadata shape enforced:

```json
{
  "constraint_id": "HALT-001",
  "expect": "PASS | FAIL"
}
```

Current status:

```json
{
  "phase": 3,
  "halt_001": "IMPLEMENTED_PENDING_CI",
  "fixture_status": "PARTIALLY_IMPLEMENTED",
  "conformance_claimable": false
}
```

Boundary preserved:

```text
This PR implements HALT-001 fixtures only.
It does not claim full executable conformance.
It does not implement CAP/PROOF constraints because those are not ratified law.
```

Linked issue: #180