### PR TITLE
Add observer attestation lineage and revoked-observer control

### DIFF
--- a/constitutional-runtime/README.md
+++ b/constitutional-runtime/README.md
@@ -7,16 +7,18 @@ Minimal deterministic replay + divergence engine for constitutional membrane ver
 - **Positive control** — `fixtures/receipt.valid.json` (genesis MATCH, empty replay path)
 - **Negative control** — `fixtures/receipt.divergent.json` (D3 divergence, deterministic mismatch)
 - **Contradiction control** — `fixtures/contradiction.valid.json` (multi-observer CONSTITUTIONAL_CONTRADICTION)
+- **Revoked observer control** — `fixtures/contradiction.revoked-observer.json` (claim rejected after observer activity filtering)
 - **Lineage control** — `fixtures/lineage.valid.json`
 - **Schema surface** — `schema/*.schema.json` (strict, no additionalProperties)
 
 ## Verified Constitutional Controls
 
-| Control | Fixture | Verdict | Divergence | Mutation Surface | Binding | Exit Code |
-|---------|---------|---------|------------|------------------|------------------|-----------|
-| Genesis Positive | `receipt.valid.json` | `MATCH` | `D0` | Mutable/Frozen | — | 0 |
-| Replay Divergence | `receipt.divergent.json` | `DIVERGENCE` | `D3` | Frozen | — | 2 |
-| Observer Contradiction | `contradiction.valid.json` | `CONSTITUTIONAL_CONTRADICTION` | `D3` | Frozen | `lineage_tip` | 2 |
+| Control | Fixture | Claimed Verdict | Evaluated Verdict | Active Observers | Divergence | Mutation Surface | Exit Code |
+|---------|---------|-----------------|-------------------|------------------|------------|------------------|-----------|
+| Genesis Positive | `receipt.valid.json` | `MATCH` | `MATCH` | — | `D0` | Mutable/Frozen | 0 |
+| Replay Divergence | `receipt.divergent.json` | `DIVERGENCE` | `DIVERGENCE` | — | `D3` | Frozen | 2 |
+| Observer Contradiction | `contradiction.valid.json` | `CONSTITUTIONAL_CONTRADICTION` | `CONSTITUTIONAL_CONTRADICTION` | >=2 | `D3` | Frozen | 2 |
+| Revoked Observer Negative | `contradiction.revoked-observer.json` | `CONSTITUTIONAL_CONTRADICTION` | `INSUFFICIENT_EVIDENCE` | 1 | `D0` | Frozen | 4 |
 
 ## CLI Contract
 
@@ -43,6 +45,7 @@ This script:
 - Validates positive control (exit 0)
 - Validates divergent control (exit 2)
 - Validates contradiction control with lineage binding (exit 2)
+- Validates revoked-observer negative control (exit 4)
 - Fails hard on any drift
 
 ## Contradiction Control (with lineage binding)
@@ -53,7 +56,18 @@ Observer disagreement is now bound to specific replay context:
 - `replay_path` (optional) — preserves genesis/empty-path compatibility
 - Enforced structurally: **No contradiction without lineage context**
 
-A contradiction receipt records multiple observer reports for the same event where observers report conflicting state roots. In v0.1, any exact root conflict is treated as D3 and freezes the mutation surface.
+A contradiction receipt records multiple observer reports for the same event where observers report conflicting state roots. In v0.1, any exact root conflict from enough active observers is treated as D3 and freezes the mutation surface.
+
+## Observer Activity Rules
+
+Observer activity is enforced at evaluation time:
+
+- Only `ACTIVE` observers whose `lineage_tip` matches the receipt contribute evidence
+- `REVOKED` observers are filtered out and treated as non-evidence
+- Contradiction requires at least 2 active observers with conflicting `observed_state_root` values
+- Receipts describe claims; the validator determines legitimacy
+
+Negative control: `contradiction.revoked-observer.json` claims `CONSTITUTIONAL_CONTRADICTION`, but contains only 1 active observer after filtering. The validator returns `INSUFFICIENT_EVIDENCE` with exit code 4.
 
 This layer is intentionally narrow:
 
@@ -73,6 +87,6 @@ This layer is intentionally narrow:
 
 ## Status
 
-Branch: `constitutional-runtime-contradiction-lineage-binding`
+Branch: `constitutional-runtime-observer-attestation-lineage`
 
 Membrane: structurally self-describing + externally reproducible

--- a/constitutional-runtime/README.md
+++ b/constitutional-runtime/README.md
@@ -8,17 +8,21 @@ Minimal deterministic replay + divergence engine for constitutional membrane ver
 - **Negative control** — `fixtures/receipt.divergent.json` (D3 divergence, deterministic mismatch)
 - **Contradiction control** — `fixtures/contradiction.valid.json` (multi-observer CONSTITUTIONAL_CONTRADICTION)
 - **Revoked observer control** — `fixtures/contradiction.revoked-observer.json` (claim rejected after observer activity filtering)
+- **Observer transition controls** — `fixtures/observer.active.json`, `fixtures/observer.revoked.json`, `fixtures/observer-transition.invalid-state.json`
 - **Lineage control** — `fixtures/lineage.valid.json`
 - **Schema surface** — `schema/*.schema.json` (strict, no additionalProperties)
 
 ## Verified Constitutional Controls
 
-| Control | Fixture | Claimed Verdict | Evaluated Verdict | Active Observers | Divergence | Mutation Surface | Exit Code |
-|---------|---------|-----------------|-------------------|------------------|------------|------------------|-----------|
-| Genesis Positive | `receipt.valid.json` | `MATCH` | `MATCH` | — | `D0` | Mutable/Frozen | 0 |
-| Replay Divergence | `receipt.divergent.json` | `DIVERGENCE` | `DIVERGENCE` | — | `D3` | Frozen | 2 |
-| Observer Contradiction | `contradiction.valid.json` | `CONSTITUTIONAL_CONTRADICTION` | `CONSTITUTIONAL_CONTRADICTION` | >=2 | `D3` | Frozen | 2 |
-| Revoked Observer Negative | `contradiction.revoked-observer.json` | `CONSTITUTIONAL_CONTRADICTION` | `INSUFFICIENT_EVIDENCE` | 1 | `D0` | Frozen | 4 |
+| Control Type | Fixture | Claimed Verdict | Evaluated Outcome | Key Property | Exit Code |
+|--------------|---------|-----------------|-------------------|--------------|-----------|
+| Genesis Positive | `receipt.valid.json` | `MATCH` | `MATCH` | Empty replay path | 0 |
+| Replay Divergence | `receipt.divergent.json` | `DIVERGENCE` | `DIVERGENCE` | Root mismatch | 2 |
+| Observer Contradiction | `contradiction.valid.json` | `CONSTITUTIONAL_CONTRADICTION` | `CONSTITUTIONAL_CONTRADICTION` | >=2 ACTIVE observers | 2 |
+| Revoked Observer Negative | `contradiction.revoked-observer.json` | `CONSTITUTIONAL_CONTRADICTION` | `INSUFFICIENT_EVIDENCE` | Only 1 ACTIVE after filtering | 4 |
+| Observer Transition Active | `observer.active.json` | `OBSERVER_TRANSITION` | Accepted by transition tests | ACTIVE -> ACTIVE baseline | — |
+| Observer Transition Revoke | `observer.revoked.json` | `OBSERVER_TRANSITION` | Accepted by transition tests | ACTIVE -> REVOKED explicit transition | — |
+| Observer Transition Invalid | `observer-transition.invalid-state.json` | `OBSERVER_TRANSITION` | Meaningless / no-op | ACTIVE -> ACTIVE self-transition | — |
 
 ## CLI Contract
 
@@ -44,6 +48,7 @@ This script:
 - Builds from source
 - Validates positive control (exit 0)
 - Validates divergent control (exit 2)
+- Runs observer transition evaluator tests
 - Validates contradiction control with lineage binding (exit 2)
 - Validates revoked-observer negative control (exit 4)
 - Fails hard on any drift
@@ -68,6 +73,16 @@ Observer activity is enforced at evaluation time:
 - Receipts describe claims; the validator determines legitimacy
 
 Negative control: `contradiction.revoked-observer.json` claims `CONSTITUTIONAL_CONTRADICTION`, but contains only 1 active observer after filtering. The validator returns `INSUFFICIENT_EVIDENCE` with exit code 4.
+
+## Observer Transition Rules
+
+Observer status changes are modeled as explicit `ObserverTransition` receipts:
+
+- `ACTIVE -> REVOKED` is a meaningful revocation event
+- Self-transitions such as `ACTIVE -> ACTIVE` are schema-valid but semantically no-op
+- `applyObserverTransition()` only applies when the observer identity and prior status match the transition
+- Future reports from REVOKED observers are filtered by observer activity checks
+- Receipts claim; the runtime validates
 
 This layer is intentionally narrow:
 

--- a/constitutional-runtime/fixtures/contradiction.revoked-observer.json
+++ b/constitutional-runtime/fixtures/contradiction.revoked-observer.json
@@ -1,0 +1,34 @@
+{
+  "event_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "replay_path": [
+    "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
+  ],
+  "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
+  "reports": [
+    {
+      "observer": {
+        "observer_id": "1111111111111111111111111111111111111111111111111111111111111111",
+        "public_key": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+        "status": "ACTIVE",
+        "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c"
+      },
+      "event_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+      "observed_state_root": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
+      "signature": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0"
+    },
+    {
+      "observer": {
+        "observer_id": "2222222222222222222222222222222222222222222222222222222222222222",
+        "public_key": "f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4",
+        "status": "REVOKED",
+        "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c"
+      },
+      "event_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+      "observed_state_root": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      "signature": "f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3"
+    }
+  ],
+  "verdict": "CONSTITUTIONAL_CONTRADICTION",
+  "divergence": "D3",
+  "mutation_surface": "Frozen"
+}

