### PR TITLE
Add continuity surface schema freeze validator

### DIFF
--- a/.github/workflows/validate-continuity-surface-schema-freeze.yml
+++ b/.github/workflows/validate-continuity-surface-schema-freeze.yml
@@ -1,0 +1,25 @@
+name: Validate continuity surface schema freeze
+
+on:
+  push:
+    paths:
+      - "schemas/continuity_surface.v1.schema.json"
+      - "receipts/continuity_surface_schema_freeze.v1.json"
+      - ".github/workflows/validate-continuity-surface-schema-freeze.yml"
+      - "scripts/validate_continuity_surface_schema_freeze.py"
+  pull_request:
+    paths:
+      - "schemas/continuity_surface.v1.schema.json"
+      - "receipts/continuity_surface_schema_freeze.v1.json"
+      - ".github/workflows/validate-continuity-surface-schema-freeze.yml"
+      - "scripts/validate_continuity_surface_schema_freeze.py"
+
+jobs:
+  validate-schema-freeze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: scripts/validate_continuity_surface_schema_freeze.py

--- a/scripts/validate_continuity_surface_schema_freeze.py
+++ b/scripts/validate_continuity_surface_schema_freeze.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import json, hashlib, sys
+from pathlib import Path
+
+SCHEMA_PATH = Path("schemas/continuity_surface.v1.schema.json")
+RECEIPT_PATH = Path("receipts/continuity_surface_schema_freeze.v1.json")
+
+def load_json(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"[ERROR] Missing file: {path}", file=sys.stderr); sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"[ERROR] Invalid JSON in {path}: {e}", file=sys.stderr); sys.exit(1)
+
+def canonicalize_jcs(obj):
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+def main():
+    schema_obj = load_json(SCHEMA_PATH)
+    receipt_obj = load_json(RECEIPT_PATH)
+
+    if receipt_obj.get("canonicalization") != "JCS": sys.exit("[ERROR] receipt.canonicalization must be JCS")
+    if receipt_obj.get("hash_algorithm") != "sha256": sys.exit("[ERROR] receipt.hash_algorithm must be sha256")
+    if receipt_obj.get("status") != "FROZEN": sys.exit("[ERROR] receipt.status must be FROZEN")
+
+    expected = receipt_obj.get("schema_sha256")
+    actual = "sha256:" + hashlib.sha256(canonicalize_jcs(schema_obj)).hexdigest()
+
+    if actual != expected:
+        print("[ERROR] Continuity surface schema hash mismatch", file=sys.stderr)
+        print(f"  Expected: {expected}", file=sys.stderr)
+        print(f"  Actual:   {actual}", file=sys.stderr)
+        sys.exit(1)
+
+    print("[OK] Continuity surface schema matches frozen commitment")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a bounded CI validator that verifies the frozen continuity surface schema commitment without mutating schema, receipt, or canon.