### PR TITLE
Add multi-observer contradiction receipts

### DIFF
--- a/constitutional-runtime/README.md
+++ b/constitutional-runtime/README.md
@@ -6,6 +6,7 @@ Minimal deterministic replay + divergence engine for constitutional membrane ver
 
 - **Positive control** — `fixtures/receipt.valid.json` (genesis MATCH, empty replay path)
 - **Negative control** — `fixtures/receipt.divergent.json` (D3 divergence, deterministic mismatch)
+- **Contradiction control** — `fixtures/contradiction.valid.json` (multi-observer CONSTITUTIONAL_CONTRADICTION)
 - **Lineage control** — `fixtures/lineage.valid.json`
 - **Schema surface** — `schema/*.schema.json` (strict, no additionalProperties)
 
@@ -18,7 +19,7 @@ node dist/cli.js <receipt.json> <lineage.json>
 ## Exit Codes
 
 - `0` → MATCH
-- `2` → DIVERGENCE
+- `2` → DIVERGENCE / CONSTITUTIONAL_CONTRADICTION
 - `4` → UNKNOWN / INSUFFICIENT_EVIDENCE
 
 ## Reproduction
@@ -33,7 +34,22 @@ This script:
 - Builds from source
 - Validates positive control (exit 0)
 - Validates divergent control (exit 2)
+- Validates contradiction control (exit 2)
 - Fails hard on any drift
+
+## Contradiction Receipts
+
+Observer disagreement is constitutional state, not hidden operator context.
+
+A contradiction receipt records multiple observer reports for the same event where observers report conflicting state roots. In v0.1, any exact root conflict is treated as D3 and freezes the mutation surface.
+
+This layer is intentionally narrow:
+
+- No fuzzy consensus
+- No weighted observers
+- No settlement logic
+- No quorum mutation
+- Duplicate observer reports do not inflate agreement
 
 ## Design Principles
 
@@ -41,9 +57,10 @@ This script:
 - Schemas precede semantics
 - Declared topology does not equal verified topology until commits land
 - Divergence classification is intentionally conservative (D0 vs D3)
+- Contradiction is evidence, not adjudication
 
 ## Status
 
-Branch: `constitutional-runtime-v0-1`
+Branch: `constitutional-runtime-observer-reports`
 
 Membrane: structurally self-describing + externally reproducible

--- a/constitutional-runtime/fixtures/contradiction.valid.json
+++ b/constitutional-runtime/fixtures/contradiction.valid.json
@@ -1,0 +1,20 @@
+{
+  "event_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "reports": [
+    {
+      "observer_id": "1111111111111111111111111111111111111111111111111111111111111111",
+      "event_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+      "observed_state_root": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
+      "signature": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0"
+    },
+    {
+      "observer_id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "event_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+      "observed_state_root": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      "signature": "f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3"
+    }
+  ],
+  "verdict": "CONSTITUTIONAL_CONTRADICTION",
+  "divergence": "D3",
+  "mutation_surface": "Frozen"
+}

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -15,4 +15,18 @@ if [ "$code" -ne 2 ]; then
   exit 1
 fi
 
+# === CONTRADICTION CONTROL ===
+echo "→ Testing contradiction receipt (expect CONSTITUTIONAL_CONTRADICTION / exit 2)"
+set +e
+node dist/cli.js fixtures/contradiction.valid.json fixtures/lineage.valid.json
+contradiction_code=$?
+set -e
+
+if [ "$contradiction_code" -ne 2 ]; then
+  echo "Wrong exit code for contradiction: $contradiction_code"
+  exit 1
+fi
+
+echo "✅ CONSTITUTIONAL_CONTRADICTION verified (exit 2)"
+echo "🎉 All three constitutional controls verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION)"
 echo "REPRODUCE_OK"

