### PR TITLE
Add Replay Governance PR base gate and BROKEN_CHAIN schemas

### DIFF
--- a/.github/workflows/replay-governance-pr-base-gate.yml
+++ b/.github/workflows/replay-governance-pr-base-gate.yml
@@ -1,0 +1,84 @@
+name: Replay Governance PR Base Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - 'docs/replay-governance/**'
+      - 'receipts/replay-governance/**'
+      - '.github/workflows/replay-governance-pr-base-gate.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  verify-preflight-base-sha:
+    name: Verify preflight base SHA receipt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Verify preflight receipt exists and matches PR base
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          RECEIPT_PATH: receipts/replay-governance/preflight/master_sha_resolution.json
+        run: |
+          set -euo pipefail
+
+          if [ ! -f "$RECEIPT_PATH" ]; then
+            echo "BROKEN_CHAIN: missing preflight receipt: $RECEIPT_PATH" >&2
+            exit 1
+          fi
+
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          receipt_path = Path(os.environ["RECEIPT_PATH"])
+          pr_base_sha = os.environ["PR_BASE_SHA"]
+
+          try:
+              receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+          except Exception as exc:
+              print(f"BROKEN_CHAIN: invalid JSON receipt: {exc}", file=sys.stderr)
+              sys.exit(1)
+
+          required = {
+              "preflight_check": "MASTER_SHA_RESOLUTION",
+              "repository": "jsonwisdom/AL",
+              "base_branch": "master",
+              "required_value": "git rev-parse origin/master",
+              "purpose": "bind replay-governance-boundary-pilot to explicit base commit",
+          }
+
+          for key, expected in required.items():
+              actual = receipt.get(key)
+              if actual != expected:
+                  print(
+                      f"BROKEN_CHAIN: receipt field mismatch for {key}: expected {expected!r}, got {actual!r}",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+
+          resolved_base_sha = receipt.get("resolved_base_sha")
+          if not isinstance(resolved_base_sha, str) or len(resolved_base_sha) != 40:
+              print("BROKEN_CHAIN: resolved_base_sha must be a 40-character git SHA", file=sys.stderr)
+              sys.exit(1)
+
+          if resolved_base_sha != pr_base_sha:
+              print(
+                  f"BROKEN_CHAIN: PR base SHA mismatch: receipt={resolved_base_sha} pr_base={pr_base_sha}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          print("CHAIN_OK: preflight receipt matches PR base SHA")
+          PY

--- a/docs/replay-governance/explorer/broken_chain_event.schema.json
+++ b/docs/replay-governance/explorer/broken_chain_event.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/jsonwisdom/AL/docs/replay-governance/explorer/broken_chain_event.schema.json",
+  "title": "BROKEN_CHAIN Explorer Event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_type",
+    "source",
+    "repository",
+    "workflow",
+    "run_id",
+    "pr_number",
+    "base_branch",
+    "expected_base_sha",
+    "observed_base_sha",
+    "failure_reason",
+    "disclosure_status"
+  ],
+  "properties": {
+    "event_type": {
+      "const": "BROKEN_CHAIN"
+    },
+    "source": {
+      "const": "replay-governance-pr-base-gate"
+    },
+    "repository": {
+      "const": "jsonwisdom/AL"
+    },
+    "workflow": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^[0-9]+$"
+    },
+    "pr_number": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "base_branch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "expected_base_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "observed_base_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "failure_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "disclosure_status": {
+      "const": "PUBLIC_DISCLOSURE_REQUIRED"
+    }
+  }
+}

--- a/docs/replay-governance/explorer/broken_chain_event.schema.json
+++ b/docs/replay-governance/explorer/broken_chain_event.schema.json
@@ -15,7 +15,8 @@
     "expected_base_sha",
     "observed_base_sha",
     "failure_reason",
-    "disclosure_status"
+    "disclosure_status",
+    "immutability"
   ],
   "properties": {
     "event_type": {
@@ -57,6 +58,26 @@
     },
     "disclosure_status": {
       "const": "PUBLIC_DISCLOSURE_REQUIRED"
+    },
+    "immutability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "once_emitted",
+        "sha_mismatch_record",
+        "override"
+      ],
+      "properties": {
+        "once_emitted": {
+          "const": "CANNOT_BE_RETRACTED"
+        },
+        "sha_mismatch_record": {
+          "const": "APPEND_ONLY"
+        },
+        "override": {
+          "const": "FORBIDDEN"
+        }
+      }
     }
   }
 }

--- a/docs/replay-governance/explorer/broken_chain_remediation.schema.json
+++ b/docs/replay-governance/explorer/broken_chain_remediation.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/jsonwisdom/AL/docs/replay-governance/explorer/broken_chain_remediation.schema.json",
+  "title": "BROKEN_CHAIN Remediation Event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_type",
+    "source",
+    "repository",
+    "remediates_event_hash",
+    "remediation_action",
+    "remediation_status",
+    "root_cause_summary",
+    "successor_receipt_hash",
+    "immutability"
+  ],
+  "properties": {
+    "event_type": {
+      "const": "BROKEN_CHAIN_REMEDIATION"
+    },
+    "source": {
+      "const": "replay-governance-pr-base-gate"
+    },
+    "repository": {
+      "const": "jsonwisdom/AL"
+    },
+    "remediates_event_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "remediation_action": {
+      "type": "string",
+      "minLength": 1
+    },
+    "remediation_status": {
+      "enum": [
+        "EXPLAINED",
+        "SUPERSEDED_BY_SUCCESSOR_RECEIPT",
+        "FALSE_POSITIVE_PROVEN_BY_REPLAY",
+        "NOT_REMEDIATED"
+      ]
+    },
+    "root_cause_summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "successor_receipt_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "immutability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original_event",
+        "remediation_mode",
+        "override"
+      ],
+      "properties": {
+        "original_event": {
+          "const": "REMAINS_VISIBLE"
+        },
+        "remediation_mode": {
+          "const": "ADD_SUCCESSOR_RECORD_ONLY"
+        },
+        "override": {
+          "const": "FORBIDDEN"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds replay-governance infrastructure for PR lineage verification and append-only BROKEN_CHAIN disclosure semantics.

## Artifacts

- `.github/workflows/replay-governance-pr-base-gate.yml`
- `docs/replay-governance/explorer/broken_chain_event.schema.json`
- `docs/replay-governance/explorer/broken_chain_remediation.schema.json`

## Constitutional properties

- PR lineage must match declared constitutional anchor
- BROKEN_CHAIN is disclosed as a historical fact, not a transient UI state
- Failure events are append-only and cannot be retracted
- Remediation is additive through successor records only
- Runtime gate does not write to explorer state

## Notes

This PR introduces the enforcement and schema layer only. A real mismatch test PR should be opened separately to validate failing behavior before treating the gate as fully proven.