### PR TITLE
baseline: add constitutional baseline governance membrane

### DIFF
--- a/.github/workflows/baseline-drift.yml
+++ b/.github/workflows/baseline-drift.yml
@@ -1,0 +1,38 @@
+name: Baseline Drift Gate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  baseline-drift:
+    name: Baseline Drift Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check baseline drift
+        id: driftcheck
+        run: |
+          npx ts-node scripts/baseline_governance.ts check reports/baselines/manifest_v1.json
+
+      - name: Upload drift receipts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: baseline-drift-receipts
+          path: reports/baselines/drift/
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -45,6 +45,104 @@ cat _truth/receipts/index.json | jq '.index.receipts[] | {path, claims}'
 cat receipts/2025-04-10T08-30-00Z-attestation.json | jq '{claim, algorithm, timestamp, signature}'
 ```
 
+## Baseline Governance
+
+Baselines in this repository are not test fixtures.
+Baselines are constitutional memory: the byte-stable record of expected system behavior.
+
+They define what is trusted, what is allowed, and what constitutes drift.
+All runners (calibration, capture, curriculum) are bound to these baselines.
+
+The governance chain is:
+
+manifest → check → drift receipt → approval evidence → human update
+
+No step is implicit.
+No step is automated.
+No step is skipped.
+
+### Manifest
+
+The manifest is the only lawful registry of baseline pairs:
+
+`reports/baselines/manifest_v1.json`
+
+If a runner is not listed in the manifest, it does not exist.
+CI and the governance CLI must read only this manifest.
+
+### Baseline Drift Gate (CI)
+
+The drift gate lives at:
+
+`.github/workflows/baseline-drift.yml`
+
+CI responsibilities:
+
+- witness drift
+- preserve drift evidence
+- fail the build on drift
+
+CI may not approve drift.
+CI may not update baselines.
+CI may not infer runners or discover files.
+
+### Operator Commands
+
+All governance actions are performed through the Baseline Governance CLI:
+
+`scripts/baseline_governance.ts`
+
+#### Status
+
+```bash
+npx ts-node scripts/baseline_governance.ts status reports/baselines/manifest_v1.json
+```
+
+#### Check
+
+```bash
+npx ts-node scripts/baseline_governance.ts check reports/baselines/manifest_v1.json
+```
+
+#### Approve Update (Evidence Only)
+
+```bash
+npx ts-node scripts/baseline_governance.ts approve-update \
+  calibration \
+  reports/calibration/latest.json \
+  reports/baselines/calibration/baseline.json \
+  --drift <driftReceiptHash> \
+  --commit <commitHash> \
+  --reason "<reason>" \
+  --reviewer "<reviewer>"
+```
+
+Missing any required fields makes the update invalid.
+
+### Manual Baseline Update Rule
+
+A baseline may be replaced only when:
+
+1. A drift receipt exists.
+2. The operator has reviewed both canonical receipts.
+3. An approval evidence block has been generated.
+4. A human reviewer signs off.
+5. CI re-runs and confirms stability.
+
+There are no other lawful paths.
+
+### Prohibited CI Behavior
+
+- ❌ Auto-updating baselines
+- ❌ Regenerating baselines
+- ❌ Mutating baselines in CI
+- ❌ Accepting drift without evidence
+- ❌ Discovering runners or files
+- ❌ Inferring baseline locations
+- ❌ Silent absolution
+
+Baselines change only through explicit operator action.
+
 ## Structure
 
 ```txt

--- a/reports/baselines/manifest_v1.json
+++ b/reports/baselines/manifest_v1.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "baseline_manifest_v1",
+  "entries": [
+    {
+      "runner": "calibration",
+      "baselinePath": "reports/baselines/calibration/baseline.json",
+      "candidatePath": "reports/calibration/latest.json",
+      "required": true
+    },
+    {
+      "runner": "capture",
+      "baselinePath": "reports/baselines/capture/baseline.json",
+      "candidatePath": "reports/capture/latest.json",
+      "required": true
+    },
+    {
+      "runner": "curriculum",
+      "baselinePath": "reports/baselines/curriculum/baseline.json",
+      "candidatePath": "reports/curriculum/latest.json",
+      "required": true
+    }
+  ]
+}

