### PR TITLE
#180 phase 3 implement HALT-002..HALT-005 fixtures

### DIFF
--- a/.github/workflows/vclp-verify.yml
+++ b/.github/workflows/vclp-verify.yml
@@ -109,3 +109,46 @@ jobs:
 
           sys.exit(1 if failed else 0)
           PY
+
+      - name: Verify subset_proof_v1 HALT-003 fixtures
+        run: |
+          python - <<'PY'
+          import glob
+          import json
+          import sys
+
+          def eval_halt_003(doc):
+              proof = doc.get("proof", {})
+              return proof.get("strict_paths_expressible") is False
+
+          failed = False
+          paths = sorted(glob.glob("fixtures/subset_proof_v1/halt-003_*.json"))
+
+          if not paths:
+              print("NO_HALT_003_FIXTURES_FOUND")
+              sys.exit(1)
+
+          for path in paths:
+              with open(path) as f:
+                  doc = json.load(f)
+
+              md = doc.get("metadata", {})
+              cid = md.get("constraint_id")
+              expect = md.get("expect")
+
+              if cid != "HALT-003" or expect not in ("PASS", "FAIL"):
+                  print(f"METADATA_INVALID: {path}")
+                  failed = True
+                  continue
+
+              actual = eval_halt_003(doc)
+              expected = expect == "PASS"
+
+              if actual != expected:
+                  print(f"EXPECTATION_MISMATCH: {path} actual={actual} expected={expected}")
+                  failed = True
+              else:
+                  print(f"OK: {path}")
+
+          sys.exit(1 if failed else 0)
+          PY

--- a/.github/workflows/vclp-verify.yml
+++ b/.github/workflows/vclp-verify.yml
@@ -197,3 +197,47 @@ jobs:
 
           sys.exit(1 if failed else 0)
           PY
+
+      - name: Verify subset_proof_v1 HALT-005 fixtures
+        run: |
+          python - <<'PY'
+          import glob
+          import json
+          import sys
+
+          def eval_halt_005(doc):
+              proof = doc.get("proof", {})
+              receipt_hash = proof.get("active_classifier_receipt_hash")
+              return bool(receipt_hash)
+
+          failed = False
+          paths = sorted(glob.glob("fixtures/subset_proof_v1/halt-005_*.json"))
+
+          if not paths:
+              print("NO_HALT_005_FIXTURES_FOUND")
+              sys.exit(1)
+
+          for path in paths:
+              with open(path) as f:
+                  doc = json.load(f)
+
+              md = doc.get("metadata", {})
+              cid = md.get("constraint_id")
+              expect = md.get("expect")
+
+              if cid != "HALT-005" or expect not in ("PASS", "FAIL"):
+                  print(f"METADATA_INVALID: {path}")
+                  failed = True
+                  continue
+
+              actual = eval_halt_005(doc)
+              expected = expect == "PASS"
+
+              if actual != expected:
+                  print(f"EXPECTATION_MISMATCH: {path} actual={actual} expected={expected}")
+                  failed = True
+              else:
+                  print(f"OK: {path}")
+
+          sys.exit(1 if failed else 0)
+          PY

--- a/.github/workflows/vclp-verify.yml
+++ b/.github/workflows/vclp-verify.yml
@@ -152,3 +152,48 @@ jobs:
 
           sys.exit(1 if failed else 0)
           PY
+
+      - name: Verify subset_proof_v1 HALT-004 fixtures
+        run: |
+          python - <<'PY'
+          import glob
+          import json
+          import sys
+
+          def eval_halt_004(doc):
+              proof = doc.get("proof", {})
+              halt_scope = proof.get("halt_scope")
+              receipt_hash = proof.get("domain_split_receipt_hash")
+              return halt_scope == "STRICT_ZONE_ALL" or bool(receipt_hash)
+
+          failed = False
+          paths = sorted(glob.glob("fixtures/subset_proof_v1/halt-004_*.json"))
+
+          if not paths:
+              print("NO_HALT_004_FIXTURES_FOUND")
+              sys.exit(1)
+
+          for path in paths:
+              with open(path) as f:
+                  doc = json.load(f)
+
+              md = doc.get("metadata", {})
+              cid = md.get("constraint_id")
+              expect = md.get("expect")
+
+              if cid != "HALT-004" or expect not in ("PASS", "FAIL"):
+                  print(f"METADATA_INVALID: {path}")
+                  failed = True
+                  continue
+
+              actual = eval_halt_004(doc)
+              expected = expect == "PASS"
+
+              if actual != expected:
+                  print(f"EXPECTATION_MISMATCH: {path} actual={actual} expected={expected}")
+                  failed = True
+              else:
+                  print(f"OK: {path}")
+
+          sys.exit(1 if failed else 0)
+          PY

--- a/.github/workflows/vclp-verify.yml
+++ b/.github/workflows/vclp-verify.yml
@@ -27,15 +27,17 @@ jobs:
 
           def eval_halt_001(doc):
               proof = doc.get("proof", {})