--- a/constitutional-runtime/schema/contradiction.schema.json
+++ b/constitutional-runtime/schema/contradiction.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ContradictionReceipt",
+  "description": "Multi-observer contradiction as first-class constitutional artifact",
+  "type": "object",
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "reports": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "$ref": "observer-report.schema.json"
+      }
+    },
+    "verdict": {
+      "const": "CONSTITUTIONAL_CONTRADICTION"
+    },
+    "divergence": {
+      "const": "D3"
+    },
+    "mutation_surface": {
+      "const": "Frozen"
+    }
+  },
+  "required": [
+    "event_id",
+    "reports",
+    "verdict",
+    "divergence",
+    "mutation_surface"
+  ],
+  "additionalProperties": false
+}

--- a/constitutional-runtime/schema/observer-report.schema.json
+++ b/constitutional-runtime/schema/observer-report.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ObserverReport",
+  "description": "Single cryptographically signed observation for contradiction detection",
+  "type": "object",
+  "properties": {
+    "observer_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Raw 32-byte observer public key in hex"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "observed_state_root": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{128}$",
+      "description": "Ed25519 64-byte signature in hex"
+    }
+  },
+  "required": [
+    "observer_id",
+    "event_id",
+    "observed_state_root",
+    "signature"
+  ],
+  "additionalProperties": false
+}

--- a/constitutional-runtime/src/cli.ts
+++ b/constitutional-runtime/src/cli.ts
@@ -39,4 +39,5 @@ console.log(JSON.stringify(result, null, 2));
 
 if (result.verdict === "MATCH") process.exit(0);
 if (result.verdict === "DIVERGENCE") process.exit(2);
+if (result.verdict === "CONSTITUTIONAL_CONTRADICTION") process.exit(2);
 process.exit(4);

--- a/constitutional-runtime/src/contradiction.ts
+++ b/constitutional-runtime/src/contradiction.ts
@@ -1,0 +1,77 @@
+import { DivergenceClass, Hash } from "./types.js";
+
+export interface ObserverReport {
+  observer_id: Hash;
+  event_id: Hash;
+  observed_state_root: Hash;
+  signature: string;
+}
+
+export interface ContradictionReceipt {
+  event_id: Hash;
+  reports: ObserverReport[];
+  verdict: "CONSTITUTIONAL_CONTRADICTION";
+  divergence: "D3";
+  mutation_surface: "Frozen";
+}
+
+export function detectContradiction(
+  reports: ObserverReport[]
+): {
+  isContradiction: boolean;
+  divergence: DivergenceClass;
+  uniqueObserverCount: number;
+  conflictingRoots: Hash[];
+} {
+  if (reports.length < 2) {
+    return {
+      isContradiction: false,
+      divergence: "D0",
+      uniqueObserverCount: 0,
+      conflictingRoots: []
+    };
+  }
+
+  const byObserver = new Map<Hash, ObserverReport>();
+  for (const report of reports) {
+    byObserver.set(report.observer_id, report);
+  }
+
+  const uniqueReports = Array.from(byObserver.values());
+  const uniqueObserverCount = uniqueReports.length;
+
+  if (uniqueObserverCount < 2) {
+    return {
+      isContradiction: false,
+      divergence: "D0",
+      uniqueObserverCount,
+      conflictingRoots: []
+    };
+  }
+
+  const rootSet = new Set<Hash>();
+  for (const report of uniqueReports) {
+    rootSet.add(report.observed_state_root);
+  }
+
+  const hasConflict = rootSet.size > 1;
+
+  return {
+    isContradiction: hasConflict,
+    divergence: hasConflict ? "D3" : "D0",
+    uniqueObserverCount,
+    conflictingRoots: hasConflict ? Array.from(rootSet) : []
+  };
+}
+
+export function isValidContradictionReceipt(
+  receipt: Partial<ContradictionReceipt>
+): boolean {
+  return (
+    receipt.verdict === "CONSTITUTIONAL_CONTRADICTION" &&
+    receipt.divergence === "D3" &&
+    receipt.mutation_surface === "Frozen" &&
+    Array.isArray(receipt.reports) &&
+    receipt.reports.length >= 2
+  );
+}