--- a/constitutional-runtime/fixtures/contradiction.valid.json
+++ b/constitutional-runtime/fixtures/contradiction.valid.json
@@ -6,13 +6,23 @@
   "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
   "reports": [
     {
-      "observer_id": "1111111111111111111111111111111111111111111111111111111111111111",
+      "observer": {
+        "observer_id": "1111111111111111111111111111111111111111111111111111111111111111",
+        "public_key": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+        "status": "ACTIVE",
+        "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c"
+      },
       "event_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
       "observed_state_root": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
       "signature": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0"
     },
     {
-      "observer_id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "observer": {
+        "observer_id": "2222222222222222222222222222222222222222222222222222222222222222",
+        "public_key": "f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4",
+        "status": "ACTIVE",
+        "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c"
+      },
       "event_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
       "observed_state_root": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
       "signature": "f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3"

--- a/constitutional-runtime/fixtures/degraded-observer-mode.fake-escalation.json
+++ b/constitutional-runtime/fixtures/degraded-observer-mode.fake-escalation.json
@@ -1,0 +1,14 @@
+{
+  "verdict": "DEGRADED_OBSERVER_MODE",
+  "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
+  "replay_path": [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  ],
+  "expectedObserverCount": 10,
+  "activeObserverCount": 9,
+  "missingObserverCount": 1,
+  "activeRatio": 0.9,
+  "confidenceLevel": "DEGRADED",
+  "mutation_surface": "Frozen"
+}

--- a/constitutional-runtime/fixtures/degraded-observer-mode.valid.json
+++ b/constitutional-runtime/fixtures/degraded-observer-mode.valid.json
@@ -1,0 +1,16 @@
+{
+  "verdict": "DEGRADED_OBSERVER_MODE",
+  "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
+  "replay_path": [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  ],
+  "expectedObserverCount": 10,
+  "activeObserverCount": 7,
+  "missingObserverCount": 3,
+  "activeRatio": 0.7,
+  "confidenceLevel": "DEGRADED",
+  "mutation_surface": "Frozen"
+}

--- a/constitutional-runtime/fixtures/observer-registry.valid.json
+++ b/constitutional-runtime/fixtures/observer-registry.valid.json
@@ -1,0 +1,32 @@
+{
+  "verdict": "OBSERVER_REGISTRY",
+  "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
+  "replay_path": [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  ],
+  "observers": [
+    {
+      "observer_id": "1111111111111111111111111111111111111111111111111111111111111111",
+      "public_key": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+      "status": "ACTIVE",
+      "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c"
+    },
+    {
+      "observer_id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "public_key": "f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f",
+      "status": "ACTIVE",
+      "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c"
+    },
+    {
+      "observer_id": "3333333333333333333333333333333333333333333333333333333333333333",
+      "public_key": "1111111111111111111111111111111111111111111111111111111111111111",
+      "status": "REVOKED",
+      "lineage_tip": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
+    }
+  ],
+  "totalActive": 2,
+  "totalRevoked": 1,
+  "mutation_surface": "Frozen"
+}

--- a/constitutional-runtime/fixtures/observer-transition.invalid-state.json
+++ b/constitutional-runtime/fixtures/observer-transition.invalid-state.json
@@ -1,0 +1,9 @@
+{
+  "observer_id": "3333333333333333333333333333333333333333333333333333333333333333",
+  "from_status": "ACTIVE",
+  "to_status": "ACTIVE",
+  "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
+  "reason": "Meaningless self-transition with no state change",
+  "verdict": "OBSERVER_TRANSITION",
+  "mutation_surface": "Frozen"
+}

--- a/constitutional-runtime/fixtures/observer.active.json
+++ b/constitutional-runtime/fixtures/observer.active.json
@@ -1,0 +1,9 @@
+{
+  "observer_id": "1111111111111111111111111111111111111111111111111111111111111111",
+  "from_status": "ACTIVE",
+  "to_status": "ACTIVE",
+  "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c",
+  "reason": "Genesis observer attestation",
+  "verdict": "OBSERVER_TRANSITION",
+  "mutation_surface": "Frozen"
+}

--- a/constitutional-runtime/fixtures/observer.revoked.json
+++ b/constitutional-runtime/fixtures/observer.revoked.json
@@ -1,0 +1,9 @@
+{
+  "observer_id": "2222222222222222222222222222222222222222222222222222222222222222",
+  "from_status": "ACTIVE",
+  "to_status": "REVOKED",
+  "lineage_tip": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "reason": "Explicit revocation at this lineage tip",
+  "verdict": "OBSERVER_TRANSITION",
+  "mutation_surface": "Frozen"
+}

--- a/constitutional-runtime/fixtures/observer.valid.json
+++ b/constitutional-runtime/fixtures/observer.valid.json
@@ -1,0 +1,6 @@
+{
+  "observer_id": "1111111111111111111111111111111111111111111111111111111111111111",
+  "public_key": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "status": "ACTIVE",
+  "lineage_tip": "ed8246be8f3a4b2c5d7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c"
+}

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -20,6 +20,11 @@ echo "→ Running observer transition evaluator tests"
 node dist/observer-transition.test.js
 echo "✅ ObserverTransition pure evaluator tests passed"
 
+# === OBSERVER REGISTRY TESTS ===
+echo "→ Running observer registry evaluator tests"
+node dist/observer-registry.test.js
+echo "✅ ObserverRegistry pure evaluator tests passed"
+
 # === OBSERVER TRANSITION LINEAGE CONSISTENCY OBSERVABILITY ===
 echo "→ Testing observer transition lineage consistency observability"
 transition_result=$(node dist/cli.js fixtures/observer.revoked.json fixtures/lineage.valid.json)
@@ -103,5 +108,5 @@ fi
 active_count=$(echo "$revoked_result" | grep -o '"activeObserverCount": [0-9]*' | cut -d':' -f2 | tr -d ' ' || echo "0")
 echo "✅ INSUFFICIENT_EVIDENCE verified (exit 4, activeObserverCount=${active_count})"
 
-echo "🎉 All controls and transition tests verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION + observer transitions)"
+echo "🎉 All controls and evaluator tests verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION + observer transitions + observer registry)"
 echo "REPRODUCE_OK"

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -15,6 +15,11 @@ if [ "$code" -ne 2 ]; then
   exit 1
 fi
 
+# === OBSERVER TRANSITION TESTS ===
+echo "→ Running observer transition evaluator tests"
+node dist/observer-transition.test.js
+echo "✅ ObserverTransition pure evaluator tests passed"
+
 # === CONTRADICTION CONTROL WITH LINEAGE BINDING ===
 echo "→ Testing contradiction receipt with lineage binding (expect CONSTITUTIONAL_CONTRADICTION / exit 2)"
 set +e
@@ -52,5 +57,5 @@ fi
 active_count=$(echo "$revoked_result" | grep -o '"activeObserverCount": [0-9]*' | cut -d':' -f2 | tr -d ' ' || echo "0")
 echo "✅ INSUFFICIENT_EVIDENCE verified (exit 4, activeObserverCount=${active_count})"
 
-echo "🎉 All controls verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION + REVOKED observer negative control)"
+echo "🎉 All controls and transition tests verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION + observer transitions)"
 echo "REPRODUCE_OK"

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -25,6 +25,11 @@ echo "→ Running observer registry evaluator tests"
 node dist/observer-registry.test.js
 echo "✅ ObserverRegistry pure evaluator tests passed"
 
+# === OBSERVER REGISTRY RESOLUTION TESTS ===
+echo "→ Running observer registry resolution evaluator tests"
+node dist/observer-registry-resolution.test.js
+echo "✅ ObserverRegistry resolution tests passed"
+
 # === OBSERVER REGISTRY OBSERVABILITY ===
 echo "→ Testing observer-registry observability in validator"
 registry_result=$(node dist/cli.js fixtures/observer-registry.valid.json fixtures/lineage.valid.json)

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -25,6 +25,26 @@ echo "→ Running observer registry evaluator tests"
 node dist/observer-registry.test.js
 echo "✅ ObserverRegistry pure evaluator tests passed"
 
+# === OBSERVER REGISTRY OBSERVABILITY ===
+echo "→ Testing observer-registry observability in validator"
+registry_result=$(node dist/cli.js fixtures/observer-registry.valid.json fixtures/lineage.valid.json)
+registry_total_active=$(echo "$registry_result" | grep -o '"totalActive": [0-9]*' | head -n 1 | cut -d':' -f2 | tr -d ' ' || true)
+registry_total_revoked=$(echo "$registry_result" | grep -o '"totalRevoked": [0-9]*' | head -n 1 | cut -d':' -f2 | tr -d ' ' || true)
+registry_observer_count=$(echo "$registry_result" | grep -o '"observerCount": [0-9]*' | head -n 1 | cut -d':' -f2 | tr -d ' ' || true)
+registry_replay_len=$(echo "$registry_result" | grep -o '"replayPathLength": [0-9]*' | head -n 1 | cut -d':' -f2 | tr -d ' ' || true)
+registry_consistent_totals=$(echo "$registry_result" | grep -o '"hasConsistentTotals": true' | cut -d':' -f2 | tr -d ' ' || true)
+
+if [ "$registry_total_active" = "2" ] && [ "$registry_total_revoked" = "1" ] && [ "$registry_observer_count" = "3" ] && [ "$registry_replay_len" = "3" ] && [ "$registry_consistent_totals" = "true" ]; then
+  echo "✅ Observer registry observability verified"
+  echo "   totalActive=${registry_total_active}, totalRevoked=${registry_total_revoked}, observerCount=${registry_observer_count}"
+  echo "   replayPathLength=${registry_replay_len}, hasConsistentTotals=true"
+  echo "   visible context ≠ authoritative settlement"
+else
+  echo "❌ Registry observability assertion failed"
+  echo "$registry_result"
+  exit 1
+fi
+
 # === OBSERVER TRANSITION LINEAGE CONSISTENCY OBSERVABILITY ===
 echo "→ Testing observer transition lineage consistency observability"
 transition_result=$(node dist/cli.js fixtures/observer.revoked.json fixtures/lineage.valid.json)

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -20,6 +20,20 @@ echo "→ Running observer transition evaluator tests"
 node dist/observer-transition.test.js
 echo "✅ ObserverTransition pure evaluator tests passed"
 
+# === OBSERVER TRANSITION LINEAGE CONSISTENCY OBSERVABILITY ===
+echo "→ Testing observer transition lineage consistency observability"
+transition_result=$(node dist/cli.js fixtures/observer.revoked.json fixtures/lineage.valid.json)
+transition_reason=$(echo "$transition_result" | grep -o '"reason": "observer_context_not_available"' | cut -d'"' -f4 || true)
+transition_consistency=$(echo "$transition_result" | grep -o '"isConsistent": null' | cut -d':' -f2 | tr -d ' ' || true)
+
+if [ "$transition_reason" = "observer_context_not_available" ] && [ "$transition_consistency" = "null" ]; then
+  echo "✅ Lineage consistency uncertainty explicitly surfaced (isConsistent=null)"
+else
+  echo "❌ Lineage consistency observability failed"
+  echo "$transition_result"
+  exit 1
+fi
+
 # === CONTRADICTION CONTROL WITH LINEAGE BINDING ===
 echo "→ Testing contradiction receipt with lineage binding (expect CONSTITUTIONAL_CONTRADICTION / exit 2)"
 set +e

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -28,5 +28,29 @@ if [ "$contradiction_code" -ne 2 ]; then
 fi
 
 echo "✅ CONSTITUTIONAL_CONTRADICTION with lineage_tip verified (exit 2)"
-echo "🎉 All three constitutional controls verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION with lineage binding)"
+
+# === REVOKED OBSERVER NEGATIVE CONTROL ===
+echo "→ Testing contradiction with REVOKED observer (expect INSUFFICIENT_EVIDENCE / exit 4)"
+set +e
+revoked_result=$(node dist/cli.js fixtures/contradiction.revoked-observer.json fixtures/lineage.valid.json)
+revoked_code=$?
+set -e
+
+if [ "$revoked_code" -ne 4 ]; then
+  echo "Wrong exit code for revoked-observer case: $revoked_code (expected 4)"
+  echo "$revoked_result"
+  exit 1
+fi
+
+revoked_verdict=$(echo "$revoked_result" | grep -o '"verdict": "[^"]*"' | cut -d'"' -f4)
+if [ "$revoked_verdict" != "INSUFFICIENT_EVIDENCE" ]; then
+  echo "Wrong verdict: $revoked_verdict (expected INSUFFICIENT_EVIDENCE)"
+  echo "$revoked_result"
+  exit 1
+fi
+
+active_count=$(echo "$revoked_result" | grep -o '"activeObserverCount": [0-9]*' | cut -d':' -f2 | tr -d ' ' || echo "0")
+echo "✅ INSUFFICIENT_EVIDENCE verified (exit 4, activeObserverCount=${active_count})"
+
+echo "🎉 All controls verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION + REVOKED observer negative control)"
 echo "REPRODUCE_OK"

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -34,6 +34,19 @@ else
   exit 1
 fi
 
+# === OBSERVER TRANSITION REPLAY-PATH VISIBILITY ===
+echo "→ Testing replay-path visibility in observer transition"
+transition_replay_path_length=$(echo "$transition_result" | grep -o '"replayPathLength": [0-9]*' | head -n 1 | cut -d':' -f2 | tr -d ' ' || true)
+
+if [ -n "$transition_replay_path_length" ]; then
+  echo "✅ Replay-path visibility confirmed (replayPathLength=${transition_replay_path_length})"
+  echo "   Context is visible, not enforced"
+else
+  echo "❌ Replay-path visibility failed"
+  echo "$transition_result"
+  exit 1
+fi
+
 # === CONTRADICTION CONTROL WITH LINEAGE BINDING ===
 echo "→ Testing contradiction receipt with lineage binding (expect CONSTITUTIONAL_CONTRADICTION / exit 2)"
 set +e

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -25,9 +25,12 @@ echo "→ Testing observer transition lineage consistency observability"
 transition_result=$(node dist/cli.js fixtures/observer.revoked.json fixtures/lineage.valid.json)
 transition_reason=$(echo "$transition_result" | grep -o '"reason": "observer_context_not_available"' | cut -d'"' -f4 || true)
 transition_consistency=$(echo "$transition_result" | grep -o '"isConsistent": null' | cut -d':' -f2 | tr -d ' ' || true)
+transition_valid_binding=$(echo "$transition_result" | grep -o '"hasValidLineageBinding": true' | cut -d':' -f2 | tr -d ' ' || true)
 
-if [ "$transition_reason" = "observer_context_not_available" ] && [ "$transition_consistency" = "null" ]; then
-  echo "✅ Lineage consistency uncertainty explicitly surfaced (isConsistent=null)"
+if [ "$transition_reason" = "observer_context_not_available" ] && [ "$transition_consistency" = "null" ] && [ "$transition_valid_binding" = "true" ]; then
+  echo "✅ Lineage binding + explicit uncertainty verified"
+  echo "   hasValidLineageBinding=true (structural binding enforced)"
+  echo "   isConsistent=null (observer context unavailable; unknown ≠ true)"
 else
   echo "❌ Lineage consistency observability failed"
   echo "$transition_result"

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -30,6 +30,11 @@ echo "→ Running observer registry resolution evaluator tests"
 node dist/observer-registry-resolution.test.js
 echo "✅ ObserverRegistry resolution tests passed"
 
+# === DEGRADED OBSERVER MODE TESTS ===
+echo "→ Running degraded observer mode evaluator tests"
+node dist/degraded-mode.test.js
+echo "✅ DegradedMode pure evaluator tests passed"
+
 # === OBSERVER REGISTRY OBSERVABILITY ===
 echo "→ Testing observer-registry observability in validator"
 registry_result=$(node dist/cli.js fixtures/observer-registry.valid.json fixtures/lineage.valid.json)
@@ -133,5 +138,5 @@ fi
 active_count=$(echo "$revoked_result" | grep -o '"activeObserverCount": [0-9]*' | cut -d':' -f2 | tr -d ' ' || echo "0")
 echo "✅ INSUFFICIENT_EVIDENCE verified (exit 4, activeObserverCount=${active_count})"
 
-echo "🎉 All controls and evaluator tests verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION + observer transitions + observer registry)"
+echo "🎉 All controls and evaluator tests verified (MATCH / DIVERGENCE / CONSTITUTIONAL_CONTRADICTION + observer transitions + observer registry + degraded observer mode)"
 echo "REPRODUCE_OK"

--- a/constitutional-runtime/reproduce.sh
+++ b/constitutional-runtime/reproduce.sh
@@ -23,16 +23,32 @@ echo "✅ ObserverTransition pure evaluator tests passed"
 # === OBSERVER TRANSITION LINEAGE CONSISTENCY OBSERVABILITY ===
 echo "→ Testing observer transition lineage consistency observability"
 transition_result=$(node dist/cli.js fixtures/observer.revoked.json fixtures/lineage.valid.json)
-transition_reason=$(echo "$transition_result" | grep -o '"reason": "observer_context_not_available"' | cut -d'"' -f4 || true)
-transition_consistency=$(echo "$transition_result" | grep -o '"isConsistent": null' | cut -d':' -f2 | tr -d ' ' || true)
+transition_reason=$(echo "$transition_result" | grep -o '"reason": "observer_resolved_with_placeholder_key"' | cut -d'"' -f4 || true)
+transition_consistency=$(echo "$transition_result" | grep -o '"isConsistent": true' | cut -d':' -f2 | tr -d ' ' || true)
 transition_valid_binding=$(echo "$transition_result" | grep -o '"hasValidLineageBinding": true' | cut -d':' -f2 | tr -d ' ' || true)
 
-if [ "$transition_reason" = "observer_context_not_available" ] && [ "$transition_consistency" = "null" ] && [ "$transition_valid_binding" = "true" ]; then
-  echo "✅ Lineage binding + explicit uncertainty verified"
+if [ "$transition_reason" = "observer_resolved_with_placeholder_key" ] && [ "$transition_consistency" = "true" ] && [ "$transition_valid_binding" = "true" ]; then
+  echo "✅ Lineage binding + placeholder observer resolution verified"
   echo "   hasValidLineageBinding=true (structural binding enforced)"
-  echo "   isConsistent=null (observer context unavailable; unknown ≠ true)"
+  echo "   isConsistent=true (synthetic placeholder observer; not authoritative registry state)"
 else
   echo "❌ Lineage consistency observability failed"
+  echo "$transition_result"
+  exit 1
+fi
+
+# === RESOLVED OBSERVER OBSERVABILITY ===
+echo "→ Testing resolvedObserver visibility in validator"
+resolved_observer_available=$(echo "$transition_result" | grep -o '"resolvedObserverAvailable": true' | cut -d':' -f2 | tr -d ' ' || true)
+placeholder_source=$(echo "$transition_result" | grep -o '"public_key_source": "placeholder"' | cut -d'"' -f4 || true)
+
+if [ "$resolved_observer_available" = "true" ] && [ "$placeholder_source" = "placeholder" ]; then
+  echo "✅ resolvedObserver visibility confirmed"
+  echo "   resolvedObserverAvailable=true"
+  echo "   public_key_source=placeholder (synthetic)"
+  echo "   Context is visible (no registry authority yet)"
+else
+  echo "❌ resolvedObserver visibility assertion failed"
   echo "$transition_result"
   exit 1
 fi

--- a/constitutional-runtime/schema/degraded-observer-mode.schema.json
+++ b/constitutional-runtime/schema/degraded-observer-mode.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DegradedObserverMode",
+  "description": "Explicit degraded observer surface signal that does not grant expanded authority",
+  "type": "object",
+  "properties": {
+    "verdict": {
+      "const": "DEGRADED_OBSERVER_MODE"
+    },
+    "lineage_tip": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "replay_path": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    },
+    "expectedObserverCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "activeObserverCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "missingObserverCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "activeRatio": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "confidenceLevel": {
+      "enum": ["HEALTHY", "DEGRADED", "INSUFFICIENT"]
+    },
+    "mutation_surface": {
+      "const": "Frozen"
+    }
+  },
+  "required": [
+    "verdict",
+    "lineage_tip",
+    "expectedObserverCount",
+    "activeObserverCount",
+    "missingObserverCount",
+    "activeRatio",
+    "confidenceLevel",
+    "mutation_surface"
+  ],
+  "additionalProperties": false
+}