--- a/reports/baselines/schema/baseline_receipt_v1.json
+++ b/reports/baselines/schema/baseline_receipt_v1.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://epoch03/baseline_receipt_v1.json",
+  "title": "Baseline Receipt v1",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "receiptType",
+    "harnessVersion",
+    "commit",
+    "generatedAt",
+    "networkEvents",
+    "metrics",
+    "receiptHash"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "baseline_receipt_v1"
+    },
+    "receiptType": {
+      "type": "string",
+      "enum": ["calibration", "capture", "curriculum"]
+    },
+    "harnessVersion": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{7,40}$"
+    },
+    "commit": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{7,40}$"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "networkEvents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "timestamp",
+          "method",
+          "resourceType",
+          "url",
+          "tier"
+        ],
+        "properties": {
+          "timestamp": { "type": "number" },
+          "method": { "type": "string" },
+          "resourceType": { "type": "string" },
+          "url": { "type": "string" },
+          "tier": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 5
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "required": [
+        "tier3PlusCount",
+        "eventCount"
+      ],
+      "properties": {
+        "tier3PlusCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "eventCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "receiptHash": {
+      "type": "string",
+      "description": "SHA-256 of the canonicalized receipt body",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/baseline_governance.ts
+++ b/scripts/baseline_governance.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env ts-node
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { loadBaseline } from "../src/baselines/load_baseline.js";
+import { writeDriftReceipt } from "../src/baselines/write_drift_receipt.js";
+import { createHash } from "node:crypto";
+
+function canonicalize(value: unknown): string {
+  return JSON.stringify(sortCanonical(value));
+}
+
+function sortCanonical(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortCanonical);
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => [k, sortCanonical(v)])
+    );
+  }
+  return value;
+}
+
+function sha256(data: string): string {
+  return createHash("sha256").update(data, "utf8").digest("hex");
+}
+
+interface ManifestEntry {
+  runner: string;
+  baselinePath: string;
+  candidatePath: string;
+  required: boolean;
+}
+
+interface BaselineManifest {
+  schemaVersion: "baseline_manifest_v1";
+  entries: ManifestEntry[];
+}
+
+function loadManifest(path: string): BaselineManifest {
+  const absolute = resolve(process.cwd(), path);
+  const raw = readFileSync(absolute, "utf8");
+  const parsed = JSON.parse(raw);
+
+  if (parsed.schemaVersion !== "baseline_manifest_v1") {
+    throw new Error(
+      `Invalid manifest schemaVersion: ${parsed.schemaVersion}`
+    );
+  }
+
+  if (!Array.isArray(parsed.entries)) {
+    throw new Error("Manifest missing entries[] array");
+  }
+
+  return parsed;
+}
+
+async function cmdStatus(manifestPath: string) {
+  const manifest = loadManifest(manifestPath);
+
+  console.log("Baseline Manifest Status");
+  console.log("------------------------");
+
+  for (const entry of manifest.entries) {
+    const baselineAbs = resolve(process.cwd(), entry.baselinePath);
+    const candidateAbs = resolve(process.cwd(), entry.candidatePath);
+
+    const baselineExists = existsSync(baselineAbs);
+    const candidateExists = existsSync(candidateAbs);
+
+    console.log(`Runner: ${entry.runner}`);
+    console.log(`  baseline:  ${baselineAbs}`);
+    console.log(`  candidate: ${candidateAbs}`);
+    console.log(`  required:  ${entry.required}`);
+    console.log(`  baseline_exists:  ${baselineExists}`);
+    console.log(`  candidate_exists: ${candidateExists}`);
+    console.log("");
+  }
+}
+
+async function cmdCheck(manifestPath: string) {
+  const manifest = loadManifest(manifestPath);
+
+  let driftDetected = false;
+
+  for (const entry of manifest.entries) {
+    const baselineAbs = resolve(process.cwd(), entry.baselinePath);
+    const candidateAbs = resolve(process.cwd(), entry.candidatePath);
+
+    try {
+      const baseline = loadBaseline(baselineAbs);
+      const candidate = loadBaseline(candidateAbs);
+
+      const baselineCanon = canonicalize(baseline);
+      const candidateCanon = canonicalize(candidate);
+
+      const baselineHash = sha256(baselineCanon);
+      const candidateHash = sha256(candidateCanon);
+
+      if (baselineHash !== candidateHash) {
+        console.error(`❌ Drift detected for runner: ${entry.runner}`);
+
+        const receiptPath = writeDriftReceipt(
+          baselineAbs,
+          candidateAbs
+        );
+
+        console.error(`   Drift receipt: ${receiptPath}`);
+        driftDetected = true;
+      } else {
+        console.log(`✓ Stable: ${entry.runner}`);
+      }
+    } catch (err) {
+      console.error(`❌ Error checking runner ${entry.runner}:`);
+      console.error(err);
+      process.exit(2);
+    }
+  }
+
+  if (driftDetected) {
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+async function cmdApproveUpdate(args: string[]) {
+  if (args.length < 6) {
+    console.error(
+      "Usage: approve-update <runner> <candidatePath> <baselinePath> --drift <receiptHash> --commit <commitHash> --reason \"text\" --reviewer \"name\""
+    );
+    process.exit(2);
+  }
+
+  const runner = args[0];
+  const candidatePath = args[1];
+  const baselinePath = args[2];
+
+  const flags = {
+    drift: "",
+    commit: "",
+    reason: "",
+    reviewer: ""
+  };
+
+  for (let i = 3; i < args.length; i++) {
+    if (args[i] === "--drift") flags.drift = args[++i];
+    else if (args[i] === "--commit") flags.commit = args[++i];
+    else if (args[i] === "--reason") flags.reason = args[++i];
+    else if (args[i] === "--reviewer") flags.reviewer = args[++i];
+  }
+
+  if (!flags.drift || !flags.commit || !flags.reason || !flags.reviewer) {
+    console.error("Missing required flags for approve-update");
+    process.exit(2);
+  }
+
+  const evidence = {
+    schemaVersion: "baseline_update_evidence_v1",
+    runner,
+    baselinePath,
+    candidatePath,
+    driftReceiptHash: flags.drift,
+    commitHash: flags.commit,
+    reasonForUpdate: flags.reason,
+    reviewerSignoff: flags.reviewer,
+    generatedAt: new Date().toISOString()
+  };
+
+  console.log(JSON.stringify(evidence, null, 2));
+  process.exit(0);
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+
+  if (!command) {
+    console.error("Commands: status | check | approve-update");
+    process.exit(2);
+  }
+
+  if (command === "status") {
+    if (rest.length !== 1) {
+      console.error("Usage: status <manifestPath>");
+      process.exit(2);
+    }
+    await cmdStatus(rest[0]);
+    return;
+  }
+
+  if (command === "check") {
+    if (rest.length !== 1) {
+      console.error("Usage: check <manifestPath>");
+      process.exit(2);
+    }
+    await cmdCheck(rest[0]);
+    return;
+  }
+
+  if (command === "approve-update") {
+    await cmdApproveUpdate(rest);
+    return;
+  }
+
+  console.error(`Unknown command: ${command}`);
+  process.exit(2);
+}
+
+main();

--- a/src/baselines/compare_baseline.ts
+++ b/src/baselines/compare_baseline.ts
@@ -1,0 +1,70 @@
+import { createHash } from "node:crypto";
+import { loadBaseline, BaselineReceipt } from "./load_baseline.js";
+
+function canonicalize(value: unknown): string {
+  return JSON.stringify(sortCanonical(value));
+}
+
+function sortCanonical(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortCanonical);
+  }
+
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => [k, sortCanonical(v)])
+    );
+  }
+
+  return value;
+}
+
+function sha256(data: string): string {
+  return createHash("sha256").update(data, "utf8").digest("hex");
+}
+
+export interface DriftResult {
+  drift: boolean;
+  baselineHash: string;
+  candidateHash: string;
+  diff?: {
+    baseline: string;
+    candidate: string;
+  };
+}
+
+export function compareBaseline(
+  baselinePath: string,
+  candidatePath: string
+): DriftResult {
+  const baseline: BaselineReceipt = loadBaseline(baselinePath);
+  const candidate: BaselineReceipt = loadBaseline(candidatePath);
+
+  const baselineCanon = canonicalize(baseline);
+  const candidateCanon = canonicalize(candidate);
+
+  const baselineHash = sha256(baselineCanon);
+  const candidateHash = sha256(candidateCanon);
+
+  const drift = baselineHash !== candidateHash;
+
+  if (drift) {
+    return {
+      drift: true,
+      baselineHash,
+      candidateHash,
+      diff: {
+        baseline: baselineCanon,
+        candidate: candidateCanon
+      }
+    };
+  }
+
+  return {
+    drift: false,
+    baselineHash,
+    candidateHash
+  };
+}