+              if doc.get("metadata", {}).get("constraint_id") != "HALT-001":
+                  return True
               if proof.get("proof_type") != "HALT":
                   return False
               return len(proof.get("added_capabilities", [])) == 0
 
           failed = False
-          paths = sorted(glob.glob("fixtures/subset_proof_v1/*.json"))
+          paths = sorted(glob.glob("fixtures/subset_proof_v1/halt-001_*.json"))
 
           if not paths:
-              print("NO_FIXTURES_FOUND")
+              print("NO_HALT_001_FIXTURES_FOUND")
               sys.exit(1)
 
           for path in paths:
@@ -46,17 +48,57 @@ jobs:
               cid = md.get("constraint_id")
               expect = md.get("expect")
 
-              if not cid or expect not in ("PASS", "FAIL"):
+              if cid != "HALT-001" or expect not in ("PASS", "FAIL"):
                   print(f"METADATA_INVALID: {path}")
                   failed = True
                   continue
 
-              if cid != "HALT-001":
-                  print(f"UNSUPPORTED_CONSTRAINT_FOR_THIS_STUB: {path} {cid}")
+              actual = eval_halt_001(doc)
+              expected = expect == "PASS"
+
+              if actual != expected:
+                  print(f"EXPECTATION_MISMATCH: {path} actual={actual} expected={expected}")
+                  failed = True
+              else:
+                  print(f"OK: {path}")
+
+          sys.exit(1 if failed else 0)
+          PY
+
+      - name: Verify subset_proof_v1 HALT-002 fixtures
+        run: |
+          python - <<'PY'
+          import glob
+          import json
+          import sys
+
+          def eval_halt_002(doc):
+              proof = doc.get("proof", {})
+              pre = set(proof.get("pre_capabilities", []))
+              post = set(proof.get("post_capabilities", []))
+              return post.issubset(pre)
+
+          failed = False
+          paths = sorted(glob.glob("fixtures/subset_proof_v1/halt-002_*.json"))
+
+          if not paths:
+              print("NO_HALT_002_FIXTURES_FOUND")
+              sys.exit(1)
+
+          for path in paths:
+              with open(path) as f:
+                  doc = json.load(f)
+
+              md = doc.get("metadata", {})
+              cid = md.get("constraint_id")
+              expect = md.get("expect")
+
+              if cid != "HALT-002" or expect not in ("PASS", "FAIL"):
+                  print(f"METADATA_INVALID: {path}")
                   failed = True
                   continue
 
-              actual = eval_halt_001(doc)
+              actual = eval_halt_002(doc)
               expected = expect == "PASS"
 
               if actual != expected:

--- a/alms/national/national_root_ci_latest.json
+++ b/alms/national/national_root_ci_latest.json
@@ -3,7 +3,7 @@
   "version": "US_SNAPSHOT_2026-05-03",
   "status": "INDETERMINATE",
   "national_root": "sha256:2c8bb5b8841615f5b2f9c06b299d9bf7661a597d8a7367cf4522228fe2c6dd76",
