### PR TITLE
Add Wisconsin budget negotiation receipt machine

### DIFF
--- a/docs/wi_budget_negotiation_2026/README.md
+++ b/docs/wi_budget_negotiation_2026/README.md
@@ -1,0 +1,31 @@
+# WI_BUDGET_NEGOTIATION_2026 Receipt Machine
+
+Status: PACKAGE_READY_FOR_OPERATOR_PDF
+
+This package captures only operator-provided local PDF bytes.
+
+## Boundaries
+
+- No autonomous fetch
+- No news hashing for canon
+- No social-media hashing for canon
+- No legal inference at intake
+- No anchoring until enacted canonical text is operator-verified
+
+## State Path
+
+1. AWAITING_PRIMARY_ARTIFACT_UPLOAD
+2. ARTIFACT_BYTES_RECEIVED
+3. ARTIFACT_ROLE_ASSIGNED
+4. TEXT_HASH_VERIFIED
+5. ANCHOR_READY
+
+## Valid Artifact Roles
+
+- governor_press_release_pdf
+- special_session_order_pdf
+- lfb_fiscal_memo_pdf
+- enrolled_bill_text_pdf
+- unknown
+
+Default role: unknown.

--- a/scripts/wi_assign_role.sh
+++ b/scripts/wi_assign_role.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE="${1:?usage: ./scripts/wi_assign_role.sh <artifact_file> <role>}"
+ROLE="${2:?usage: ./scripts/wi_assign_role.sh <artifact_file> <role>}"
+
+OUT="receipts/wi_budget_negotiation_2026"
+MANIFEST="$OUT/artifact_manifest.jsonl"
+TMP="$OUT/artifact_manifest.tmp.jsonl"
+TS="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+case "$ROLE" in
+  governor_press_release_pdf|special_session_order_pdf|lfb_fiscal_memo_pdf|enrolled_bill_text_pdf|unknown) ;;
+  *) echo "INVALID_ROLE: $ROLE"; exit 1 ;;
+esac
+
+test -f "$MANIFEST" || { echo "MISSING_MANIFEST"; exit 1; }
+
+jq -c --arg file "$FILE" --arg role "$ROLE" --arg ts "$TS" '
+  if .artifact_file == $file then
+    .artifact_role = $role
+    | .role_assigned_by = "operator_manual"
+    | .role_assigned_timestamp_utc = $ts
+  else . end
+' "$MANIFEST" > "$TMP"
+
+mv "$TMP" "$MANIFEST"
+
+jq -s --arg ts "$TS" '{
+  event:"WI_BUDGET_NEGOTIATION_2026",
+  state:"ARTIFACT_ROLE_ASSIGNED",
+  posture:"SEALED_PASSIVE_WITNESS",
+  transition_allowed:true,
+  hash_ready:true,
+  anchor_ready:false,
+  semantic_expansion:"DISABLED",
+  role_assignment:"operator_manual",
+  artifacts:.
+}' "$MANIFEST" > "$OUT/state.json"
+
+jq -cS '.receipt_hash=null' "$OUT/state.json" > "$OUT/state.canonical.json"
+HASH="$(sha256sum "$OUT/state.canonical.json" | awk '{print $1}')"
+jq --arg h "$HASH" '. + {receipt_hash:$h}' "$OUT/state.json" > "$OUT/state.receipt.json"
+
+echo "ROLE_ASSIGNMENT_OK"
+echo "file=$FILE"
+echo "role=$ROLE"
+echo "receipt_hash=$HASH"

--- a/scripts/wi_assign_role.sh
+++ b/scripts/wi_assign_role.sh
@@ -16,6 +16,13 @@ esac
 
 test -f "$MANIFEST" || { echo "MISSING_MANIFEST"; exit 1; }
 
+MATCH_COUNT="$(jq -r --arg file "$FILE" 'select(.artifact_file == $file) | .artifact_file' "$MANIFEST" | wc -l | tr -d ' ')"
+if [ "$MATCH_COUNT" = "0" ]; then
+  rm -f "$TMP"
+  echo "ARTIFACT_NOT_FOUND: $FILE"
+  exit 1
+fi
+
 jq -c --arg file "$FILE" --arg role "$ROLE" --arg ts "$TS" '
   if .artifact_file == $file then
     .artifact_role = $role