--- a/src/baselines/load_baseline.ts
+++ b/src/baselines/load_baseline.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createRequire } from "node:module";
+import Ajv, { JSONSchemaType } from "ajv";
+import addFormats from "ajv-formats";
+
+const require = createRequire(import.meta.url);
+
+const schemaPath = resolve(
+  process.cwd(),
+  "reports/baselines/schema/baseline_receipt_v1.json"
+);
+const schema = require(schemaPath);
+
+export interface NetworkEvent {
+  timestamp: number;
+  method: string;
+  resourceType: string;
+  url: string;
+  tier: number;
+}
+
+export interface BaselineMetrics {
+  tier3PlusCount: number;
+  eventCount: number;
+}
+
+export interface BaselineReceipt {
+  schemaVersion: "baseline_receipt_v1";
+  receiptType: "calibration" | "capture" | "curriculum";
+  harnessVersion: string;
+  commit: string;
+  generatedAt: string;
+  networkEvents: NetworkEvent[];
+  metrics: BaselineMetrics;
+  receiptHash: string;
+}
+
+const ajv = new Ajv({ allErrors: true, strict: true });
+addFormats(ajv);
+
+const validate = ajv.compile<BaselineReceipt>(
+  schema as JSONSchemaType<BaselineReceipt>
+);
+
+export function loadBaseline(path: string): BaselineReceipt {
+  const absolute = resolve(process.cwd(), path);
+
+  let raw: string;
+  try {
+    raw = readFileSync(absolute, "utf8");
+  } catch (err) {
+    throw new Error(`Failed to read baseline at ${absolute}: ${err}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Invalid JSON in baseline at ${absolute}: ${err}`);
+  }
+
+  const valid = validate(parsed);
+  if (!valid) {
+    const errors = ajv.errorsText(validate.errors, { separator: "\n" });
+    throw new Error(
+      `Baseline at ${absolute} does not match baseline_receipt_v1 schema:\n${errors}`
+    );
+  }
+
+  return parsed;
+}

