### PR TITLE
Add GIRLify inheritance documentation rule

### DIFF
--- a/docs/GIRLIFY_INHERITANCE_RULE_00000000013.md
+++ b/docs/GIRLIFY_INHERITANCE_RULE_00000000013.md
@@ -1,0 +1,39 @@
+# GIRLIFY_INHERITANCE_RULE_00000000013
+
+Authority: NONE  
+Status: PROCESS_BOUND_DRAFT  
+Identity Anchor: jaywisdom.base.eth  
+Repo Rule: GitHub Rule #0.00000000013
+
+## Rule
+
+Every `.md` file should be written like someone you love may need to understand the system after you.
+
+Documentation is inheritance infrastructure.
+
+## Meaning
+
+Markdown in this repository must be readable enough to inherit, protective enough to teach, beautiful enough to invite inspection, precise enough to verify, structured enough to replay, and receipt-bound enough to resist narrative drift.
+
+## Feminine Constraint
+
+Feminine means care, clarity, context, and proof.
+
+It does not mean stereotype, gimmick, aesthetic cosplay, or gender essentialism.
+
+## Maxwell's Demon
+
+Markdown acts as Maxwell's Demon at the repo membrane:
+
+- narrative enters
+- structure exits
+- ambiguity is sorted into claims, evidence, risks, and next actions
+- no authority passes without receipts
+
+## Lock
+
+Pretty JSON is a father leaving receipts, not vibes.
+
+Readable systems are family armor.
+Replayable reasoning is inheritance.
+Receipts are love letters disguised as math.

--- a/governance/girlify_inheritance_rule_00000000013.json
+++ b/governance/girlify_inheritance_rule_00000000013.json
@@ -1,0 +1,13 @@
+{
+  "artifact": "GIRLIFY_INHERITANCE_RULE_00000000013",
+  "authority": "NONE",
+  "status": "PROCESS_BOUND_DRAFT",
+  "identity_anchor": "jaywisdom.base.eth",
+  "reason": "Jay has three daughters",
+  "repo_rule": "GitHub Rule #0.00000000013",
+  "meaning": "Documentation must be readable, protective, beautiful, and verifiable enough for daughters to inherit.",
+  "feminine": "care + clarity + context + proof",
+  "not": "stereotype, gimmick, aesthetic cosplay, or gender essentialism",
+  "maxwells_demon": "sorts narrative chaos into inspectable evidence",
+  "lock": "Pretty JSON is a father leaving receipts, not vibes."
+}


### PR DESCRIPTION
Adds GitHub Rule #0.00000000013: Markdown as inheritance infrastructure, mirrored in JSON for replayable governance.