### PR TITLE
Add lineage binding to contradiction receipts

### DIFF
--- a/constitutional-runtime/README.md
+++ b/constitutional-runtime/README.md
@@ -10,6 +10,14 @@ Minimal deterministic replay + divergence engine for constitutional membrane ver
 - **Lineage control** — `fixtures/lineage.valid.json`
 - **Schema surface** — `schema/*.schema.json` (strict, no additionalProperties)
 
+## Verified Constitutional Controls
+
+| Control | Fixture | Verdict | Divergence | Mutation Surface | Binding | Exit Code |
+|---------|---------|---------|------------|------------------|------------------|-----------|
+| Genesis Positive | `receipt.valid.json` | `MATCH` | `D0` | Mutable/Frozen | — | 0 |
+| Replay Divergence | `receipt.divergent.json` | `DIVERGENCE` | `D3` | Frozen | — | 2 |
+| Observer Contradiction | `contradiction.valid.json` | `CONSTITUTIONAL_CONTRADICTION` | `D3` | Frozen | `lineage_tip` | 2 |
+
 ## CLI Contract
 
 ```bash
@@ -34,12 +42,16 @@ This script:
 - Builds from source
 - Validates positive control (exit 0)
 - Validates divergent control (exit 2)
-- Validates contradiction control (exit 2)
+- Validates contradiction control with lineage binding (exit 2)
 - Fails hard on any drift
 
-## Contradiction Receipts
+## Contradiction Control (with lineage binding)
 
-Observer disagreement is constitutional state, not hidden operator context.
+Observer disagreement is now bound to specific replay context:
+
+- `lineage_tip` (required) — anchors contradiction to a concrete tip/root
+- `replay_path` (optional) — preserves genesis/empty-path compatibility
+- Enforced structurally: **No contradiction without lineage context**
 
 A contradiction receipt records multiple observer reports for the same event where observers report conflicting state roots. In v0.1, any exact root conflict is treated as D3 and freezes the mutation surface.
 
@@ -61,6 +73,6 @@ This layer is intentionally narrow:
 
 ## Status
 
-Branch: `constitutional-runtime-observer-reports`
+Branch: `constitutional-runtime-contradiction-lineage-binding`
 
 Membrane: structurally self-describing + externally reproducible

--- a/constitutional-runtime/fixtures/contradiction.valid.json
+++ b/constitutional-runtime/fixtures/contradiction.valid.json
@@ -1,5 +1,9 @@
 {
   "event_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "replay_path": [
+    "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
+  ],
+  "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
   "reports": [
     {
       "observer_id": "1111111111111111111111111111111111111111111111111111111111111111",

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -15,18 +15,18 @@ if [ "$code" -ne 2 ]; then
   exit 1
 fi
 
-# === CONTRADICTION CONTROL ===
-echo "→ Testing contradiction receipt (expect CONSTITUTIONAL_CONTRADICTION / exit 2)"
+# === CONTRADICTION CONTROL WITH LINEAGE BINDING ===
+echo "→ Testing contradiction receipt with lineage binding (expect CONSTITUTIONAL_CONTRADICTION / exit 2)"
 set +e
 node dist/cli.js fixtures/contradiction.valid.json fixtures/lineage.valid.json
 contradiction_code=$?
 set -e
 
 if [ "$contradiction_code" -ne 2 ]; then
-  echo "Wrong exit code for contradiction: $contradiction_code"
+  echo "Wrong exit code for lineage-bound contradiction: $contradiction_code"
   exit 1
 fi
 
-echo "✅ CONSTITUTIONAL_CONTRADICTION verified (exit 2)"
-echo "🎉 All three constitutional controls verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION)"
+echo "✅ CONSTITUTIONAL_CONTRADICTION with lineage_tip verified (exit 2)"
+echo "🎉 All three constitutional controls verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION with lineage binding)"
 echo "REPRODUCE_OK"

--- a/constitutional-runtime/schema/contradiction.schema.json
+++ b/constitutional-runtime/schema/contradiction.schema.json
@@ -1,10 +1,18 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ContradictionReceipt",
-  "description": "Multi-observer contradiction as first-class constitutional artifact",
+  "description": "Multi-observer contradiction bound to specific lineage context",
   "type": "object",
   "properties": {
     "event_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "replay_path": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+    },
+    "lineage_tip": {
       "type": "string",
       "pattern": "^[0-9a-f]{64}$"
     },
@@ -27,6 +35,7 @@
   },
   "required": [
     "event_id",
+    "lineage_tip",
     "reports",
     "verdict",
     "divergence",

--- a/constitutional-runtime/src/contradiction.ts
+++ b/constitutional-runtime/src/contradiction.ts
@@ -9,6 +9,8 @@ export interface ObserverReport {
 
 export interface ContradictionReceipt {
   event_id: Hash;
+  replay_path?: Hash[];
+  lineage_tip: Hash;
   reports: ObserverReport[];
   verdict: "CONSTITUTIONAL_CONTRADICTION";
   divergence: "D3";
@@ -16,24 +18,38 @@ export interface ContradictionReceipt {
 }
 
 export function detectContradiction(
-  reports: ObserverReport[]
+  receipt: ContradictionReceipt
 ): {
   isContradiction: boolean;
   divergence: DivergenceClass;
   uniqueObserverCount: number;
   conflictingRoots: Hash[];
+  isLineageBound: boolean;
 } {
-  if (reports.length < 2) {
+  const isLineageBound = typeof receipt.lineage_tip === "string" && receipt.lineage_tip.length === 64;
+
+  if (!isLineageBound) {
     return {
       isContradiction: false,
       divergence: "D0",
       uniqueObserverCount: 0,
-      conflictingRoots: []
+      conflictingRoots: [],
+      isLineageBound: false
+    };
+  }
+
+  if (receipt.reports.length < 2) {
+    return {
+      isContradiction: false,
+      divergence: "D0",
+      uniqueObserverCount: 0,
+      conflictingRoots: [],
+      isLineageBound: true
     };
   }
 
   const byObserver = new Map<Hash, ObserverReport>();
-  for (const report of reports) {
+  for (const report of receipt.reports) {
     byObserver.set(report.observer_id, report);
   }
 
@@ -45,7 +61,8 @@ export function detectContradiction(
       isContradiction: false,
       divergence: "D0",
       uniqueObserverCount,
-      conflictingRoots: []
+      conflictingRoots: [],
+      isLineageBound: true
     };
   }
 
@@ -60,7 +77,8 @@ export function detectContradiction(
     isContradiction: hasConflict,
     divergence: hasConflict ? "D3" : "D0",
     uniqueObserverCount,
-    conflictingRoots: hasConflict ? Array.from(rootSet) : []
+    conflictingRoots: hasConflict ? Array.from(rootSet) : [],
+    isLineageBound: true
   };
 }
 
@@ -71,6 +89,8 @@ export function isValidContradictionReceipt(
     receipt.verdict === "CONSTITUTIONAL_CONTRADICTION" &&
     receipt.divergence === "D3" &&
     receipt.mutation_surface === "Frozen" &&
+    typeof receipt.event_id === "string" &&
+    typeof receipt.lineage_tip === "string" &&
     Array.isArray(receipt.reports) &&
     receipt.reports.length >= 2
   );

--- a/constitutional-runtime/src/signature.ts
+++ b/constitutional-runtime/src/signature.ts
@@ -2,7 +2,7 @@ import * as ed from "@noble/ed25519";
 import { sha512 } from "@noble/hashes/sha2.js";
 import { hexToBytes } from "@noble/hashes/utils";
 
-ed.hashes.sha512 = sha512;
+ed.hashes.sha512 = sha512 as unknown as typeof ed.hashes.sha512;
 
 export function verifySignature(
   canonicalEventBytes: Uint8Array,

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -13,7 +13,7 @@ import {
   isValidContradictionReceipt
 } from "./contradiction.js";
 
-const Ajv = AjvModule;
+const Ajv = (AjvModule as unknown as { default?: typeof AjvModule }).default ?? AjvModule;
 const SCHEMA_DIR = join(process.cwd(), "schema");
 
 let lineageValidator: any = null;
@@ -134,7 +134,7 @@ export function validateReceipt(
       };
     }
 
-    const canonicalStr = canonicalizeForSignature(event as Record<string, unknown>);
+    const canonicalStr = canonicalizeForSignature(event as unknown as Record<string, unknown>);
     const canonicalBytes = new TextEncoder().encode(canonicalStr);
 
     for (const sig of event.signatures) {

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -1,7 +1,7 @@
 import { Lineage, Receipt, Verdict } from "./types.js";
 import { replayReceipt, pathExists } from "./replay.js";
 import { divergenceClass, mutationSurface } from "./divergence.js";
-import Ajv from "ajv";
+import AjvModule from "ajv";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { verifySignature } from "./signature.js";
@@ -13,6 +13,7 @@ import {
   isValidContradictionReceipt
 } from "./contradiction.js";
 
+const Ajv = AjvModule;
 const SCHEMA_DIR = join(process.cwd(), "schema");
 
 let lineageValidator: any = null;
@@ -133,7 +134,7 @@ export function validateReceipt(
       };
     }
 
-    const canonicalStr = canonicalizeForSignature(event);
+    const canonicalStr = canonicalizeForSignature(event as Record<string, unknown>);
     const canonicalBytes = new TextEncoder().encode(canonicalStr);
 
     for (const sig of event.signatures) {

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -1,7 +1,7 @@
 import { Lineage, Receipt, Verdict } from "./types.js";
 import { replayReceipt, pathExists } from "./replay.js";
 import { divergenceClass, mutationSurface } from "./divergence.js";
-import AjvModule from "ajv";
+import Ajv from "ajv/dist/ajv.js";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { verifySignature } from "./signature.js";
@@ -13,7 +13,6 @@ import {
   isValidContradictionReceipt
 } from "./contradiction.js";
 
-const Ajv = (AjvModule as unknown as { default?: typeof AjvModule }).default ?? AjvModule;
 const SCHEMA_DIR = join(process.cwd(), "schema");
 
 let lineageValidator: any = null;

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -68,8 +68,10 @@ export function validateReceipt(
   divergence?: string;
   mutation_surface?: "Mutable" | "Frozen";
   details?: {
-    uniqueObservers: number;
-    conflictingRoots: string[];
+    uniqueObservers?: number;
+    conflictingRoots?: string[];
+    lineage_tip?: string;
+    reason?: string;
   };
 } {
   if ("reports" in receipt) {
@@ -81,7 +83,17 @@ export function validateReceipt(
       };
     }
 
-    const result = detectContradiction(receipt.reports);
+    const result = detectContradiction(receipt);
+
+    if (!result.isLineageBound) {
+      return {
+        verdict: "INSUFFICIENT_EVIDENCE",
+        mutation_surface: "Frozen",
+        details: {
+          reason: "missing_lineage_binding"
+        }
+      };
+    }
 
     if (result.isContradiction) {
       return {
@@ -90,7 +102,8 @@ export function validateReceipt(
         mutation_surface: "Frozen",
         details: {
           uniqueObservers: result.uniqueObserverCount,
-          conflictingRoots: result.conflictingRoots
+          conflictingRoots: result.conflictingRoots,
+          lineage_tip: receipt.lineage_tip
         }
       };
     }


### PR DESCRIPTION
Adds lineage binding to constitutional-runtime contradiction receipts.

Summary:
- Require `lineage_tip` in contradiction schema
- Add optional `replay_path` for replay context
- Update contradiction fixture with lineage binding
- Update pure contradiction evaluator to require lineage binding
- Enforce lineage binding in validator path
- Update reproduce.sh and README surfaces
- Include TypeScript portability fixes for clean-clone reproduction

Verified externally in Google Cloud Shell:
- `npm install`
- `./reproduce.sh`
- `REPRODUCE_OK`

Invariants preserved:
- No contradiction without lineage context
- Existing MATCH / DIVERGENCE paths unchanged
- Contradiction remains evidence, not adjudication
- No fuzzy consensus
- No quorum mutation
- No settlement semantics

This keeps the membrane explicit: shape → schema family → lineage context → contradiction evidence → D3/Frozen.