--- a/scripts/wi_receipt_machine_intake.sh
+++ b/scripts/wi_receipt_machine_intake.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVENT="WI_BUDGET_NEGOTIATION_2026"
+IN="incoming/wi_budget_negotiation_2026"
+OUT="receipts/wi_budget_negotiation_2026"
+TS="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+mkdir -p "$IN" "$OUT"
+
+COUNT="$(find "$IN" -maxdepth 1 -type f \( -name '*.pdf' -o -name '*.PDF' \) | wc -l | tr -d ' ')"
+
+if [ "$COUNT" = "0" ]; then
+  cat > "$OUT/state.json" <<JSON
+{
+  "event": "$EVENT",
+  "state": "AWAITING_PRIMARY_ARTIFACT_UPLOAD",
+  "posture": "SEALED_PASSIVE_WITNESS",
+  "transition_allowed": false,
+  "reason": "no operator-provided canonical pdf bytes found",
+  "timestamp_utc": "$TS"
+}
+JSON
+  cat "$OUT/state.json"
+  exit 0
+fi
+
+MANIFEST="$OUT/artifact_manifest.jsonl"
+: > "$MANIFEST"
+
+find "$IN" -maxdepth 1 -type f \( -name '*.pdf' -o -name '*.PDF' \) -print0 \
+| sort -z \
+| while IFS= read -r -d '' f; do
+  NAME="$(basename "$f")"
+  SIZE="$(wc -c < "$f" | tr -d ' ')"
+  SHA256="$(sha256sum "$f" | awk '{print $1}')"
+
+  jq -cn \
+    --arg event "$EVENT" \
+    --arg file "$NAME" \
+    --arg path "$f" \
+    --arg sha256 "$SHA256" \
+    --arg size "$SIZE" \
+    --arg role "unknown" \
+    --arg timestamp_utc "$TS" \
+    '{
+      event:$event,
+      artifact_file:$file,
+      artifact_path:$path,
+      artifact_sha256:$sha256,
+      artifact_size_bytes:($size|tonumber),
+      artifact_role:$role,
+      source:"operator_provided_local_bytes",
+      canonical_status:"PRIMARY_BYTES_RECEIVED_UNCLASSIFIED",
+      timestamp_utc:$timestamp_utc
+    }' >> "$MANIFEST"
+done
+
+jq -s --arg event "$EVENT" --arg ts "$TS" '{
+  event:$event,
+  state:"ARTIFACT_BYTES_RECEIVED",
+  posture:"SEALED_PASSIVE_WITNESS",
+  transition_allowed:true,
+  hash_ready:true,
+  anchor_ready:false,
+  semantic_expansion:"DISABLED",
+  artifacts:.
+}' "$MANIFEST" > "$OUT/state.json"
+
+jq -cS '.receipt_hash=null' "$OUT/state.json" > "$OUT/state.canonical.json"
+HASH="$(sha256sum "$OUT/state.canonical.json" | awk '{print $1}')"
+jq --arg h "$HASH" '. + {receipt_hash:$h}' "$OUT/state.json" > "$OUT/state.receipt.json"
+
+echo "RECEIPT_MACHINE_OK"
+echo "receipt=$OUT/state.receipt.json"
+echo "receipt_hash=$HASH"


### PR DESCRIPTION
## Summary

Adds a bounded local-only receipt intake package for Wisconsin budget negotiation artifacts.

## Included

- `scripts/wi_receipt_machine_intake.sh`
- `scripts/wi_assign_role.sh`
- `docs/wi_budget_negotiation_2026/README.md`

## Invariants

- No autonomous fetch
- No legal inference at ingest
- No auto-classification
- No anchoring without operator verification
- Hashes seal state, not legal effect

## Review Surface

This PR intentionally avoids direct writes to `master` and keeps all actions operator-reviewable.