--- a/constitutional-runtime/schema/observer-registry.schema.json
+++ b/constitutional-runtime/schema/observer-registry.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ObserverRegistry",
+  "description": "Resolved observer registry snapshot bound to replay context",
+  "type": "object",
+  "properties": {
+    "verdict": {
+      "const": "OBSERVER_REGISTRY"
+    },
+    "lineage_tip": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "replay_path": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    },
+    "observers": {
+      "type": "array",
+      "items": {
+        "$ref": "observer.schema.json"
+      }
+    },
+    "totalActive": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "totalRevoked": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "mutation_surface": {
+      "const": "Frozen"
+    }
+  },
+  "required": [
+    "verdict",
+    "lineage_tip",
+    "replay_path",
+    "observers",
+    "totalActive",
+    "totalRevoked",
+    "mutation_surface"
+  ],
+  "additionalProperties": false
+}

--- a/constitutional-runtime/schema/observer-report.schema.json
+++ b/constitutional-runtime/schema/observer-report.schema.json
@@ -1,13 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ObserverReport",
-  "description": "Single cryptographically signed observation for contradiction detection",
+  "description": "Signed report from a constitutional Observer",
   "type": "object",
   "properties": {
-    "observer_id": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$",
-      "description": "Raw 32-byte observer public key in hex"
+    "observer": {
+      "$ref": "observer.schema.json"
     },
     "event_id": {
       "type": "string",
@@ -19,12 +17,11 @@
     },
     "signature": {
       "type": "string",
-      "pattern": "^[0-9a-f]{128}$",
-      "description": "Ed25519 64-byte signature in hex"
+      "pattern": "^[0-9a-f]{128}$"
     }
   },
   "required": [
-    "observer_id",
+    "observer",
     "event_id",
     "observed_state_root",
     "signature"

--- a/constitutional-runtime/schema/observer-transition.schema.json
+++ b/constitutional-runtime/schema/observer-transition.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ObserverTransition",
-  "description": "Explicit status transition receipt for observer attestation lineage",
+  "description": "Explicit observer status transition bound to replay context",
   "type": "object",
   "properties": {
     "observer_id": {
@@ -13,6 +13,13 @@
     },
     "to_status": {
       "enum": ["ACTIVE", "REVOKED"]
+    },
+    "replay_path": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
     },
     "lineage_tip": {
       "type": "string",

--- a/constitutional-runtime/schema/observer-transition.schema.json
+++ b/constitutional-runtime/schema/observer-transition.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ObserverTransition",
+  "description": "Explicit status transition receipt for observer attestation lineage",
+  "type": "object",
+  "properties": {
+    "observer_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "from_status": {
+      "enum": ["ACTIVE", "REVOKED"]
+    },
+    "to_status": {
+      "enum": ["ACTIVE", "REVOKED"]
+    },
+    "lineage_tip": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "reason": {
+      "type": "string",
+      "maxLength": 256
+    },
+    "verdict": {
+      "const": "OBSERVER_TRANSITION"
+    },
+    "mutation_surface": {
+      "const": "Frozen"
+    }
+  },
+  "required": [
+    "observer_id",
+    "from_status",
+    "to_status",
+    "lineage_tip",
+    "verdict",
+    "mutation_surface"
+  ],
+  "additionalProperties": false
+}

--- a/constitutional-runtime/schema/observer.schema.json
+++ b/constitutional-runtime/schema/observer.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Observer",
+  "type": "object",
+  "properties": {
+    "observer_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "public_key": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "status": {
+      "enum": ["ACTIVE", "REVOKED"]
+    },
+    "lineage_tip": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  },
+  "required": ["observer_id", "public_key", "status", "lineage_tip"],
+  "additionalProperties": false
+}

--- a/constitutional-runtime/src/contradiction.ts
+++ b/constitutional-runtime/src/contradiction.ts
@@ -1,7 +1,8 @@
 import { DivergenceClass, Hash } from "./types.js";
