### PR TITLE
TEST: replay governance gate missing preflight receipt

### DIFF
--- a/docs/replay-governance/broken-chain-trigger-test.md
+++ b/docs/replay-governance/broken-chain-trigger-test.md
@@ -1,0 +1,1 @@
+BROKEN_CHAIN trigger test 2026-05-27T15:50:22Z


### PR DESCRIPTION
Expected result: replay-governance-pr-base-gate fails with BROKEN_CHAIN because the preflight receipt is missing.