--- a/constitutional-runtime/src/types.ts
+++ b/constitutional-runtime/src/types.ts
@@ -7,7 +7,8 @@ export type Verdict =
   | "DIVERGENCE"
   | "INVALID"
   | "INSUFFICIENT_EVIDENCE"
-  | "CONSTITUTIONAL_UNKNOWN";
+  | "CONSTITUTIONAL_UNKNOWN"
+  | "CONSTITUTIONAL_CONTRADICTION";
 
 export interface Signature {
   observer_id: string;

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -7,6 +7,11 @@ import { join } from "node:path";
 import { verifySignature } from "./signature.js";
 import { canonicalizeForSignature } from "./canonical.js";
 import { evaluateObserverThreshold } from "./threshold.js";
+import {
+  ContradictionReceipt,
+  detectContradiction,
+  isValidContradictionReceipt
+} from "./contradiction.js";
 
 const SCHEMA_DIR = join(process.cwd(), "schema");
 
@@ -43,22 +48,49 @@ export function validateReceiptSchema(data: unknown): { valid: boolean; errors?:
 }
 
 export function validateReceipt(
-  receipt: Receipt,
+  receipt: Receipt | ContradictionReceipt,
   lineage: Lineage
 ): {
   verdict: Verdict;
   computed_root?: string;
   divergence?: string;
   mutation_surface?: "Mutable" | "Frozen";
+  details?: {
+    uniqueObservers: number;
+    conflictingRoots: string[];
+  };
 } {
-  if (!pathExists(receipt, lineage)) {
+  if ("reports" in receipt && isValidContradictionReceipt(receipt)) {
+    const result = detectContradiction(receipt.reports);
+
+    if (result.isContradiction) {
+      return {
+        verdict: "CONSTITUTIONAL_CONTRADICTION",
+        divergence: "D3",
+        mutation_surface: "Frozen",
+        details: {
+          uniqueObservers: result.uniqueObserverCount,
+          conflictingRoots: result.conflictingRoots
+        }
+      };
+    }
+
     return {
       verdict: "INSUFFICIENT_EVIDENCE",
       mutation_surface: "Frozen"
     };
   }
 
-  for (const eventId of receipt.replay_path) {
+  const replayReceiptInput = receipt as Receipt;
+
+  if (!pathExists(replayReceiptInput, lineage)) {
+    return {
+      verdict: "INSUFFICIENT_EVIDENCE",
+      mutation_surface: "Frozen"
+    };
+  }
+
+  for (const eventId of replayReceiptInput.replay_path) {
     const event = lineage.events[eventId];
 
     if (event.signatures.length === 0) {
@@ -89,8 +121,8 @@ export function validateReceipt(
     }
   }
 
-  const computed = replayReceipt(receipt, lineage);
-  const d = divergenceClass(computed, receipt.state_snapshot);
+  const computed = replayReceipt(replayReceiptInput, lineage);
+  const d = divergenceClass(computed, replayReceiptInput.state_snapshot);
   const surface = mutationSurface(d);
 
   if (d === "D0") {


### PR DESCRIPTION
Implements Issue #203: multi-observer contradiction receipts for constitutional-runtime.

Adds a narrow, deterministic contradiction surface:

- observer-report and contradiction schemas
- contradiction.valid.json fixture
- pure detectContradiction evaluator
- validator integration for CONSTITUTIONAL_CONTRADICTION / D3 / Frozen
- CLI exit code mapping for contradiction receipts
- reproduce.sh third control
- README documentation for contradiction receipts

Discipline preserved:

- Contradiction is evidence, not adjudication
- No fuzzy consensus
- No weighted observers
- No quorum mutation
- No settlement semantics
- v0.1 replay behavior remains untouched

Canon line: observer disagreement becomes constitutional state, not hidden operator context.

Closes #203.