+import { Observer, isActiveObserver } from "./observer.js";
 
 export interface ObserverReport {
-  observer_id: Hash;
+  observer: Observer;
   event_id: Hash;
   observed_state_root: Hash;
   signature: string;
@@ -22,9 +23,10 @@ export function detectContradiction(
 ): {
   isContradiction: boolean;
   divergence: DivergenceClass;
-  uniqueObserverCount: number;
+  uniqueActiveObservers: number;
   conflictingRoots: Hash[];
   isLineageBound: boolean;
+  activeObserverCount: number;
 } {
   const isLineageBound = typeof receipt.lineage_tip === "string" && receipt.lineage_tip.length === 64;
 
@@ -32,37 +34,45 @@ export function detectContradiction(
     return {
       isContradiction: false,
       divergence: "D0",
-      uniqueObserverCount: 0,
+      uniqueActiveObservers: 0,
       conflictingRoots: [],
-      isLineageBound: false
+      isLineageBound: false,
+      activeObserverCount: 0
     };
   }
 
-  if (receipt.reports.length < 2) {
+  const activeReports = receipt.reports.filter((report) =>
+    isActiveObserver(report.observer, receipt.lineage_tip)
+  );
+  const activeObserverCount = activeReports.length;
+
+  if (activeObserverCount < 2) {
     return {
       isContradiction: false,
       divergence: "D0",
-      uniqueObserverCount: 0,
+      uniqueActiveObservers: 0,
       conflictingRoots: [],
-      isLineageBound: true
+      isLineageBound: true,
+      activeObserverCount
     };
   }
 
   const byObserver = new Map<Hash, ObserverReport>();
-  for (const report of receipt.reports) {
-    byObserver.set(report.observer_id, report);
+  for (const report of activeReports) {
+    byObserver.set(report.observer.observer_id, report);
   }
 
   const uniqueReports = Array.from(byObserver.values());
-  const uniqueObserverCount = uniqueReports.length;
+  const uniqueActiveObservers = uniqueReports.length;
 
-  if (uniqueObserverCount < 2) {
+  if (uniqueActiveObservers < 2) {
     return {
       isContradiction: false,
       divergence: "D0",
-      uniqueObserverCount,
+      uniqueActiveObservers,
       conflictingRoots: [],
-      isLineageBound: true
+      isLineageBound: true,
+      activeObserverCount
     };
   }
 
@@ -76,9 +86,10 @@ export function detectContradiction(
   return {
     isContradiction: hasConflict,
     divergence: hasConflict ? "D3" : "D0",
-    uniqueObserverCount,
+    uniqueActiveObservers,
     conflictingRoots: hasConflict ? Array.from(rootSet) : [],
-    isLineageBound: true
+    isLineageBound: true,
+    activeObserverCount
   };
 }
 

--- a/constitutional-runtime/src/degraded-mode.test.ts
+++ b/constitutional-runtime/src/degraded-mode.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs";
+import {
+  DegradedObserverMode,
+  assessObserverHealth,
+  calculateActiveRatio,
+  determineConfidenceLevel,
+  isFakeEscalationSignal,
+  isValidDegradedObserverMode
+} from "./degraded-mode.js";
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function runDegradedModeTests(): void {
+  console.log("Running DegradedMode pure evaluator tests...");
+
+  const validDegraded = readJson<DegradedObserverMode>("fixtures/degraded-observer-mode.valid.json");
+  const fakeEscalation = readJson<DegradedObserverMode>("fixtures/degraded-observer-mode.fake-escalation.json");
+
+  assert(
+    isValidDegradedObserverMode(validDegraded) &&
+      isValidDegradedObserverMode(fakeEscalation),
+    "isValidDegradedObserverMode() must accept valid fixtures"
+  );
+  console.log("OK isValidDegradedObserverMode accepts valid fixtures");
+
+  assert(
+    calculateActiveRatio(7, 10) === 0.7 &&
+      calculateActiveRatio(9, 10) === 0.9 &&
+      calculateActiveRatio(0, 10) === 0,
+    "calculateActiveRatio() must compute expected ratios"
+  );
+  console.log("OK calculateActiveRatio computes expected ratios");
+
+  assert(
+    determineConfidenceLevel(0.95) === "HEALTHY" &&
+      determineConfidenceLevel(0.7) === "DEGRADED" &&
+      determineConfidenceLevel(0.4) === "INSUFFICIENT",
+    "determineConfidenceLevel() must apply expected thresholds"
+  );
+  console.log("OK determineConfidenceLevel applies expected thresholds");
+
+  const health = assessObserverHealth(10, 7);
+  assert(
+    health.activeRatio === 0.7 &&
+      health.confidenceLevel === "DEGRADED" &&
+      health.missingObserverCount === 3 &&
+      health.isDegraded === true,
+    "assessObserverHealth() must return expected degraded assessment"
+  );
+  console.log("OK assessObserverHealth returns expected degraded assessment");
+
+  assert(
+    !isFakeEscalationSignal(validDegraded) &&
+      isFakeEscalationSignal(fakeEscalation),
+    "isFakeEscalationSignal() must flag healthy-surface degraded claims"
+  );
+  console.log("OK isFakeEscalationSignal flags fake escalation signal");
+
+  const zeroActive = assessObserverHealth(5, 0);
+  assert(
+    zeroActive.activeRatio === 0 &&
+      zeroActive.confidenceLevel === "INSUFFICIENT" &&
+      zeroActive.missingObserverCount === 5,
+    "zero active observers must be insufficient"
+  );
+  console.log("OK zero active observers handled as INSUFFICIENT");
+
+  const zeroExpected = assessObserverHealth(0, 0);
+  assert(
+    zeroExpected.activeRatio === 0 &&
+      zeroExpected.confidenceLevel === "INSUFFICIENT" &&
+      zeroExpected.missingObserverCount === 0,
+    "zero expected observers must not create authority"
+  );
+  console.log("OK zero expected observers handled without authority expansion");
+
+  console.log("DegradedMode tests: 7/7 passed");
+}
+
+try {
+  runDegradedModeTests();
+} catch (error) {
+  console.error("DegradedMode tests failed:", error);
+  process.exit(1);
+}

--- a/constitutional-runtime/src/degraded-mode.ts
+++ b/constitutional-runtime/src/degraded-mode.ts
@@ -1,0 +1,90 @@
+import { Hash } from "./types.js";
+
+export type ConfidenceLevel = "HEALTHY" | "DEGRADED" | "INSUFFICIENT";
+
+export interface DegradedObserverMode {
+  verdict: "DEGRADED_OBSERVER_MODE";
+  lineage_tip: Hash;
+  replay_path?: Hash[];
+  expectedObserverCount: number;
+  activeObserverCount: number;
+  missingObserverCount: number;
+  activeRatio: number;
+  confidenceLevel: ConfidenceLevel;
+  mutation_surface: "Frozen";
+}
+
+export interface ObserverHealthAssessment {
+  activeRatio: number;
+  confidenceLevel: ConfidenceLevel;
+  missingObserverCount: number;
+  isDegraded: boolean;
+}
+
+export function calculateActiveRatio(
+  activeObserverCount: number,
+  expectedObserverCount: number
+): number {
+  if (expectedObserverCount <= 0) return 0;
+  return Math.min(1, Math.max(0, activeObserverCount / expectedObserverCount));
+}
+
+export function determineConfidenceLevel(activeRatio: number): ConfidenceLevel {
+  if (activeRatio >= 0.9) return "HEALTHY";
+  if (activeRatio >= 0.5) return "DEGRADED";
+  return "INSUFFICIENT";
+}
+
+export function assessObserverHealth(
+  expectedObserverCount: number,
+  activeObserverCount: number
+): ObserverHealthAssessment {
+  const activeRatio = calculateActiveRatio(activeObserverCount, expectedObserverCount);
+  const confidenceLevel = determineConfidenceLevel(activeRatio);
+
+  return {
+    activeRatio,
+    confidenceLevel,
+    missingObserverCount: Math.max(0, expectedObserverCount - activeObserverCount),
+    isDegraded: confidenceLevel !== "HEALTHY"
+  };
+}
+
+export function isValidDegradedObserverMode(
+  mode: Partial<DegradedObserverMode>
+): boolean {
+  if (
+    mode.verdict !== "DEGRADED_OBSERVER_MODE" ||
+    typeof mode.lineage_tip !== "string" ||
+    mode.lineage_tip.length !== 64 ||
+    (mode.replay_path !== undefined &&
+      (!Array.isArray(mode.replay_path) ||
+        !mode.replay_path.every((id) => typeof id === "string" && id.length === 64))) ||
+    typeof mode.expectedObserverCount !== "number" ||
+    typeof mode.activeObserverCount !== "number" ||
+    typeof mode.missingObserverCount !== "number" ||
+    typeof mode.activeRatio !== "number" ||
+    (mode.confidenceLevel !== "HEALTHY" &&
+      mode.confidenceLevel !== "DEGRADED" &&
+      mode.confidenceLevel !== "INSUFFICIENT") ||
+    mode.mutation_surface !== "Frozen"
+  ) {
+    return false;
+  }
+
+  const assessed = assessObserverHealth(
+    mode.expectedObserverCount,
+    mode.activeObserverCount
+  );
+
+  return (
+    mode.missingObserverCount === assessed.missingObserverCount &&
+    Math.abs(mode.activeRatio - assessed.activeRatio) < Number.EPSILON &&
+    mode.confidenceLevel === assessed.confidenceLevel
+  );
+}
+
+export function isFakeEscalationSignal(mode: DegradedObserverMode): boolean {
+  if (!isValidDegradedObserverMode(mode)) return false;
+  return mode.confidenceLevel === "DEGRADED" && mode.activeRatio >= 0.85;
+}

--- a/constitutional-runtime/src/observer-registry-resolution.test.ts
+++ b/constitutional-runtime/src/observer-registry-resolution.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { ObserverRegistry } from "./observer-registry.js";
+import { ObserverTransition } from "./observer-transition.js";
+import {
+  resolveObserverWithRegistry,
+  resolveObserversWithRegistry,
+  resolveRegistryWithTransitions
+} from "./observer-registry-resolution.js";
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function runObserverRegistryResolutionTests(): void {
+  console.log("Running ObserverRegistry resolution tests...");
+
+  const registry = readJson<ObserverRegistry>("fixtures/observer-registry.valid.json");
+  const revokedTransition = readJson<ObserverTransition>("fixtures/observer.revoked.json");
+
+  const firstObserverId = "1111111111111111111111111111111111111111111111111111111111111111";
+  const secondObserverId = "2222222222222222222222222222222222222222222222222222222222222222";
+  const thirdObserverId = "3333333333333333333333333333333333333333333333333333333333333333";
+  const unknownObserverId = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+  const resolvedFirst = resolveObserverWithRegistry(registry, firstObserverId, []);
+  assert(
+    resolvedFirst.source === "registry" &&
+      resolvedFirst.observer !== null &&
+      resolvedFirst.observer.status === "ACTIVE" &&
+      resolvedFirst.appliedTransitionCount === 0,
+    "resolveObserverWithRegistry() must return active observer from registry"
+  );
+  console.log("OK resolveObserverWithRegistry returns observer from registry snapshot");
+
+  const resolvedSecondWithTransition = resolveObserverWithRegistry(registry, secondObserverId, [
+    revokedTransition
+  ]);
+  assert(
+    resolvedSecondWithTransition.source === "registry" &&
+      resolvedSecondWithTransition.observer !== null &&
+      resolvedSecondWithTransition.observer.status === "REVOKED" &&
+      resolvedSecondWithTransition.appliedTransitionCount === 1,
+    "resolveObserverWithRegistry() must apply valid matching transition"
+  );
+  console.log("OK resolveObserverWithRegistry applies valid matching transition");
+
+  const resolvedMany = resolveObserversWithRegistry(registry, [firstObserverId, thirdObserverId], []);
+  assert(
+    resolvedMany.size === 2 &&
+      resolvedMany.get(thirdObserverId)?.observer?.status === "REVOKED",
+    "resolveObserversWithRegistry() must resolve multiple observers"
+  );
+  console.log("OK resolveObserversWithRegistry resolves multiple observers");
+
+  const updatedRegistry = resolveRegistryWithTransitions(registry, [revokedTransition]);
+  assert(
+    updatedRegistry.totalActive === 1 && updatedRegistry.totalRevoked === 2,
+    `resolveRegistryWithTransitions() must update totals after transition, got active=${updatedRegistry.totalActive}, revoked=${updatedRegistry.totalRevoked}`
+  );
+  console.log("OK resolveRegistryWithTransitions updates snapshot totals");
+
+  const unknown = resolveObserverWithRegistry(registry, unknownObserverId, []);
+  assert(
+    unknown.source === "missing" && unknown.observer === null,
+    "resolveObserverWithRegistry() must return missing/null for unknown observer"
+  );
+  console.log("OK resolveObserverWithRegistry handles unknown observer");
+
+  console.log("ObserverRegistry resolution tests: 5/5 passed");
+}
+
+try {
+  runObserverRegistryResolutionTests();
+} catch (error) {
+  console.error("ObserverRegistry resolution tests failed:", error);
+  process.exit(1);
+}

--- a/constitutional-runtime/src/observer-registry-resolution.ts
+++ b/constitutional-runtime/src/observer-registry-resolution.ts
@@ -1,0 +1,101 @@
+import { Hash } from "./types.js";
+import { Observer } from "./observer.js";
+import {
+  ObserverRegistry,
+  hasConsistentObserverTotals,
+  isValidObserverRegistry,
+  resolveObserverFromRegistry
+} from "./observer-registry.js";
+import {
+  ObserverTransition,
+  applyObserverTransition,
+  isValidObserverTransitionForObserver
+} from "./observer-transition.js";
+
+export interface RegistryBackedResolution {
+  observer: Observer | null;
+  source: "registry" | "missing";
+  appliedTransitionCount: number;
+  registryLineageTip: Hash;
+}
+
+export function resolveObserverWithRegistry(
+  registry: ObserverRegistry,
+  observerId: Hash,
+  knownTransitions: ObserverTransition[] = []
+): RegistryBackedResolution {
+  if (!isValidObserverRegistry(registry) || !hasConsistentObserverTotals(registry)) {
+    return {
+      observer: null,
+      source: "missing",
+      appliedTransitionCount: 0,
+      registryLineageTip: registry.lineage_tip
+    };
+  }
+
+  const registryObserver = resolveObserverFromRegistry(registry, observerId);
+  if (!registryObserver) {
+    return {
+      observer: null,
+      source: "missing",
+      appliedTransitionCount: 0,
+      registryLineageTip: registry.lineage_tip
+    };
+  }
+
+  let current = registryObserver;
+  let appliedTransitionCount = 0;
+
+  for (const transition of knownTransitions) {
+    if (!isValidObserverTransitionForObserver(current, transition)) continue;
+    current = applyObserverTransition(current, transition);
+    appliedTransitionCount += 1;
+  }
+
+  return {
+    observer: current,
+    source: "registry",
+    appliedTransitionCount,
+    registryLineageTip: registry.lineage_tip
+  };
+}
+
+export function resolveObserversWithRegistry(
+  registry: ObserverRegistry,
+  observerIds: Hash[],
+  knownTransitions: ObserverTransition[] = []
+): Map<Hash, RegistryBackedResolution> {
+  const results = new Map<Hash, RegistryBackedResolution>();
+
+  for (const observerId of observerIds) {
+    results.set(
+      observerId,
+      resolveObserverWithRegistry(registry, observerId, knownTransitions)
+    );
+  }
+
+  return results;
+}
+
+export function resolveRegistryWithTransitions(
+  registry: ObserverRegistry,
+  knownTransitions: ObserverTransition[] = []
+): ObserverRegistry {
+  if (!isValidObserverRegistry(registry)) return registry;
+
+  const observers = registry.observers.map((observer) => {
+    const result = resolveObserverWithRegistry(
+      registry,
+      observer.observer_id,
+      knownTransitions
+    );
+    return result.observer ?? observer;
+  });
+
+  return {
+    ...registry,
+    observers,
+    totalActive: observers.filter((observer) => observer.status === "ACTIVE").length,
+    totalRevoked: observers.filter((observer) => observer.status === "REVOKED").length
+  };
+}

--- a/constitutional-runtime/src/observer-registry.test.ts
+++ b/constitutional-runtime/src/observer-registry.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs";
+import {
+  ObserverRegistry,
+  buildObserverRegistry,
+  countActiveObservers,
+  countRevokedObservers,
+  hasConsistentObserverTotals,
+  isValidObserverRegistry,
+  resolveObserverFromRegistry
+} from "./observer-registry.js";
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function runObserverRegistryTests(): void {
+  console.log("Running ObserverRegistry pure evaluator tests...");
+
+  const registry = readJson<ObserverRegistry>("fixtures/observer-registry.valid.json");
+
+  assert(
+    isValidObserverRegistry(registry),
+    "isValidObserverRegistry() must accept valid registry fixture"
+  );
+  console.log("OK isValidObserverRegistry accepts valid registry fixture");
+
+  assert(
+    hasConsistentObserverTotals(registry),
+    "hasConsistentObserverTotals() must pass on registry fixture"
+  );
+  console.log("OK hasConsistentObserverTotals passes on registry fixture");
+
+  const activeCount = countActiveObservers(registry.observers, registry.lineage_tip);
+  const revokedCount = countRevokedObservers(registry.observers);
+  assert(
+    activeCount === 2 && revokedCount === 1,
+    `count mismatch: active=${activeCount}, revoked=${revokedCount}`
+  );
+  console.log("OK countActiveObservers / countRevokedObservers correct (2/1)");
+
+  const resolved = resolveObserverFromRegistry(
+    registry,
+    "1111111111111111111111111111111111111111111111111111111111111111"
+  );
+  assert(
+    resolved !== null && resolved.status === "ACTIVE",
+    "resolveObserverFromRegistry() must return expected active observer"
+  );
+  console.log("OK resolveObserverFromRegistry returns expected observer");
+
+  const built = buildObserverRegistry(
+    registry.observers,
+    registry.lineage_tip,
+    [],
+    registry.replay_path
+  );
+  assert(
+    built.verdict === "OBSERVER_REGISTRY" &&
+      built.totalActive === 2 &&
+      built.totalRevoked === 1 &&
+      built.replay_path.length === registry.replay_path.length,
+    "buildObserverRegistry() must construct consistent registry"
+  );
+  console.log("OK buildObserverRegistry constructs consistent registry");
+
+  const empty = buildObserverRegistry(
+    [],
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    [],
+    []
+  );
+  assert(
+    empty.totalActive === 0 && empty.totalRevoked === 0,
+    "empty registry must have zero active and revoked observers"
+  );
+  console.log("OK empty registry edge case handled correctly");
+
+  console.log("ObserverRegistry tests: 6/6 passed");
+}
+
+try {
+  runObserverRegistryTests();
+} catch (error) {
+  console.error("ObserverRegistry tests failed:", error);
+  process.exit(1);
+}

--- a/constitutional-runtime/src/observer-registry.ts
+++ b/constitutional-runtime/src/observer-registry.ts
@@ -1,0 +1,88 @@
+import { Hash } from "./types.js";
+import {
+  Observer,
+  isActiveObserver,
+  isValidObserver,
+  resolveObserverAtLineage
+} from "./observer.js";
+import { ObserverTransition } from "./observer-transition.js";
+
+export interface ObserverRegistry {
+  verdict: "OBSERVER_REGISTRY";
+  lineage_tip: Hash;
+  replay_path: Hash[];
+  observers: Observer[];
+  totalActive: number;
+  totalRevoked: number;
+  mutation_surface: "Frozen";
+}
+
+export function isValidObserverRegistry(registry: Partial<ObserverRegistry>): boolean {
+  return (
+    registry.verdict === "OBSERVER_REGISTRY" &&
+    typeof registry.lineage_tip === "string" &&
+    registry.lineage_tip.length === 64 &&
+    Array.isArray(registry.replay_path) &&
+    registry.replay_path.every((id) => typeof id === "string" && id.length === 64) &&
+    Array.isArray(registry.observers) &&
+    registry.observers.every((observer) => isValidObserver(observer)) &&
+    typeof registry.totalActive === "number" &&
+    typeof registry.totalRevoked === "number" &&
+    registry.totalActive >= 0 &&
+    registry.totalRevoked >= 0 &&
+    registry.mutation_surface === "Frozen"
+  );
+}
+
+export function countActiveObservers(observers: Observer[], lineageTip?: Hash): number {
+  return observers.filter((observer) => isActiveObserver(observer, lineageTip)).length;
+}
+
+export function countRevokedObservers(observers: Observer[]): number {
+  return observers.filter((observer) => isValidObserver(observer) && observer.status === "REVOKED").length;
+}
+
+export function hasConsistentObserverTotals(registry: ObserverRegistry): boolean {
+  return (
+    registry.totalActive === countActiveObservers(registry.observers, registry.lineage_tip) &&
+    registry.totalRevoked === countRevokedObservers(registry.observers)
+  );
+}
+
+export function resolveObserverFromRegistry(
+  registry: ObserverRegistry,
+  observerId: Hash
+): Observer | null {
+  if (!isValidObserverRegistry(registry)) return null;
+  return registry.observers.find((observer) => observer.observer_id === observerId) ?? null;
+}
+
+export function buildObserverRegistry(
+  rawObservers: Observer[],
+  lineageTip: Hash,
+  knownTransitions: ObserverTransition[] = [],
+  replayPath: Hash[] = []
+): ObserverRegistry {
+  const resolvedObservers = rawObservers.flatMap((observer) => {
+    if (!isValidObserver(observer)) return [];
+
+    const resolved = resolveObserverAtLineage(
+      observer.observer_id,
+      observer.public_key,
+      lineageTip,
+      knownTransitions
+    );
+
+    return resolved ? [resolved] : [observer];
+  });
+
+  return {
+    verdict: "OBSERVER_REGISTRY",
+    lineage_tip: lineageTip,
+    replay_path: replayPath,
+    observers: resolvedObservers,
+    totalActive: countActiveObservers(resolvedObservers, lineageTip),
+    totalRevoked: countRevokedObservers(resolvedObservers),
+    mutation_surface: "Frozen"
+  };
+}

--- a/constitutional-runtime/src/observer-transition.test.ts
+++ b/constitutional-runtime/src/observer-transition.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs";
+import {
+  applyObserverTransition,
+  isMeaningfulObserverTransition,
+  isObserverRevocation,
+  isValidObserverTransition,
+  ObserverTransition
+} from "./observer-transition.js";
+import { Observer } from "./observer.js";
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function runObserverTransitionTests(): void {
+  console.log("Running ObserverTransition pure evaluator tests...");
+
+  const active = readJson<ObserverTransition>("fixtures/observer.active.json");
+  const revoked = readJson<ObserverTransition>("fixtures/observer.revoked.json");
+  const invalidState = readJson<ObserverTransition>("fixtures/observer-transition.invalid-state.json");
+
+  assert(
+    isValidObserverTransition(active) &&
+      isValidObserverTransition(revoked) &&
+      isValidObserverTransition(invalidState),
+    "isValidObserverTransition() must accept schema-valid transition fixtures"
+  );
+  console.log("OK isValidObserverTransition accepts all schema-valid transitions");
+
+  assert(
+    isMeaningfulObserverTransition(revoked) && !isMeaningfulObserverTransition(invalidState),
+    "isMeaningfulObserverTransition() must distinguish state changes from self-transitions"
+  );
+  console.log("OK isMeaningfulObserverTransition distinguishes meaningful state changes");
+
+  assert(
+    isObserverRevocation(revoked) &&
+      !isObserverRevocation(active) &&
+      !isObserverRevocation(invalidState),
+    "isObserverRevocation() must detect ACTIVE to REVOKED only"
+  );
+  console.log("OK isObserverRevocation detects ACTIVE to REVOKED only");
+
+  const observerBefore: Observer = {
+    observer_id: revoked.observer_id,
+    public_key: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+    status: "ACTIVE",
+    lineage_tip: active.lineage_tip
+  };
+
+  const observerAfter = applyObserverTransition(observerBefore, revoked);
+  assert(
+    observerAfter.status === "REVOKED" && observerAfter.lineage_tip === revoked.lineage_tip,
+    "applyObserverTransition() must apply valid ACTIVE to REVOKED transition"
+  );
+  console.log("OK applyObserverTransition applies valid revocation transition");
+
+  const noOpSelfTransition = applyObserverTransition(observerBefore, invalidState);
+  assert(
+    noOpSelfTransition.status === observerBefore.status &&
+      noOpSelfTransition.lineage_tip === observerBefore.lineage_tip,
+    "applyObserverTransition() must no-op on mismatched observer_id/self-transition fixture"
+  );
+  console.log("OK applyObserverTransition no-ops on invalid-state fixture");
+
+  const mismatchedPriorObserver: Observer = {
+    ...observerBefore,
+    status: "REVOKED"
+  };
+  const noOpPriorMismatch = applyObserverTransition(mismatchedPriorObserver, revoked);
+  assert(
+    noOpPriorMismatch.status === "REVOKED" &&
+      noOpPriorMismatch.lineage_tip === mismatchedPriorObserver.lineage_tip,
+    "applyObserverTransition() must no-op when observer status does not match from_status"
+  );
+  console.log("OK applyObserverTransition no-ops on prior-state mismatch");
+
+  console.log("ObserverTransition tests: 6/6 passed");
+}
+
+try {
+  runObserverTransitionTests();
+} catch (error) {
+  console.error("ObserverTransition tests failed:", error);
+  process.exit(1);
+}

--- a/constitutional-runtime/src/observer-transition.ts
+++ b/constitutional-runtime/src/observer-transition.ts
@@ -1,5 +1,5 @@
 import { Hash } from "./types.js";
-import { Observer } from "./observer.js";
+import { Observer, isValidObserver } from "./observer.js";
 
 export interface ObserverTransition {
   observer_id: Hash;
@@ -32,13 +32,33 @@ export function isMeaningfulObserverTransition(
   return transition.from_status !== transition.to_status;
 }
 
+export function hasConsistentObserverTransitionLineage(
+  observer: Observer,
+  transition: ObserverTransition
+): boolean {
+  return (
+    isValidObserver(observer) &&
+    isValidObserverTransition(transition) &&
+    observer.observer_id === transition.observer_id &&
+    observer.lineage_tip === transition.lineage_tip
+  );
+}
+
+export function isValidObserverTransitionForObserver(
+  observer: Observer,
+  transition: ObserverTransition
+): boolean {
+  return (
+    hasConsistentObserverTransitionLineage(observer, transition) &&
+    observer.status === transition.from_status
+  );
+}
+
 export function applyObserverTransition(
   observer: Observer,
   transition: ObserverTransition
 ): Observer {
-  if (!isValidObserverTransition(transition)) return observer;
-  if (observer.observer_id !== transition.observer_id) return observer;
-  if (observer.status !== transition.from_status) return observer;
+  if (!isValidObserverTransitionForObserver(observer, transition)) return observer;
 
   return {
     ...observer,

--- a/constitutional-runtime/src/observer-transition.ts
+++ b/constitutional-runtime/src/observer-transition.ts
@@ -1,0 +1,58 @@
+import { Hash } from "./types.js";
+import { Observer } from "./observer.js";
+
+export interface ObserverTransition {
+  observer_id: Hash;
+  from_status: "ACTIVE" | "REVOKED";
+  to_status: "ACTIVE" | "REVOKED";
+  lineage_tip: Hash;
+  reason?: string;
+  verdict: "OBSERVER_TRANSITION";
+  mutation_surface: "Frozen";
+}
+
+export function isValidObserverTransition(
+  transition: Partial<ObserverTransition>
+): boolean {
+  return (
+    typeof transition.observer_id === "string" &&
+    transition.observer_id.length === 64 &&
+    (transition.from_status === "ACTIVE" || transition.from_status === "REVOKED") &&
+    (transition.to_status === "ACTIVE" || transition.to_status === "REVOKED") &&
+    typeof transition.lineage_tip === "string" &&
+    transition.lineage_tip.length === 64 &&
+    transition.verdict === "OBSERVER_TRANSITION" &&
+    transition.mutation_surface === "Frozen"
+  );
+}
+
+export function isMeaningfulObserverTransition(
+  transition: ObserverTransition
+): boolean {
+  return transition.from_status !== transition.to_status;
+}
+
+export function applyObserverTransition(
+  observer: Observer,
+  transition: ObserverTransition
+): Observer {
+  if (!isValidObserverTransition(transition)) return observer;
+  if (observer.observer_id !== transition.observer_id) return observer;
+  if (observer.status !== transition.from_status) return observer;
+
+  return {
+    ...observer,
+    status: transition.to_status,
+    lineage_tip: transition.lineage_tip
+  };
+}
+
+export function isObserverRevocation(
+  transition: ObserverTransition
+): boolean {
+  return (
+    isValidObserverTransition(transition) &&
+    transition.from_status === "ACTIVE" &&
+    transition.to_status === "REVOKED"
+  );
+}

--- a/constitutional-runtime/src/observer.ts
+++ b/constitutional-runtime/src/observer.ts
@@ -1,4 +1,8 @@
 import { Hash } from "./types.js";
+import {
+  applyObserverTransition,
+  ObserverTransition
+} from "./observer-transition.js";
 
 export interface Observer {
   observer_id: Hash;
@@ -46,4 +50,59 @@ export function deduplicateObservers(observers: Observer[]): Observer[] {
     }
   }
   return Array.from(byObserverId.values());
+}
+
+export function resolveObserverAtLineage(
+  observerId: Hash,
+  publicKey: Hash,
+  lineageTip: Hash,
+  knownTransitions: ObserverTransition[] = []
+): Observer | null {
+  const initialObserver: Observer = {
+    observer_id: observerId,
+    public_key: publicKey,
+    status: "ACTIVE",
+    lineage_tip: lineageTip
+  };
+
+  if (!isValidObserver(initialObserver)) return null;
+
+  const matchingTransitions = knownTransitions.filter(
+    (transition) =>
+      transition.observer_id === observerId && transition.lineage_tip === lineageTip
+  );
+
+  let resolved = initialObserver;
+  for (const transition of matchingTransitions) {
+    resolved = applyObserverTransition(resolved, transition);
+  }
+
+  return resolved;
+}
+
+export function resolveObserversAtLineage(
+  observerIds: Hash[],
+  publicKeysByObserverId: Map<Hash, Hash>,
+  lineageTip: Hash,
+  knownTransitions: ObserverTransition[] = []
+): Map<Hash, Observer> {
+  const resolved = new Map<Hash, Observer>();
+
+  for (const observerId of observerIds) {
+    const publicKey = publicKeysByObserverId.get(observerId);
+    if (!publicKey) continue;
+
+    const observer = resolveObserverAtLineage(
+      observerId,
+      publicKey,
+      lineageTip,
+      knownTransitions
+    );
+
+    if (observer) {
+      resolved.set(observerId, observer);
+    }
+  }
+
+  return resolved;
 }

--- a/constitutional-runtime/src/observer.ts
+++ b/constitutional-runtime/src/observer.ts
@@ -1,0 +1,49 @@
+import { Hash } from "./types.js";
+
+export interface Observer {
+  observer_id: Hash;
+  public_key: Hash;
+  status: "ACTIVE" | "REVOKED";
+  lineage_tip: Hash;
+}
+
+export interface ObserverReportWithEmbedded {
+  observer: Observer;
+  event_id: Hash;
+  observed_state_root: Hash;
+  signature: string;
+}
+
+export function isValidObserver(observer: Partial<Observer>): boolean {
+  return (
+    typeof observer.observer_id === "string" &&
+    typeof observer.public_key === "string" &&
+    (observer.status === "ACTIVE" || observer.status === "REVOKED") &&
+    typeof observer.lineage_tip === "string" &&
+    observer.observer_id.length === 64 &&
+    observer.public_key.length === 64 &&
+    observer.lineage_tip.length === 64
+  );
+}
+
+export function isActiveObserver(
+  observer: Observer,
+  currentLineageTip?: Hash
+): boolean {
+  if (!isValidObserver(observer)) return false;
+  if (observer.status !== "ACTIVE") return false;
+  if (currentLineageTip && observer.lineage_tip !== currentLineageTip) {
+    return false;
+  }
+  return true;
+}
+
+export function deduplicateObservers(observers: Observer[]): Observer[] {
+  const byObserverId = new Map<Hash, Observer>();
+  for (const observer of observers) {
+    if (isValidObserver(observer)) {
+      byObserverId.set(observer.observer_id, observer);
+    }
+  }
+  return Array.from(byObserverId.values());
+}

--- a/constitutional-runtime/src/registry-backed-resolution.test.ts
+++ b/constitutional-runtime/src/registry-backed-resolution.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { validateReceipt } from "./validator.js";
+import { Lineage } from "./types.js";
+import { ObserverRegistry } from "./observer-registry.js";
+import { ObserverTransition } from "./observer-transition.js";
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function runRegistryBackedResolutionTest(): void {
+  console.log("Running registry-backed validator resolution test...");
+
+  const transition = readJson<ObserverTransition>("fixtures/observer.revoked.json");
+  const lineage = readJson<Lineage>("fixtures/lineage.valid.json");
+  const registry = readJson<ObserverRegistry>("fixtures/observer-registry.valid.json");
+
+  const result = validateReceipt(transition, lineage, registry);
+
+  assert(
+    result.verdict === "OBSERVER_TRANSITION",
+    `expected OBSERVER_TRANSITION, got ${result.verdict}`
+  );
+
+  assert(
+    result.details?.resolvedObserver?.resolvedObserverSource === "registry",
+    "resolvedObserverSource must be registry when registry context is injected"
+  );
+
+  assert(
+    result.details?.context?.resolvedObserverSource === "registry",
+    "context.resolvedObserverSource must be registry"
+  );
+
+  assert(
+    result.details?.resolvedObserver?.registryLineageTip === registry.lineage_tip,
+    "registryLineageTip must match registry lineage_tip"
+  );
+
+  console.log("OK resolvedObserverSource=registry with injected registry context");
+  console.log("Registry-backed validator resolution test passed");
+}
+
+try {
+  runRegistryBackedResolutionTest();
+} catch (error) {
+  console.error("Registry-backed validator resolution test failed:", error);
+  process.exit(1);
+}

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import { verifySignature } from "./signature.js";
 import { canonicalizeForSignature } from "./canonical.js";
 import { evaluateObserverThreshold } from "./threshold.js";
+import { resolveObserverAtLineage } from "./observer.js";
 import {
   ContradictionReceipt,
   detectContradiction,
@@ -20,6 +21,7 @@ import {
 } from "./observer-transition.js";
 
 const SCHEMA_DIR = join(process.cwd(), "schema");
+const PLACEHOLDER_PUBLIC_KEY = "0000000000000000000000000000000000000000000000000000000000000000";
 
 let lineageValidator: any = null;
 let receiptValidator: any = null;
@@ -95,11 +97,18 @@ export function validateReceipt(
     replay_path?: string[];
     replayPathLength?: number;
     hasValidLineageBinding?: boolean;
+    resolvedObserver?: {
+      observer_id: string;
+      status: "ACTIVE" | "REVOKED";
+      lineage_tip: string;
+      public_key_source: "placeholder";
+    } | null;
     context?: {
       replayPath: string[];
       replayPathLength: number;
       lineageTip: string;
       hasValidLineageBinding: boolean;
+      resolvedObserverAvailable: boolean;
       lineageConsistency: {
         observerLineageTip: string | null;
         transitionLineageTip: string;
@@ -132,11 +141,25 @@ export function validateReceipt(
 
     const replayPath = receipt.replay_path ?? [];
     const hasValidLineageBinding = typeof receipt.lineage_tip === "string" && receipt.lineage_tip.length === 64;
+    const resolvedObserver = resolveObserverAtLineage(
+      receipt.observer_id,
+      PLACEHOLDER_PUBLIC_KEY,
+      receipt.lineage_tip,
+      []
+    );
+    const resolvedObserverDetails = resolvedObserver
+      ? {
+          observer_id: resolvedObserver.observer_id,
+          status: resolvedObserver.status,
+          lineage_tip: resolvedObserver.lineage_tip,
+          public_key_source: "placeholder" as const
+        }
+      : null;
     const lineageConsistency = {
-      observerLineageTip: null,
+      observerLineageTip: resolvedObserver?.lineage_tip ?? null,
       transitionLineageTip: receipt.lineage_tip,
-      isConsistent: null,
-      reason: "observer_context_not_available"
+      isConsistent: resolvedObserver ? resolvedObserver.lineage_tip === receipt.lineage_tip : null,
+      reason: resolvedObserver ? "observer_resolved_with_placeholder_key" : "observer_context_not_available"
     };
 
     return {
@@ -149,12 +172,14 @@ export function validateReceipt(
         replay_path: replayPath,
         replayPathLength: replayPath.length,
         hasValidLineageBinding,
+        resolvedObserver: resolvedObserverDetails,
         lineage_tip: receipt.lineage_tip,
         context: {
           replayPath,
           replayPathLength: replayPath.length,
           lineageTip: receipt.lineage_tip,
           hasValidLineageBinding,
+          resolvedObserverAvailable: Boolean(resolvedObserver),
           lineageConsistency
         },
         isMeaningful: isMeaningfulObserverTransition(receipt),

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -94,10 +94,12 @@ export function validateReceipt(
     to_status?: "ACTIVE" | "REVOKED";
     replay_path?: string[];
     replayPathLength?: number;
+    hasValidLineageBinding?: boolean;
     context?: {
       replayPath: string[];
       replayPathLength: number;
       lineageTip: string;
+      hasValidLineageBinding: boolean;
       lineageConsistency: {
         observerLineageTip: string | null;
         transitionLineageTip: string;
@@ -129,6 +131,7 @@ export function validateReceipt(
     }
 
     const replayPath = receipt.replay_path ?? [];
+    const hasValidLineageBinding = typeof receipt.lineage_tip === "string" && receipt.lineage_tip.length === 64;
     const lineageConsistency = {
       observerLineageTip: null,
       transitionLineageTip: receipt.lineage_tip,
@@ -137,7 +140,7 @@ export function validateReceipt(
     };
 
     return {
-      verdict: "OBSERVER_TRANSITION",
+      verdict: hasValidLineageBinding ? "OBSERVER_TRANSITION" : "INSUFFICIENT_EVIDENCE",
       mutation_surface: "Frozen",
       details: {
         observer_id: receipt.observer_id,
@@ -145,11 +148,13 @@ export function validateReceipt(
         to_status: receipt.to_status,
         replay_path: replayPath,
         replayPathLength: replayPath.length,
+        hasValidLineageBinding,
         lineage_tip: receipt.lineage_tip,
         context: {
           replayPath,
           replayPathLength: replayPath.length,
           lineageTip: receipt.lineage_tip,
+          hasValidLineageBinding,
           lineageConsistency
         },
         isMeaningful: isMeaningfulObserverTransition(receipt),

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -92,6 +92,19 @@ export function validateReceipt(
     observer_id?: string;
     from_status?: "ACTIVE" | "REVOKED";
     to_status?: "ACTIVE" | "REVOKED";
+    replay_path?: string[];
+    replayPathLength?: number;
+    context?: {
+      replayPath: string[];
+      replayPathLength: number;
+      lineageTip: string;
+      lineageConsistency: {
+        observerLineageTip: string | null;
+        transitionLineageTip: string;
+        isConsistent: boolean | null;
+        reason: string;
+      };
+    };
     isMeaningful?: boolean;
     isRevocation?: boolean;
     lineageConsistency?: {
@@ -115,6 +128,14 @@ export function validateReceipt(
       };
     }
 
+    const replayPath = receipt.replay_path ?? [];
+    const lineageConsistency = {
+      observerLineageTip: null,
+      transitionLineageTip: receipt.lineage_tip,
+      isConsistent: null,
+      reason: "observer_context_not_available"
+    };
+
     return {
       verdict: "OBSERVER_TRANSITION",
       mutation_surface: "Frozen",
@@ -122,15 +143,18 @@ export function validateReceipt(
         observer_id: receipt.observer_id,
         from_status: receipt.from_status,
         to_status: receipt.to_status,
+        replay_path: replayPath,
+        replayPathLength: replayPath.length,
         lineage_tip: receipt.lineage_tip,
+        context: {
+          replayPath,
+          replayPathLength: replayPath.length,
+          lineageTip: receipt.lineage_tip,
+          lineageConsistency
+        },
         isMeaningful: isMeaningfulObserverTransition(receipt),
         isRevocation: isObserverRevocation(receipt),
-        lineageConsistency: {
-          observerLineageTip: null,
-          transitionLineageTip: receipt.lineage_tip,
-          isConsistent: null,
-          reason: "observer_context_not_available"
-        },
+        lineageConsistency,
         reason: receipt.reason ?? null
       }
     };

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -15,6 +15,11 @@ import {
 } from "./observer-registry.js";
 import { resolveObserverWithRegistry } from "./observer-registry-resolution.js";
 import {
+  DegradedObserverMode,
+  isFakeEscalationSignal,
+  isValidDegradedObserverMode
+} from "./degraded-mode.js";
+import {
   ContradictionReceipt,
   detectContradiction,
   isValidContradictionReceipt
@@ -34,6 +39,7 @@ let receiptValidator: any = null;
 let contradictionValidator: any = null;
 let observerTransitionValidator: any = null;
 let observerRegistryValidator: any = null;
+let degradedObserverModeValidator: any = null;
 
 function initValidators() {
   if (lineageValidator) return;
@@ -47,6 +53,7 @@ function initValidators() {
   const contradictionSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "contradiction.schema.json"), "utf8"));
   const observerTransitionSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "observer-transition.schema.json"), "utf8"));
   const observerRegistrySchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "observer-registry.schema.json"), "utf8"));
+  const degradedObserverModeSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "degraded-observer-mode.schema.json"), "utf8"));
 
   ajv.addSchema(eventSchema, "event.schema.json");
   ajv.addSchema(lineageSchema, "lineage.schema.json");
@@ -55,12 +62,14 @@ function initValidators() {
   ajv.addSchema(contradictionSchema, "contradiction.schema.json");
   ajv.addSchema(observerTransitionSchema, "observer-transition.schema.json");
   ajv.addSchema(observerRegistrySchema, "observer-registry.schema.json");
+  ajv.addSchema(degradedObserverModeSchema, "degraded-observer-mode.schema.json");
 
   lineageValidator = ajv.compile(lineageSchema);
   receiptValidator = ajv.compile(receiptSchema);
   contradictionValidator = ajv.compile(contradictionSchema);
   observerTransitionValidator = ajv.compile(observerTransitionSchema);
   observerRegistryValidator = ajv.compile(observerRegistrySchema);
+  degradedObserverModeValidator = ajv.compile(degradedObserverModeSchema);
 }
 
 export function validateLineageSchema(data: unknown): { valid: boolean; errors?: any[] } {
@@ -93,12 +102,18 @@ export function validateObserverRegistrySchema(data: unknown): { valid: boolean;
   return { valid, errors: valid ? undefined : observerRegistryValidator.errors };
 }
 
+export function validateDegradedObserverModeSchema(data: unknown): { valid: boolean; errors?: any[] } {
+  initValidators();
+  const valid = degradedObserverModeValidator(data);
+  return { valid, errors: valid ? undefined : degradedObserverModeValidator.errors };
+}
+
 export function validateReceipt(
-  receipt: Receipt | ContradictionReceipt | ObserverTransition | ObserverRegistry,
+  receipt: Receipt | ContradictionReceipt | ObserverTransition | ObserverRegistry | DegradedObserverMode,
   lineage: Lineage,
   registryContext?: ObserverRegistry
 ): {
-  verdict: Verdict | "OBSERVER_TRANSITION" | "OBSERVER_REGISTRY";
+  verdict: Verdict | "OBSERVER_TRANSITION" | "OBSERVER_REGISTRY" | "DEGRADED_OBSERVER_MODE";
   computed_root?: string;
   divergence?: string;
   mutation_surface?: "Mutable" | "Frozen";
@@ -118,6 +133,12 @@ export function validateReceipt(
     totalRevoked?: number;
     observerCount?: number;
     hasConsistentTotals?: boolean;
+    expectedObserverCount?: number;
+    missingObserverCount?: number;
+    activeRatio?: number;
+    confidenceLevel?: "HEALTHY" | "DEGRADED" | "INSUFFICIENT";
+    isValid?: boolean;
+    isFakeEscalation?: boolean;
     note?: string;
     resolvedObserver?: {
       observer_id: string;
@@ -140,6 +161,12 @@ export function validateReceipt(
       observerCount?: number;
       totalActive?: number;
       totalRevoked?: number;
+      expectedObserverCount?: number;
+      activeObserverCount?: number;
+      missingObserverCount?: number;
+      activeRatio?: number;
+      confidenceLevel?: "HEALTHY" | "DEGRADED" | "INSUFFICIENT";
+      isFakeEscalation?: boolean;
       hasConsistentTotals?: boolean;
       lineageConsistency?: {
         observerLineageTip: string | null;
@@ -192,6 +219,51 @@ export function validateReceipt(
           hasConsistentTotals: hasConsistentObserverTotals(receipt)
         },
         note: "visible context is not authoritative settlement"
+      }
+    };
+  }
+
+  if ("verdict" in receipt && receipt.verdict === "DEGRADED_OBSERVER_MODE") {
+    const schemaResult = validateDegradedObserverModeSchema(receipt);
+    if (!schemaResult.valid || !isValidDegradedObserverMode(receipt)) {
+      return {
+        verdict: "INSUFFICIENT_EVIDENCE",
+        mutation_surface: "Frozen",
+        details: {
+          reason: "schema_or_structural_validation_failed"
+        }
+      };
+    }
+
+    const isFakeEscalation = isFakeEscalationSignal(receipt);
+    const replayPath = receipt.replay_path ?? [];
+
+    return {
+      verdict: "DEGRADED_OBSERVER_MODE",
+      mutation_surface: "Frozen",
+      details: {
+        isValid: true,
+        isFakeEscalation,
+        expectedObserverCount: receipt.expectedObserverCount,
+        activeObserverCount: receipt.activeObserverCount,
+        missingObserverCount: receipt.missingObserverCount,
+        activeRatio: receipt.activeRatio,
+        confidenceLevel: receipt.confidenceLevel,
+        replay_path: replayPath,
+        replayPathLength: replayPath.length,
+        lineage_tip: receipt.lineage_tip,
+        context: {
+          replayPath,
+          replayPathLength: replayPath.length,
+          lineageTip: receipt.lineage_tip,
+          expectedObserverCount: receipt.expectedObserverCount,
+          activeObserverCount: receipt.activeObserverCount,
+          missingObserverCount: receipt.missingObserverCount,
+          activeRatio: receipt.activeRatio,
+          confidenceLevel: receipt.confidenceLevel,
+          isFakeEscalation
+        },
+        note: "degraded signal increases observability only and never grants authority"
       }
     };
   }

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -90,9 +90,11 @@ export function validateReceipt(
     conflictingRoots?: string[];
     lineage_tip?: string;
     observer_id?: string;
+    from_status?: "ACTIVE" | "REVOKED";
+    to_status?: "ACTIVE" | "REVOKED";
     isMeaningful?: boolean;
     isRevocation?: boolean;
-    reason?: string;
+    reason?: string | null;
   };
 } {
   if ("verdict" in receipt && receipt.verdict === "OBSERVER_TRANSITION") {
@@ -100,7 +102,10 @@ export function validateReceipt(
     if (!schemaResult.valid || !isValidObserverTransition(receipt)) {
       return {
         verdict: "INSUFFICIENT_EVIDENCE",
-        mutation_surface: "Frozen"
+        mutation_surface: "Frozen",
+        details: {
+          reason: "schema_or_structural_validation_failed"
+        }
       };
     }
 
@@ -109,9 +114,12 @@ export function validateReceipt(
       mutation_surface: "Frozen",
       details: {
         observer_id: receipt.observer_id,
+        from_status: receipt.from_status,
+        to_status: receipt.to_status,
         lineage_tip: receipt.lineage_tip,
         isMeaningful: isMeaningfulObserverTransition(receipt),
-        isRevocation: isObserverRevocation(receipt)
+        isRevocation: isObserverRevocation(receipt),
+        reason: receipt.reason ?? null
       }
     };
   }

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -13,6 +13,7 @@ import {
   hasConsistentObserverTotals,
   ObserverRegistry
 } from "./observer-registry.js";
+import { resolveObserverWithRegistry } from "./observer-registry-resolution.js";
 import {
   ContradictionReceipt,
   detectContradiction,
@@ -94,7 +95,8 @@ export function validateObserverRegistrySchema(data: unknown): { valid: boolean;
 
 export function validateReceipt(
   receipt: Receipt | ContradictionReceipt | ObserverTransition | ObserverRegistry,
-  lineage: Lineage
+  lineage: Lineage,
+  registryContext?: ObserverRegistry
 ): {
   verdict: Verdict | "OBSERVER_TRANSITION" | "OBSERVER_REGISTRY";
   computed_root?: string;
@@ -121,8 +123,8 @@ export function validateReceipt(
       observer_id: string;
       status: "ACTIVE" | "REVOKED";
       lineage_tip: string;
-      public_key_source: "placeholder";
-      resolvedObserverSource: "placeholder";
+      public_key_source: "placeholder" | "registry";
+      resolvedObserverSource: "placeholder" | "registry" | "none";
       appliedTransitionCount: number;
       registryLineageTip: string | null;
     } | null;
@@ -132,7 +134,7 @@ export function validateReceipt(
       lineageTip: string;
       hasValidLineageBinding?: boolean;
       resolvedObserverAvailable?: boolean;
-      resolvedObserverSource?: "placeholder";
+      resolvedObserverSource?: "placeholder" | "registry" | "none";
       appliedTransitionCount?: number;
       registryLineageTip?: string | null;
       observerCount?: number;
@@ -208,28 +210,41 @@ export function validateReceipt(
 
     const replayPath = receipt.replay_path ?? [];
     const hasValidLineageBinding = typeof receipt.lineage_tip === "string" && receipt.lineage_tip.length === 64;
-    const resolvedObserver = resolveObserverAtLineage(
-      receipt.observer_id,
-      PLACEHOLDER_PUBLIC_KEY,
-      receipt.lineage_tip,
-      []
-    );
+    const registryResolution = registryContext
+      ? resolveObserverWithRegistry(registryContext, receipt.observer_id, [])
+      : null;
+    const placeholderObserver = registryResolution?.observer
+      ? null
+      : resolveObserverAtLineage(
+          receipt.observer_id,
+          PLACEHOLDER_PUBLIC_KEY,
+          receipt.lineage_tip,
+          []
+        );
+    const resolvedObserver = registryResolution?.observer ?? placeholderObserver;
+    const resolvedObserverSource = registryResolution?.observer ? "registry" : placeholderObserver ? "placeholder" : "none";
+    const appliedTransitionCount = registryResolution?.appliedTransitionCount ?? 0;
+    const registryLineageTip = registryResolution?.observer ? registryResolution.registryLineageTip : null;
     const resolvedObserverDetails = resolvedObserver
       ? {
           observer_id: resolvedObserver.observer_id,
           status: resolvedObserver.status,
           lineage_tip: resolvedObserver.lineage_tip,
-          public_key_source: "placeholder" as const,
-          resolvedObserverSource: "placeholder" as const,
-          appliedTransitionCount: 0,
-          registryLineageTip: null
+          public_key_source: resolvedObserverSource === "registry" ? "registry" as const : "placeholder" as const,
+          resolvedObserverSource,
+          appliedTransitionCount,
+          registryLineageTip
         }
       : null;
     const lineageConsistency = {
       observerLineageTip: resolvedObserver?.lineage_tip ?? null,
       transitionLineageTip: receipt.lineage_tip,
       isConsistent: resolvedObserver ? resolvedObserver.lineage_tip === receipt.lineage_tip : null,
-      reason: resolvedObserver ? "observer_resolved_with_placeholder_key" : "observer_context_not_available"
+      reason: resolvedObserverSource === "registry"
+        ? "observer_resolved_from_registry"
+        : resolvedObserverSource === "placeholder"
+          ? "observer_resolved_with_placeholder_key"
+          : "observer_context_not_available"
     };
 
     return {
@@ -250,9 +265,9 @@ export function validateReceipt(
           lineageTip: receipt.lineage_tip,
           hasValidLineageBinding,
           resolvedObserverAvailable: Boolean(resolvedObserver),
-          resolvedObserverSource: "placeholder",
-          appliedTransitionCount: 0,
-          registryLineageTip: null,
+          resolvedObserverSource,
+          appliedTransitionCount,
+          registryLineageTip,
           lineageConsistency
         },
         isMeaningful: isMeaningfulObserverTransition(receipt),

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -122,6 +122,9 @@ export function validateReceipt(
       status: "ACTIVE" | "REVOKED";
       lineage_tip: string;
       public_key_source: "placeholder";
+      resolvedObserverSource: "placeholder";
+      appliedTransitionCount: number;
+      registryLineageTip: string | null;
     } | null;
     context?: {
       replayPath: string[];
@@ -129,6 +132,9 @@ export function validateReceipt(
       lineageTip: string;
       hasValidLineageBinding?: boolean;
       resolvedObserverAvailable?: boolean;
+      resolvedObserverSource?: "placeholder";
+      appliedTransitionCount?: number;
+      registryLineageTip?: string | null;
       observerCount?: number;
       totalActive?: number;
       totalRevoked?: number;
@@ -213,7 +219,10 @@ export function validateReceipt(
           observer_id: resolvedObserver.observer_id,
           status: resolvedObserver.status,
           lineage_tip: resolvedObserver.lineage_tip,
-          public_key_source: "placeholder" as const
+          public_key_source: "placeholder" as const,
+          resolvedObserverSource: "placeholder" as const,
+          appliedTransitionCount: 0,
+          registryLineageTip: null
         }
       : null;
     const lineageConsistency = {
@@ -241,6 +250,9 @@ export function validateReceipt(
           lineageTip: receipt.lineage_tip,
           hasValidLineageBinding,
           resolvedObserverAvailable: Boolean(resolvedObserver),
+          resolvedObserverSource: "placeholder",
+          appliedTransitionCount: 0,
+          registryLineageTip: null,
           lineageConsistency
         },
         isMeaningful: isMeaningfulObserverTransition(receipt),

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -12,12 +12,19 @@ import {
   detectContradiction,
   isValidContradictionReceipt
 } from "./contradiction.js";
+import {
+  isMeaningfulObserverTransition,
+  isObserverRevocation,
+  isValidObserverTransition,
+  ObserverTransition
+} from "./observer-transition.js";
 
 const SCHEMA_DIR = join(process.cwd(), "schema");
 
 let lineageValidator: any = null;
 let receiptValidator: any = null;
 let contradictionValidator: any = null;
+let observerTransitionValidator: any = null;
 
 function initValidators() {
   if (lineageValidator) return;
@@ -29,16 +36,19 @@ function initValidators() {
   const receiptSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "receipt.schema.json"), "utf8"));
   const observerReportSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "observer-report.schema.json"), "utf8"));
   const contradictionSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "contradiction.schema.json"), "utf8"));
+  const observerTransitionSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "observer-transition.schema.json"), "utf8"));
 
   ajv.addSchema(eventSchema, "event.schema.json");
   ajv.addSchema(lineageSchema, "lineage.schema.json");
   ajv.addSchema(receiptSchema, "receipt.schema.json");
   ajv.addSchema(observerReportSchema, "observer-report.schema.json");
   ajv.addSchema(contradictionSchema, "contradiction.schema.json");
+  ajv.addSchema(observerTransitionSchema, "observer-transition.schema.json");
 
   lineageValidator = ajv.compile(lineageSchema);
   receiptValidator = ajv.compile(receiptSchema);
   contradictionValidator = ajv.compile(contradictionSchema);
+  observerTransitionValidator = ajv.compile(observerTransitionSchema);
 }
 
 export function validateLineageSchema(data: unknown): { valid: boolean; errors?: any[] } {
@@ -59,11 +69,17 @@ export function validateContradictionSchema(data: unknown): { valid: boolean; er
   return { valid, errors: valid ? undefined : contradictionValidator.errors };
 }
 
+export function validateObserverTransitionSchema(data: unknown): { valid: boolean; errors?: any[] } {
+  initValidators();
+  const valid = observerTransitionValidator(data);
+  return { valid, errors: valid ? undefined : observerTransitionValidator.errors };
+}
+
 export function validateReceipt(
-  receipt: Receipt | ContradictionReceipt,
+  receipt: Receipt | ContradictionReceipt | ObserverTransition,
   lineage: Lineage
 ): {
-  verdict: Verdict;
+  verdict: Verdict | "OBSERVER_TRANSITION";
   computed_root?: string;
   divergence?: string;
   mutation_surface?: "Mutable" | "Frozen";
@@ -73,9 +89,33 @@ export function validateReceipt(
     totalReportsSubmitted?: number;
     conflictingRoots?: string[];
     lineage_tip?: string;
+    observer_id?: string;
+    isMeaningful?: boolean;
+    isRevocation?: boolean;
     reason?: string;
   };
 } {
+  if ("verdict" in receipt && receipt.verdict === "OBSERVER_TRANSITION") {
+    const schemaResult = validateObserverTransitionSchema(receipt);
+    if (!schemaResult.valid || !isValidObserverTransition(receipt)) {
+      return {
+        verdict: "INSUFFICIENT_EVIDENCE",
+        mutation_surface: "Frozen"
+      };
+    }
+
+    return {
+      verdict: "OBSERVER_TRANSITION",
+      mutation_surface: "Frozen",
+      details: {
+        observer_id: receipt.observer_id,
+        lineage_tip: receipt.lineage_tip,
+        isMeaningful: isMeaningfulObserverTransition(receipt),
+        isRevocation: isObserverRevocation(receipt)
+      }
+    };
+  }
+
   if ("reports" in receipt) {
     const schemaResult = validateContradictionSchema(receipt);
     if (!schemaResult.valid || !isValidContradictionReceipt(receipt)) {

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -94,6 +94,12 @@ export function validateReceipt(
     to_status?: "ACTIVE" | "REVOKED";
     isMeaningful?: boolean;
     isRevocation?: boolean;
+    lineageConsistency?: {
+      observerLineageTip: string | null;
+      transitionLineageTip: string;
+      isConsistent: boolean | null;
+      reason: string;
+    };
     reason?: string | null;
   };
 } {
@@ -119,6 +125,12 @@ export function validateReceipt(
         lineage_tip: receipt.lineage_tip,
         isMeaningful: isMeaningfulObserverTransition(receipt),
         isRevocation: isObserverRevocation(receipt),
+        lineageConsistency: {
+          observerLineageTip: null,
+          transitionLineageTip: receipt.lineage_tip,
+          isConsistent: null,
+          reason: "observer_context_not_available"
+        },
         reason: receipt.reason ?? null
       }
     };

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -68,7 +68,9 @@ export function validateReceipt(
   divergence?: string;
   mutation_surface?: "Mutable" | "Frozen";
   details?: {
-    uniqueObservers?: number;
+    uniqueActiveObservers?: number;
+    activeObserverCount?: number;
+    totalReportsSubmitted?: number;
     conflictingRoots?: string[];
     lineage_tip?: string;
     reason?: string;
@@ -101,7 +103,9 @@ export function validateReceipt(
         divergence: "D3",
         mutation_surface: "Frozen",
         details: {
-          uniqueObservers: result.uniqueObserverCount,
+          uniqueActiveObservers: result.uniqueActiveObservers,
+          activeObserverCount: result.activeObserverCount,
+          totalReportsSubmitted: receipt.reports.length,
           conflictingRoots: result.conflictingRoots,
           lineage_tip: receipt.lineage_tip
         }
@@ -110,7 +114,12 @@ export function validateReceipt(
 
     return {
       verdict: "INSUFFICIENT_EVIDENCE",
-      mutation_surface: "Frozen"
+      mutation_surface: "Frozen",
+      details: {
+        activeObserverCount: result.activeObserverCount,
+        totalReportsSubmitted: receipt.reports.length,
+        reason: "insufficient_active_observers"
+      }
     };
   }
 

--- a/constitutional-runtime/src/validator.ts
+++ b/constitutional-runtime/src/validator.ts
@@ -9,6 +9,11 @@ import { canonicalizeForSignature } from "./canonical.js";
 import { evaluateObserverThreshold } from "./threshold.js";
 import { resolveObserverAtLineage } from "./observer.js";
 import {
+  isValidObserverRegistry,
+  hasConsistentObserverTotals,
+  ObserverRegistry
+} from "./observer-registry.js";
+import {
   ContradictionReceipt,
   detectContradiction,
   isValidContradictionReceipt
@@ -27,6 +32,7 @@ let lineageValidator: any = null;
 let receiptValidator: any = null;
 let contradictionValidator: any = null;
 let observerTransitionValidator: any = null;
+let observerRegistryValidator: any = null;
 
 function initValidators() {
   if (lineageValidator) return;
@@ -39,6 +45,7 @@ function initValidators() {
   const observerReportSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "observer-report.schema.json"), "utf8"));
   const contradictionSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "contradiction.schema.json"), "utf8"));
   const observerTransitionSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "observer-transition.schema.json"), "utf8"));
+  const observerRegistrySchema = JSON.parse(readFileSync(join(SCHEMA_DIR, "observer-registry.schema.json"), "utf8"));
 
   ajv.addSchema(eventSchema, "event.schema.json");
   ajv.addSchema(lineageSchema, "lineage.schema.json");
@@ -46,11 +53,13 @@ function initValidators() {
   ajv.addSchema(observerReportSchema, "observer-report.schema.json");
   ajv.addSchema(contradictionSchema, "contradiction.schema.json");
   ajv.addSchema(observerTransitionSchema, "observer-transition.schema.json");
+  ajv.addSchema(observerRegistrySchema, "observer-registry.schema.json");
 
   lineageValidator = ajv.compile(lineageSchema);
   receiptValidator = ajv.compile(receiptSchema);
   contradictionValidator = ajv.compile(contradictionSchema);
   observerTransitionValidator = ajv.compile(observerTransitionSchema);
+  observerRegistryValidator = ajv.compile(observerRegistrySchema);
 }
 
 export function validateLineageSchema(data: unknown): { valid: boolean; errors?: any[] } {
@@ -77,11 +86,17 @@ export function validateObserverTransitionSchema(data: unknown): { valid: boolea
   return { valid, errors: valid ? undefined : observerTransitionValidator.errors };
 }
 
+export function validateObserverRegistrySchema(data: unknown): { valid: boolean; errors?: any[] } {
+  initValidators();
+  const valid = observerRegistryValidator(data);
+  return { valid, errors: valid ? undefined : observerRegistryValidator.errors };
+}
+
 export function validateReceipt(
-  receipt: Receipt | ContradictionReceipt | ObserverTransition,
+  receipt: Receipt | ContradictionReceipt | ObserverTransition | ObserverRegistry,
   lineage: Lineage
 ): {
-  verdict: Verdict | "OBSERVER_TRANSITION";
+  verdict: Verdict | "OBSERVER_TRANSITION" | "OBSERVER_REGISTRY";
   computed_root?: string;
   divergence?: string;
   mutation_surface?: "Mutable" | "Frozen";
@@ -97,6 +112,11 @@ export function validateReceipt(
     replay_path?: string[];
     replayPathLength?: number;
     hasValidLineageBinding?: boolean;
+    totalActive?: number;
+    totalRevoked?: number;
+    observerCount?: number;
+    hasConsistentTotals?: boolean;
+    note?: string;
     resolvedObserver?: {
       observer_id: string;
       status: "ACTIVE" | "REVOKED";
@@ -107,9 +127,13 @@ export function validateReceipt(
       replayPath: string[];
       replayPathLength: number;
       lineageTip: string;
-      hasValidLineageBinding: boolean;
-      resolvedObserverAvailable: boolean;
-      lineageConsistency: {
+      hasValidLineageBinding?: boolean;
+      resolvedObserverAvailable?: boolean;
+      observerCount?: number;
+      totalActive?: number;
+      totalRevoked?: number;
+      hasConsistentTotals?: boolean;
+      lineageConsistency?: {
         observerLineageTip: string | null;
         transitionLineageTip: string;
         isConsistent: boolean | null;
@@ -127,6 +151,43 @@ export function validateReceipt(
     reason?: string | null;
   };
 } {
+  if ("verdict" in receipt && receipt.verdict === "OBSERVER_REGISTRY") {
+    const schemaResult = validateObserverRegistrySchema(receipt);
+    if (!schemaResult.valid || !isValidObserverRegistry(receipt)) {
+      return {
+        verdict: "INSUFFICIENT_EVIDENCE",
+        mutation_surface: "Frozen",
+        details: {
+          reason: "schema_or_structural_validation_failed"
+        }
+      };
+    }
+
+    return {
+      verdict: "OBSERVER_REGISTRY",
+      mutation_surface: "Frozen",
+      details: {
+        totalActive: receipt.totalActive,
+        totalRevoked: receipt.totalRevoked,
+        observerCount: receipt.observers.length,
+        replay_path: receipt.replay_path,
+        replayPathLength: receipt.replay_path.length,
+        lineage_tip: receipt.lineage_tip,
+        hasConsistentTotals: hasConsistentObserverTotals(receipt),
+        context: {
+          replayPath: receipt.replay_path,
+          replayPathLength: receipt.replay_path.length,
+          lineageTip: receipt.lineage_tip,
+          observerCount: receipt.observers.length,
+          totalActive: receipt.totalActive,
+          totalRevoked: receipt.totalRevoked,
+          hasConsistentTotals: hasConsistentObserverTotals(receipt)
+        },
+        note: "visible context is not authoritative settlement"
+      }
+    };
+  }
+
   if ("verdict" in receipt && receipt.verdict === "OBSERVER_TRANSITION") {
     const schemaResult = validateObserverTransitionSchema(receipt);
     if (!schemaResult.valid || !isValidObserverTransition(receipt)) {


### PR DESCRIPTION
## Summary
Extends the lineage-bound contradiction surface with observer objects as first-class constitutional entities and activity filtering.

## Changes
- Add `schema/observer.schema.json`
- Add `fixtures/observer.valid.json`
- Update `observer-report.schema.json` to reference nested observer objects
- Update `contradiction.valid.json` to use nested observers
- Add `src/observer.ts` pure evaluator (`isValidObserver`, `isActiveObserver`, `deduplicateObservers`)
- Wire active-observer filtering into `src/contradiction.ts`
- Surface active/submitted observer counts in `validator.ts`
- Add `fixtures/contradiction.revoked-observer.json` negative control
- Extend `reproduce.sh` and README with revoked-observer control

## Key invariants preserved
- Receipts claim; validator decides
- Only ACTIVE observers at matching `lineage_tip` contribute evidence
- REVOKED observers are treated as non-evidence
- Claimed `CONSTITUTIONAL_CONTRADICTION` can evaluate to `INSUFFICIENT_EVIDENCE`
- No quorum logic
- No observer weighting
- No settlement semantics

## Verification
Run from `constitutional-runtime`:

```bash
npm install
./reproduce.sh
```

Expected final line: `REPRODUCE_OK`.

This PR is stacked on PR #206 / `constitutional-runtime-contradiction-lineage-binding` to keep the diff isolated.