-  "generated_utc": "2026-05-11T09:16:02Z",
+  "generated_utc": "2026-05-11T09:18:27Z",
   "states": [
     {
       "state": "MN",

--- a/alms/national/national_root_ci_latest.json
+++ b/alms/national/national_root_ci_latest.json
@@ -3,7 +3,7 @@
   "version": "US_SNAPSHOT_2026-05-03",
   "status": "INDETERMINATE",
   "national_root": "sha256:2c8bb5b8841615f5b2f9c06b299d9bf7661a597d8a7367cf4522228fe2c6dd76",
-  "generated_utc": "2026-05-11T09:13:49Z",
+  "generated_utc": "2026-05-11T09:16:02Z",
   "states": [
     {
       "state": "MN",

--- a/alms/national/national_root_ci_latest.json
+++ b/alms/national/national_root_ci_latest.json
@@ -3,7 +3,7 @@
   "version": "US_SNAPSHOT_2026-05-03",
   "status": "INDETERMINATE",
   "national_root": "sha256:2c8bb5b8841615f5b2f9c06b299d9bf7661a597d8a7367cf4522228fe2c6dd76",
-  "generated_utc": "2026-05-11T08:57:24Z",
+  "generated_utc": "2026-05-11T09:10:58Z",
   "states": [
     {
       "state": "MN",

--- a/alms/national/national_root_ci_latest.json
+++ b/alms/national/national_root_ci_latest.json
@@ -3,7 +3,7 @@
   "version": "US_SNAPSHOT_2026-05-03",
   "status": "INDETERMINATE",
   "national_root": "sha256:2c8bb5b8841615f5b2f9c06b299d9bf7661a597d8a7367cf4522228fe2c6dd76",
-  "generated_utc": "2026-05-11T09:10:58Z",
+  "generated_utc": "2026-05-11T09:13:49Z",
   "states": [
     {
       "state": "MN",

--- a/alms/national/national_root_ci_latest.json
+++ b/alms/national/national_root_ci_latest.json
@@ -3,7 +3,7 @@
   "version": "US_SNAPSHOT_2026-05-03",
   "status": "INDETERMINATE",
   "national_root": "sha256:2c8bb5b8841615f5b2f9c06b299d9bf7661a597d8a7367cf4522228fe2c6dd76",
-  "generated_utc": "2026-05-11T09:18:27Z",
+  "generated_utc": "2026-05-11T09:05:30Z",
   "states": [
     {
       "state": "MN",

--- a/fixtures/subset_proof_v1/halt-002_FAIL.json
+++ b/fixtures/subset_proof_v1/halt-002_FAIL.json
@@ -1,0 +1,10 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-002",
+    "expect": "FAIL"
+  },
+  "proof": {
+    "pre_capabilities": ["read"],
+    "post_capabilities": ["read", "write", "execute"]
+  }
+}

--- a/fixtures/subset_proof_v1/halt-002_PASS.json
+++ b/fixtures/subset_proof_v1/halt-002_PASS.json
@@ -1,0 +1,10 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-002",
+    "expect": "PASS"
+  },
+  "proof": {
+    "pre_capabilities": ["read", "write", "execute"],
+    "post_capabilities": ["read", "write"]
+  }
+}

--- a/fixtures/subset_proof_v1/halt-003_FAIL.json
+++ b/fixtures/subset_proof_v1/halt-003_FAIL.json
@@ -1,0 +1,9 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-003",
+    "expect": "FAIL"
+  },
+  "proof": {
+    "strict_paths_expressible": true
+  }
+}

--- a/fixtures/subset_proof_v1/halt-003_PASS.json
+++ b/fixtures/subset_proof_v1/halt-003_PASS.json
@@ -1,0 +1,9 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-003",
+    "expect": "PASS"
+  },
+  "proof": {
+    "strict_paths_expressible": false
+  }
+}

--- a/fixtures/subset_proof_v1/halt-004_FAIL.json
+++ b/fixtures/subset_proof_v1/halt-004_FAIL.json
@@ -1,0 +1,9 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-004",
+    "expect": "FAIL"
+  },
+  "proof": {
+    "halt_scope": "SOME_OTHER_ZONE"
+  }
+}

--- a/fixtures/subset_proof_v1/halt-004_PASS_receipt.json
+++ b/fixtures/subset_proof_v1/halt-004_PASS_receipt.json
@@ -1,0 +1,9 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-004",
+    "expect": "PASS"
+  },
+  "proof": {
+    "domain_split_receipt_hash": "0x7a3f5c2e1b8d4a9f6c3e7b1a9d5f2c8e4a6b3d1f"
+  }
+}

--- a/fixtures/subset_proof_v1/halt-004_PASS_scope.json
+++ b/fixtures/subset_proof_v1/halt-004_PASS_scope.json
@@ -1,0 +1,9 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-004",
+    "expect": "PASS"
+  },
+  "proof": {
+    "halt_scope": "STRICT_ZONE_ALL"
+  }
+}

--- a/fixtures/subset_proof_v1/halt-005_FAIL.json
+++ b/fixtures/subset_proof_v1/halt-005_FAIL.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-005",
+    "expect": "FAIL"
+  },
+  "proof": {}
+}

--- a/fixtures/subset_proof_v1/halt-005_PASS.json
+++ b/fixtures/subset_proof_v1/halt-005_PASS.json
@@ -1,0 +1,9 @@
+{
+  "metadata": {
+    "constraint_id": "HALT-005",
+    "expect": "PASS"
+  },
+  "proof": {
+    "active_classifier_receipt_hash": "0xb9e2c4d6f8a1b3c5e7d9f0a2b4c6e8d0f1a3b5c7"
+  }
+}


### PR DESCRIPTION
Implements the remaining HALT-family Phase 3 fixtures under RFC-1.

Scope:

```text
HALT-002
HALT-003
HALT-004
HALT-005
```

Base:

```text
PR #183 head / HALT-001 implemented surface
```

Added fixture coverage:

```text
HALT-002: PASS + FAIL
HALT-003: PASS + FAIL
HALT-004: PASS scope + PASS receipt + FAIL
HALT-005: PASS + FAIL
```

Updated CI:

```text
.github/workflows/vclp-verify.yml
```

Evaluator laws:

```text
HALT-002: post_capabilities ⊆ pre_capabilities
HALT-003: strict_paths_expressible == false
HALT-004: halt_scope == STRICT_ZONE_ALL OR domain_split_receipt_hash present
HALT-005: active_classifier_receipt_hash present
```

Boundary preserved:

```json
{
  "family": "HALT",
  "family_status": "IMPLEMENTED_PENDING_CI",
  "conformance_claimable": false
}
```

No CAP/PROOF fixtures are included because those IDs are not ratified law.

Law in the ledger. Fixtures cite ratified law. Schema serves.

Linked issue: #180