--- a/src/baselines/write_drift_receipt.ts
+++ b/src/baselines/write_drift_receipt.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve, basename } from "node:path";
+import { loadBaseline } from "./load_baseline.js";
+import { createHash } from "node:crypto";
+
+function canonicalize(value: unknown): string {
+  return JSON.stringify(sortCanonical(value));
+}
+
+function sortCanonical(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortCanonical);
+  }
+
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => [k, sortCanonical(v)])
+    );
+  }
+
+  return value;
+}
+
+function sha256(data: string): string {
+  return createHash("sha256").update(data, "utf8").digest("hex");
+}
+
+export function writeDriftReceipt(
+  baselinePath: string,
+  candidatePath: string
+): string {
+  const baseline = loadBaseline(baselinePath);
+  const candidate = loadBaseline(candidatePath);
+
+  const canonicalBaseline = canonicalize(baseline);
+  const canonicalCandidate = canonicalize(candidate);
+
+  const baselineHash = sha256(canonicalBaseline);
+  const candidateHash = sha256(canonicalCandidate);
+
+  const detectedAt = new Date().toISOString();
+
+  const receiptBody = {
+    schemaVersion: "baseline_drift_receipt_v1",
+    baselinePath,
+    candidatePath,
+    baselineHash,
+    candidateHash,
+    detectedAt,
+    canonicalBaseline,
+    canonicalCandidate
+  };
+
+  const receiptHash = sha256(canonicalize(receiptBody));
+
+  const receipt = {
+    ...receiptBody,
+    receiptHash
+  };
+
+  const driftDir = resolve(process.cwd(), "reports/baselines/drift");
+
+  mkdirSync(driftDir, { recursive: true });
+
+  const filename = `drift_${receiptHash}.json`;
+  const outPath = resolve(driftDir, filename);
+
+  writeFileSync(outPath, JSON.stringify(receipt, null, 2), "utf8");
+
+  return outPath;
+}


### PR DESCRIPTION
## Summary

Adds the constitutional baseline governance membrane for replay-verifiable baseline enforcement.

This PR introduces:

- baseline manifest registry
- locked baseline receipt schema
- strict baseline loader
- byte-stable comparator
- drift receipt emitter
- governance CLI
- CI drift gate workflow
- README operator governance surface

## Governance Invariants

- No silent mutation
- No discovery
- No inference
- No auto-approval
- No ghost baselines
- Evidence before action
- Human before update

## Constitutional Effect

This PR creates the first explicit constitutional delta between the legacy baseline schema surface on `master` and the locked membrane schema introduced here.

The change is intentionally visible, reviewable, and replay-auditable.

## Branch

`baseline-governance-membrane`
