### PR TITLE
Constitution v1.0.0 replay membrane implementation

### DIFF
--- a/docs/governance/DUAL_RUN_DETERMINISM_AUDIT_V1.md
+++ b/docs/governance/DUAL_RUN_DETERMINISM_AUDIT_V1.md
@@ -1,0 +1,114 @@
+# DUAL_RUN_DETERMINISM_AUDIT_V1
+
+Status: FROZEN
+Date: 2026-05-27
+Scope: Constitutional determinism protocol for the dual-witness replay membrane
+Authority: NONE
+
+## Purpose
+
+Prove that the replay membrane produces identical traces under identical inputs and profiles.
+
+This protocol turns determinism from an assumption into an auditable invariant.
+
+## Protocol Object
+
+```json
+{
+  "protocol_id": "DUAL_RUN_DETERMINISM_AUDIT_V1",
+  "goal": "prove that the replay membrane produces identical traces under identical inputs and profiles",
+  "preconditions": {
+    "invariant_profile": "hash-locked",
+    "canon_profile": "hash-locked",
+    "inputs": "byte-identical",
+    "receipts": "byte-identical",
+    "authority": false
+  },
+  "steps": [
+    "run_1: execute validate_pr() for PR_256 and PR_257 using the same profiles",
+    "run_1: produce manifest_1.json and trace artifacts",
+    "run_2: re-execute validate_pr() with identical inputs and profiles",
+    "run_2: produce manifest_2.json and trace artifacts",
+    "compare: compute stable_hash(manifest_1) vs stable_hash(manifest_2)",
+    "compare: compute stable_hash(trace_1_red) vs stable_hash(trace_2_red)",
+    "compare: compute stable_hash(trace_1_green) vs stable_hash(trace_2_green)",
+    "verdict: deterministic if and only if all stable hashes match"
+  ],
+  "exclusions": [
+    "run_id",
+    "wall_clock_timestamp",
+    "filesystem ordering"
+  ],
+  "output": {
+    "file": "determinism_audit_report.json",
+    "fields": [
+      "deterministic",
+      "manifest_hash_1",
+      "manifest_hash_2",
+      "trace_hash_red_1",
+      "trace_hash_red_2",
+      "trace_hash_green_1",
+      "trace_hash_green_2",
+      "invariant_profile_hash",
+      "canon_profile_hash",
+      "authority"
+    ]
+  }
+}
+```
+
+## Stable Hash Rule
+
+`stable_hash(value)` means:
+
+1. Remove excluded fields.
+2. Serialize as deterministic canonical JSON.
+3. Hash with SHA-256.
+4. Prefix the digest with `0x`.
+
+Excluded fields are not evidence-bearing for determinism.
+
+## Required Output
+
+The runner must emit:
+
+```json
+{
+  "deterministic": true,
+  "manifest_hash_1": "0x...",
+  "manifest_hash_2": "0x...",
+  "trace_hash_red_1": "0x...",
+  "trace_hash_red_2": "0x...",
+  "trace_hash_green_1": "0x...",
+  "trace_hash_green_2": "0x...",
+  "invariant_profile_hash": "sha256:...",
+  "canon_profile_hash": "sha256:...",
+  "authority": false
+}
+```
+
+## Verdict Rule
+
+The audit verdict is deterministic if and only if all of the following are true:
+
+```text
+manifest_hash_1 == manifest_hash_2
+trace_hash_red_1 == trace_hash_red_2
+trace_hash_green_1 == trace_hash_green_2
+invariant_profile_hash is unchanged
+canon_profile_hash is unchanged
+```
+
+Any mismatch is a constitutional failure and must produce exit code `4`.
+
+## Constitutional Lock
+
+```json
+{
+  "profile_bound_execution": true,
+  "replay_visible_traces": true,
+  "determinism_audit": true,
+  "authority": false,
+  "interpretation": false
+}
+```

--- a/docs/governance/PUBLIC_VERIFIER_V1.md
+++ b/docs/governance/PUBLIC_VERIFIER_V1.md
@@ -1,0 +1,106 @@
+# PUBLIC_VERIFIER_V1
+
+Status: FROZEN
+Date: 2026-05-27
+Scope: External verification surface for dual-witness replay membrane artifacts
+Authority: NONE
+
+## Purpose
+
+Provide a minimal public verifier that checks replay evidence emitted by the membrane without re-running the membrane.
+
+The membrane produces evidence.
+The verifier checks evidence.
+
+## Inputs
+
+```json
+{
+  "verifier_id": "PUBLIC_VERIFIER_V1",
+  "inputs": [
+    "replay_manifest.json",
+    "comparison_report.json",
+    "determinism_audit_report.json",
+    "INVARIANT_PROFILE_V1.json",
+    "CANON_PROFILE_V1.json"
+  ]
+}
+```
+
+## Required Checks
+
+```json
+{
+  "checks": [
+    "profile_hashes_match_manifest",
+    "profile_hashes_match_determinism_audit_report",
+    "manifest_hash_1_equals_manifest_hash_2",
+    "red_trace_hash_1_equals_red_trace_hash_2",
+    "green_trace_hash_1_equals_green_trace_hash_2",
+    "comparison_report_asserts_opposite_lawful_outcomes",
+    "no_authority_claims_present"
+  ]
+}
+```
+
+## Output
+
+```json
+{
+  "verifier_id": "PUBLIC_VERIFIER_V1",
+  "verdict": "VALID",
+  "reason": "all public verification checks passed",
+  "authority": false
+}
+```
+
+Invalid output must include a reason:
+
+```json
+{
+  "verifier_id": "PUBLIC_VERIFIER_V1",
+  "verdict": "INVALID",
+  "reason": "profile hash mismatch",
+  "authority": false
+}
+```
+
+## Hash Rule
+
+Profile hashes use the profile self-exclusion rule:
+
+```text
+sha256(canonical_json(profile with profile_hash = "sha256:SELF_EXCLUDED"))
+```
+
+Stable evidence hashes use:
+
+```text
+sha256(canonical_json(value))
+```
+
+Canonical JSON means sorted object keys, UTF-8, and no optional whitespace.
+
+## Constitutional Boundary
+
+The verifier must not:
+
+- run the membrane
+- re-evaluate invariants
+- infer authority
+- validate signer identity
+- mutate artifacts
+
+The verifier may only check evidence consistency.
+
+## Constitutional Lock
+
+```json
+{
+  "membrane_role": "produce_evidence",
+  "verifier_role": "check_evidence",
+  "execution_required": false,
+  "authority": false,
+  "interpretation": false
+}
+```

--- a/profiles/CANON_PROFILE_V1.json
+++ b/profiles/CANON_PROFILE_V1.json
@@ -1,0 +1,14 @@
+{
+  "authority_claims": false,
+  "hash_algorithm": "sha256",
+  "method": "deterministic_json_canonicalization",
+  "profile_hash": "sha256:8f8baf8b2a9c6cbd6f4baf2cb7f6a0db5f3a84a5cf22f0a66126f89f9a1c07f5",
+  "profile_hash_rule": "sha256 over canonical JSON with profile_hash set to sha256:SELF_EXCLUDED",
+  "profile_id": "CANON_PROFILE_V1",
+  "rules": [
+    "sort_object_keys",
+    "remove_optional_whitespace",
+    "utf8_normalized",
+    "no_timestamps_or_nonces_in_payload"
+  ]
+}

--- a/profiles/INVARIANT_PROFILE_V1.json
+++ b/profiles/INVARIANT_PROFILE_V1.json
@@ -1,0 +1,38 @@
+{
+  "authority_claims": false,
+  "critical_set": [
+    "lineage_provenance",
+    "lineage_binding"
+  ],
+  "evaluation_order": [
+    "lineage_provenance",
+    "receipt_shape",
+    "lineage_binding",
+    "fail_closed"
+  ],
+  "profile_hash": "sha256:7299bd4749e7d878739a4102750dcf03f85958c5cb3e8b26bd0626063f9b3704",
+  "profile_hash_rule": "sha256 over canonical JSON with profile_hash set to sha256:SELF_EXCLUDED",
+  "profile_id": "INVARIANT_PROFILE_V1",
+  "invariants": [
+    {
+      "description": "Rejects if receipt missing or lineage_hash does not equal payload_hash.",
+      "id": "lineage_provenance",
+      "version": "1"
+    },
+    {
+      "description": "Validates receipt fields id, lineage_hash, issued_at, issuer_id, and signature exist and are well-typed strings.",
+      "id": "receipt_shape",
+      "version": "1"
+    },
+    {
+      "description": "Verifies receipt lineage_hash equals the canonical payload hash and issuer_id equals membrane/preflight/v1. Signature field is presence-checked only in V1 and creates no cryptographic authority claim.",
+      "id": "lineage_binding",
+      "version": "1"
+    },
+    {
+      "description": "If lineage_provenance or lineage_binding fails, final decision is REJECT.",
+      "id": "fail_closed",
+      "version": "1"
+    }
+  ]
+}

--- a/profiles/registry.json
+++ b/profiles/registry.json
@@ -1,0 +1,15 @@
+{
+  "registry_id": "CONSTITUTION_PROFILE_REGISTRY_V1",
+  "authority_claims": false,
+  "entries": [
+    {
+      "version": "1.0.0",
+      "invariant_profile": "INVARIANT_PROFILE_V1",
+      "invariant_hash": "sha256:7299bd4749e7d878739a4102750dcf03f85958c5cb3e8b26bd0626063f9b3704",
+      "canon_profile": "CANON_PROFILE_V1",
+      "canon_hash": "sha256:8f8baf8b2a9c6cbd6f4baf2cb7f6a0db5f3a84a5cf22f0a66126f89f9a1c07f5",
+      "effective_from": "2026-05-27T00:00:00Z",
+      "status": "active"
+    }
+  ]
+}

--- a/tools/public_verifier.py
+++ b/tools/public_verifier.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""PUBLIC_VERIFIER_V1.
+
+Minimal external verifier for replay membrane artifacts.
+Authority: NONE.
+This verifier checks evidence consistency only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SELF_EXCLUDED = "sha256:SELF_EXCLUDED"
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    return "0x" + hashlib.sha256(data).hexdigest()
+
+
+def sha256_profile(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def canonical_hash(value: Any) -> str:
+    return sha256_hex(canonical_json_bytes(value))
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+
+    return value
+
+
+def assert_profile_hash(profile: dict[str, Any]) -> str:
+    declared = profile.get("profile_hash")
+
+    if not isinstance(declared, str):
+        raise ValueError("profile_hash missing or invalid")
+
+    excluded = dict(profile)
+    excluded["profile_hash"] = SELF_EXCLUDED
+
+    computed = sha256_profile(canonical_json_bytes(excluded))
+
+    if computed != declared:
+        raise ValueError(f"profile hash mismatch: {computed} != {declared}")
+
+    return computed
+
+
+def fail(reason: str) -> int:
+    result = {
+        "verifier_id": "PUBLIC_VERIFIER_V1",
+        "verdict": "INVALID",
+        "reason": reason,
+        "authority": False,
+    }
+
+    print(json.dumps(result, sort_keys=True, indent=2))
+    return 1
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="public_verifier")
+
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--comparison", required=True)
+    parser.add_argument("--determinism-audit", required=True)
+    parser.add_argument("--invariant-profile", required=True)
+    parser.add_argument("--canon-profile", required=True)
+
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = load_json(Path(args.manifest))
+        comparison = load_json(Path(args.comparison))
+        determinism = load_json(Path(args.determinism_audit))
+        invariant_profile = load_json(Path(args.invariant_profile))
+        canon_profile = load_json(Path(args.canon_profile))
+
+        invariant_hash = assert_profile_hash(invariant_profile)
+        canon_hash = assert_profile_hash(canon_profile)
+
+        if manifest.get("profile_hash_invariant") != invariant_hash:
+            return fail("manifest invariant profile hash mismatch")
+
+        if manifest.get("profile_hash_canon") != canon_hash:
+            return fail("manifest canon profile hash mismatch")
+
+        if determinism.get("invariant_profile_hash") != invariant_hash:
+            return fail("determinism audit invariant profile hash mismatch")
+
+        if determinism.get("canon_profile_hash") != canon_hash:
+            return fail("determinism audit canon profile hash mismatch")
+
+        if determinism.get("manifest_hash_1") != determinism.get("manifest_hash_2"):
+            return fail("manifest determinism mismatch")
+
+        if determinism.get("trace_hash_red_1") != determinism.get("trace_hash_red_2"):
+            return fail("red trace determinism mismatch")
+
+        if determinism.get("trace_hash_green_1") != determinism.get("trace_hash_green_2"):
+            return fail("green trace determinism mismatch")
+
+        if not comparison.get("opposite_lawful_outcomes"):
+            return fail("comparison report does not assert opposite lawful outcomes")
+
+        if manifest.get("authority") is True:
+            return fail("authority claim present in manifest")
+
+        if comparison.get("authority") is True:
+            return fail("authority claim present in comparison report")
+
+        if determinism.get("authority") is True:
+            return fail("authority claim present in determinism audit report")
+
+        result = {
+            "verifier_id": "PUBLIC_VERIFIER_V1",
+            "verdict": "VALID",
+            "reason": "all public verification checks passed",
+            "authority": False,
+        }
+
+        print(json.dumps(result, sort_keys=True, indent=2))
+        return 0
+
+    except Exception as exc:
+        return fail(str(exc))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/replay_membrane.py
+++ b/tools/replay_membrane.py
@@ -77,11 +77,14 @@ def assert_profile_hash(profile: dict[str, Any]) -> str:
     declared = profile.get("profile_hash")
     if not isinstance(declared, str):
         raise ValueError("profile_hash missing or invalid")
+
     excluded = dict(profile)
     excluded["profile_hash"] = SELF_EXCLUDED
     computed = sha256_profile(canonical_json_bytes(excluded))
+
     if computed != declared:
         raise ValueError(f"profile hash mismatch for {profile.get('profile_id')}: {computed} != {declared}")
+
     return computed
 
 
@@ -91,10 +94,13 @@ def repo_root() -> Path:
 
 def load_profiles() -> tuple[dict[str, Any], dict[str, Any], str, str]:
     root = repo_root()
+
     invariant_profile = load_json(root / "profiles" / "INVARIANT_PROFILE_V1.json")
     canon_profile = load_json(root / "profiles" / "CANON_PROFILE_V1.json")
+
     invariant_hash = assert_profile_hash(invariant_profile)
     canon_hash = assert_profile_hash(canon_profile)
+
     return invariant_profile, canon_profile, invariant_hash, canon_hash
 
 
@@ -105,23 +111,30 @@ def read_bytes(path: str) -> bytes:
 def read_receipt(path: Optional[str]) -> Optional[dict[str, Any]]:
     if path is None:
         return None
+
     with Path(path).open("r", encoding="utf-8") as handle:
         value = json.load(handle)
+
     if not isinstance(value, dict):
         raise ValueError("receipt must be a JSON object")
+
     return value
 
 
 def validate_receipt_shape(receipt: dict[str, Any]) -> tuple[bool, str]:
     required = ["id", "lineage_hash", "issued_at", "issuer_id", "signature"]
     missing = [field for field in required if field not in receipt]
+
     if missing:
         return False, "RECEIPT_MISSING_FIELDS:" + ",".join(missing)
+
     if receipt.get("issuer_id") != ISSUER_ID:
         return False, "RECEIPT_ISSUER_MISMATCH"
+
     for field in required:
         if not isinstance(receipt.get(field), str) or not receipt.get(field):
             return False, "RECEIPT_FIELD_INVALID:" + field
+
     return True, "RECEIPT_SHAPE_VALID"
 
 
@@ -141,20 +154,60 @@ def validate_pr(
     expected_lineage_hash = payload_hash
 
     if pr_input.receipt is None:
-        return Decision(pr_input.pr, "REJECT", "MISSING_PREFLIGHT_RECEIPT", False, payload_hash, expected_lineage_hash, None)
+        return Decision(
+            pr_input.pr,
+            "REJECT",
+            "MISSING_PREFLIGHT_RECEIPT",
+            False,
+            payload_hash,
+            expected_lineage_hash,
+            None,
+        )
 
     shape_ok, shape_reason = validate_receipt_shape(pr_input.receipt)
     receipt_lineage_hash = pr_input.receipt.get("lineage_hash")
+
     if not shape_ok:
-        return Decision(pr_input.pr, "REJECT", shape_reason, True, payload_hash, expected_lineage_hash, receipt_lineage_hash if isinstance(receipt_lineage_hash, str) else None)
+        return Decision(
+            pr_input.pr,
+            "REJECT",
+            shape_reason,
+            True,
+            payload_hash,
+            expected_lineage_hash,
+            receipt_lineage_hash if isinstance(receipt_lineage_hash, str) else None,
+        )
 
     if receipt_lineage_hash != expected_lineage_hash:
-        return Decision(pr_input.pr, "REJECT", "LINEAGE_HASH_MISMATCH", True, payload_hash, expected_lineage_hash, receipt_lineage_hash)
+        return Decision(
+            pr_input.pr,
+            "REJECT",
+            "LINEAGE_HASH_MISMATCH",
+            True,
+            payload_hash,
+            expected_lineage_hash,
+            receipt_lineage_hash,
+        )
 
-    return Decision(pr_input.pr, "ADMIT", "VALID_PREFLIGHT_LINEAGE_RECEIPT", True, payload_hash, expected_lineage_hash, receipt_lineage_hash)
+    return Decision(
+        pr_input.pr,
+        "ADMIT",
+        "VALID_PREFLIGHT_LINEAGE_RECEIPT",
+        True,
+        payload_hash,
+        expected_lineage_hash,
+        receipt_lineage_hash,
+    )
 
 
-def run_once(red: PRInput, green: PRInput, invariant_profile: dict[str, Any], canon_profile: dict[str, Any], invariant_profile_hash: str, canon_profile_hash: str) -> dict[str, Any]:
+def run_once(
+    red: PRInput,
+    green: PRInput,
+    invariant_profile: dict[str, Any],
+    canon_profile: dict[str, Any],
+    invariant_profile_hash: str,
+    canon_profile_hash: str,
+) -> dict[str, Any]:
     red_decision = validate_pr(red, invariant_profile, canon_profile, invariant_profile_hash, canon_profile_hash)
     green_decision = validate_pr(green, invariant_profile, canon_profile, invariant_profile_hash, canon_profile_hash)
 
@@ -202,6 +255,7 @@ def write_receipt_log(path: Path, decision: dict[str, Any]) -> None:
 def build_inputs(args: argparse.Namespace) -> tuple[PRInput, PRInput]:
     if args.red != EXPECTED_RED:
         raise ValueError(f"--red must be {EXPECTED_RED}")
+
     if args.green != EXPECTED_GREEN:
         raise ValueError(f"--green must be {EXPECTED_GREEN}")
 
@@ -213,6 +267,7 @@ def build_inputs(args: argparse.Namespace) -> tuple[PRInput, PRInput]:
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="replay_membrane")
+
     parser.add_argument("--red", required=True)
     parser.add_argument("--green", required=True)
     parser.add_argument("--red-payload", required=True)
@@ -221,76 +276,93 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--green-receipt")
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--verbose", action="store_true")
+
     return parser.parse_args(argv)
 
 
 def main(argv: list[str]) -> int:
     try:
         args = parse_args(argv)
+
         invariant_profile, canon_profile, invariant_hash, canon_hash = load_profiles()
         red, green = build_inputs(args)
-        first = run_once(red, green, invariant_profile, canon_profile, invariant_hash, canon_hash)
-        second = run_once(red, green, invariant_profile, canon_profile, invariant_hash, canon_hash)
 
-        first_stable = stable_projection(first)
-        second_stable = stable_projection(second)
-        deterministic = first_stable == second_stable
+        run_1 = run_once(red, green, invariant_profile, canon_profile, invariant_hash, canon_hash)
+        run_2 = run_once(red, green, invariant_profile, canon_profile, invariant_hash, canon_hash)
 
-        trace_hash_red = canonical_hash(first_stable["red"])
-        trace_hash_green = canonical_hash(first_stable["green"])
-        manifest_hash = canonical_hash(first_stable)
+        stable_1 = stable_projection(run_1)
+        stable_2 = stable_projection(run_2)
+
+        manifest_hash_1 = canonical_hash(stable_1)
+        manifest_hash_2 = canonical_hash(stable_2)
+
+        trace_hash_red_1 = canonical_hash(stable_1["red"])
+        trace_hash_red_2 = canonical_hash(stable_2["red"])
+
+        trace_hash_green_1 = canonical_hash(stable_1["green"])
+        trace_hash_green_2 = canonical_hash(stable_2["green"])
+
+        deterministic = (
+            manifest_hash_1 == manifest_hash_2
+            and trace_hash_red_1 == trace_hash_red_2
+            and trace_hash_green_1 == trace_hash_green_2
+        )
 
         if not deterministic:
-            first = dict(first)
-            first["exit_code"] = EXIT_NON_DETERMINISM
-            first["exit_reason"] = "NON_DETERMINISM_DETECTED"
+            run_1 = dict(run_1)
+            run_1["exit_code"] = EXIT_NON_DETERMINISM
+            run_1["exit_reason"] = "NON_DETERMINISM_DETECTED"
 
         output_dir = Path(args.output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        determinism_proof = {
+        determinism_audit_report = {
             "deterministic": deterministic,
-            "manifest_hash": manifest_hash,
-            "trace_hash_red": trace_hash_red,
-            "trace_hash_green": trace_hash_green,
-            "profile_hash_invariant": invariant_hash,
-            "profile_hash_canon": canon_hash,
+            "manifest_hash_1": manifest_hash_1,
+            "manifest_hash_2": manifest_hash_2,
+            "trace_hash_red_1": trace_hash_red_1,
+            "trace_hash_red_2": trace_hash_red_2,
+            "trace_hash_green_1": trace_hash_green_1,
+            "trace_hash_green_2": trace_hash_green_2,
+            "invariant_profile_hash": invariant_hash,
+            "canon_profile_hash": canon_hash,
             "authority": False,
         }
 
         manifest = {
             "run_id": "replay-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
             "cli": "replay_membrane",
-            "exit_code": first["exit_code"],
-            "exit_reason": first["exit_reason"],
-            "red": first["red"],
-            "green": first["green"],
+            "exit_code": run_1["exit_code"],
+            "exit_reason": run_1["exit_reason"],
+            "red": run_1["red"],
+            "green": run_1["green"],
             "profile_hash_invariant": invariant_hash,
             "profile_hash_canon": canon_hash,
-            "determinism_proof": determinism_proof,
+            "determinism_audit_report": determinism_audit_report,
         }
 
         comparison_report = {
             "proof": "SAME_INVARIANT_SET_HANDLED_BOTH_PATHS",
-            "red_decision": first["red"]["decision"],
-            "green_decision": first["green"]["decision"],
-            "opposite_lawful_outcomes": first["red"]["decision"] == "REJECT" and first["green"]["decision"] == "ADMIT",
+            "red_decision": run_1["red"]["decision"],
+            "green_decision": run_1["green"]["decision"],
+            "opposite_lawful_outcomes": run_1["red"]["decision"] == "REJECT" and run_1["green"]["decision"] == "ADMIT",
             "authority": False,
             "interpretation": False,
             "profile_hash_invariant": invariant_hash,
             "profile_hash_canon": canon_hash,
         }
 
-        write_receipt_log(output_dir / "PR_256_receipt.log", first["red"])
-        write_receipt_log(output_dir / "PR_257_receipt.log", first["green"])
+        write_receipt_log(output_dir / "PR_256_receipt.log", run_1["red"])
+        write_receipt_log(output_dir / "PR_257_receipt.log", run_1["green"])
         write_json(output_dir / "comparison_report.json", comparison_report)
-        write_json(output_dir / "determinism_proof.json", determinism_proof)
+        write_json(output_dir / "determinism_audit_report.json", determinism_audit_report)
         write_json(output_dir / "replay_manifest.json", manifest)
 
         if args.verbose:
             print(json.dumps(manifest, sort_keys=True, indent=2))
 
-        return int(first["exit_code"])
+        return int(run_1["exit_code"])
+
     except Exception as exc:
         sys.stderr.write(f"HARNESS_INTERNAL_ERROR: {exc}\n")
         return EXIT_INTERNAL_ERROR

--- a/tools/replay_membrane.py
+++ b/tools/replay_membrane.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -21,15 +20,7 @@ from typing import Any, Optional
 EXPECTED_RED = "PR_256"
 EXPECTED_GREEN = "PR_257"
 ISSUER_ID = "membrane/preflight/v1"
-INVARIANT_SET = {
-    "version": "DUAL_WITNESS_INVARIANT_SET_V1",
-    "invariants": [
-        "LINEAGE_PROVENANCE_INVARIANT",
-        "FAIL_CLOSED_INVARIANT",
-        "REPLAY_IDENTITY_INVARIANT",
-        "RECEIPT_BINDING_INVARIANT",
-    ],
-}
+SELF_EXCLUDED = "sha256:SELF_EXCLUDED"
 
 EXIT_SUCCESS = 0
 EXIT_RED_FALSE_POSITIVE = 1
@@ -62,12 +53,49 @@ def sha256_hex(data: bytes) -> str:
     return "0x" + hashlib.sha256(data).hexdigest()
 
 
+def sha256_profile(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
 def canonical_json_bytes(value: Any) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
 
 
-def invariant_set_hash() -> str:
-    return sha256_hex(canonical_json_bytes(INVARIANT_SET))
+def canonical_hash(value: Any) -> str:
+    return sha256_hex(canonical_json_bytes(value))
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def assert_profile_hash(profile: dict[str, Any]) -> str:
+    declared = profile.get("profile_hash")
+    if not isinstance(declared, str):
+        raise ValueError("profile_hash missing or invalid")
+    excluded = dict(profile)
+    excluded["profile_hash"] = SELF_EXCLUDED
+    computed = sha256_profile(canonical_json_bytes(excluded))
+    if computed != declared:
+        raise ValueError(f"profile hash mismatch for {profile.get('profile_id')}: {computed} != {declared}")
+    return computed
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_profiles() -> tuple[dict[str, Any], dict[str, Any], str, str]:
+    root = repo_root()
+    invariant_profile = load_json(root / "profiles" / "INVARIANT_PROFILE_V1.json")
+    canon_profile = load_json(root / "profiles" / "CANON_PROFILE_V1.json")
+    invariant_hash = assert_profile_hash(invariant_profile)
+    canon_hash = assert_profile_hash(canon_profile)
+    return invariant_profile, canon_profile, invariant_hash, canon_hash
 
 
 def read_bytes(path: str) -> bytes:
@@ -97,59 +125,38 @@ def validate_receipt_shape(receipt: dict[str, Any]) -> tuple[bool, str]:
     return True, "RECEIPT_SHAPE_VALID"
 
 
-def validate_pr(pr_input: PRInput) -> Decision:
+def validate_pr(
+    pr_input: PRInput,
+    invariant_profile: dict[str, Any],
+    canon_profile: dict[str, Any],
+    invariant_profile_hash: str,
+    canon_profile_hash: str,
+) -> Decision:
+    _ = invariant_profile
+    _ = canon_profile
+    _ = invariant_profile_hash
+    _ = canon_profile_hash
+
     payload_hash = sha256_hex(pr_input.payload_bytes)
     expected_lineage_hash = payload_hash
 
     if pr_input.receipt is None:
-        return Decision(
-            pr=pr_input.pr,
-            decision="REJECT",
-            reason="MISSING_PREFLIGHT_RECEIPT",
-            receipt_present=False,
-            payload_hash=payload_hash,
-            expected_lineage_hash=expected_lineage_hash,
-            receipt_lineage_hash=None,
-        )
+        return Decision(pr_input.pr, "REJECT", "MISSING_PREFLIGHT_RECEIPT", False, payload_hash, expected_lineage_hash, None)
 
     shape_ok, shape_reason = validate_receipt_shape(pr_input.receipt)
     receipt_lineage_hash = pr_input.receipt.get("lineage_hash")
     if not shape_ok:
-        return Decision(
-            pr=pr_input.pr,
-            decision="REJECT",
-            reason=shape_reason,
-            receipt_present=True,
-            payload_hash=payload_hash,
-            expected_lineage_hash=expected_lineage_hash,
-            receipt_lineage_hash=receipt_lineage_hash if isinstance(receipt_lineage_hash, str) else None,
-        )
+        return Decision(pr_input.pr, "REJECT", shape_reason, True, payload_hash, expected_lineage_hash, receipt_lineage_hash if isinstance(receipt_lineage_hash, str) else None)
 
     if receipt_lineage_hash != expected_lineage_hash:
-        return Decision(
-            pr=pr_input.pr,
-            decision="REJECT",
-            reason="LINEAGE_HASH_MISMATCH",
-            receipt_present=True,
-            payload_hash=payload_hash,
-            expected_lineage_hash=expected_lineage_hash,
-            receipt_lineage_hash=receipt_lineage_hash,
-        )
+        return Decision(pr_input.pr, "REJECT", "LINEAGE_HASH_MISMATCH", True, payload_hash, expected_lineage_hash, receipt_lineage_hash)
 
-    return Decision(
-        pr=pr_input.pr,
-        decision="ADMIT",
-        reason="VALID_PREFLIGHT_LINEAGE_RECEIPT",
-        receipt_present=True,
-        payload_hash=payload_hash,
-        expected_lineage_hash=expected_lineage_hash,
-        receipt_lineage_hash=receipt_lineage_hash,
-    )
+    return Decision(pr_input.pr, "ADMIT", "VALID_PREFLIGHT_LINEAGE_RECEIPT", True, payload_hash, expected_lineage_hash, receipt_lineage_hash)
 
 
-def run_once(red: PRInput, green: PRInput) -> dict[str, Any]:
-    red_decision = validate_pr(red)
-    green_decision = validate_pr(green)
+def run_once(red: PRInput, green: PRInput, invariant_profile: dict[str, Any], canon_profile: dict[str, Any], invariant_profile_hash: str, canon_profile_hash: str) -> dict[str, Any]:
+    red_decision = validate_pr(red, invariant_profile, canon_profile, invariant_profile_hash, canon_profile_hash)
+    green_decision = validate_pr(green, invariant_profile, canon_profile, invariant_profile_hash, canon_profile_hash)
 
     if red_decision.decision == "ADMIT":
         exit_code = EXIT_RED_FALSE_POSITIVE
@@ -166,7 +173,9 @@ def run_once(red: PRInput, green: PRInput) -> dict[str, Any]:
         "exit_reason": exit_reason,
         "red": asdict(red_decision),
         "green": asdict(green_decision),
-        "invariant_set_hash": invariant_set_hash(),
+        "profile_hash_invariant": invariant_profile_hash,
+        "profile_hash_canon": canon_profile_hash,
+        "authority": False,
     }
 
 
@@ -176,7 +185,9 @@ def stable_projection(result: dict[str, Any]) -> dict[str, Any]:
         "exit_reason": result["exit_reason"],
         "red": result["red"],
         "green": result["green"],
-        "invariant_set_hash": result["invariant_set_hash"],
+        "profile_hash_invariant": result["profile_hash_invariant"],
+        "profile_hash_canon": result["profile_hash_canon"],
+        "authority": result["authority"],
     }
 
 
@@ -194,21 +205,10 @@ def build_inputs(args: argparse.Namespace) -> tuple[PRInput, PRInput]:
     if args.green != EXPECTED_GREEN:
         raise ValueError(f"--green must be {EXPECTED_GREEN}")
 
-    red = PRInput(
-        pr=args.red,
-        payload_path=args.red_payload,
-        payload_bytes=read_bytes(args.red_payload),
-        receipt_path=args.red_receipt,
-        receipt=read_receipt(args.red_receipt),
+    return (
+        PRInput(args.red, args.red_payload, read_bytes(args.red_payload), args.red_receipt, read_receipt(args.red_receipt)),
+        PRInput(args.green, args.green_payload, read_bytes(args.green_payload), args.green_receipt, read_receipt(args.green_receipt)),
     )
-    green = PRInput(
-        pr=args.green,
-        payload_path=args.green_payload,
-        payload_bytes=read_bytes(args.green_payload),
-        receipt_path=args.green_receipt,
-        receipt=read_receipt(args.green_receipt),
-    )
-    return red, green
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -227,11 +227,19 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def main(argv: list[str]) -> int:
     try:
         args = parse_args(argv)
+        invariant_profile, canon_profile, invariant_hash, canon_hash = load_profiles()
         red, green = build_inputs(args)
-        first = run_once(red, green)
-        second = run_once(red, green)
+        first = run_once(red, green, invariant_profile, canon_profile, invariant_hash, canon_hash)
+        second = run_once(red, green, invariant_profile, canon_profile, invariant_hash, canon_hash)
 
-        deterministic = stable_projection(first) == stable_projection(second)
+        first_stable = stable_projection(first)
+        second_stable = stable_projection(second)
+        deterministic = first_stable == second_stable
+
+        trace_hash_red = canonical_hash(first_stable["red"])
+        trace_hash_green = canonical_hash(first_stable["green"])
+        manifest_hash = canonical_hash(first_stable)
+
         if not deterministic:
             first = dict(first)
             first["exit_code"] = EXIT_NON_DETERMINISM
@@ -240,6 +248,16 @@ def main(argv: list[str]) -> int:
         output_dir = Path(args.output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
+        determinism_proof = {
+            "deterministic": deterministic,
+            "manifest_hash": manifest_hash,
+            "trace_hash_red": trace_hash_red,
+            "trace_hash_green": trace_hash_green,
+            "profile_hash_invariant": invariant_hash,
+            "profile_hash_canon": canon_hash,
+            "authority": False,
+        }
+
         manifest = {
             "run_id": "replay-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
             "cli": "replay_membrane",
@@ -247,8 +265,9 @@ def main(argv: list[str]) -> int:
             "exit_reason": first["exit_reason"],
             "red": first["red"],
             "green": first["green"],
-            "invariant_set_hash": first["invariant_set_hash"],
-            "deterministic": deterministic,
+            "profile_hash_invariant": invariant_hash,
+            "profile_hash_canon": canon_hash,
+            "determinism_proof": determinism_proof,
         }
 
         comparison_report = {
@@ -258,19 +277,21 @@ def main(argv: list[str]) -> int:
             "opposite_lawful_outcomes": first["red"]["decision"] == "REJECT" and first["green"]["decision"] == "ADMIT",
             "authority": False,
             "interpretation": False,
-            "invariant_set_hash": first["invariant_set_hash"],
+            "profile_hash_invariant": invariant_hash,
+            "profile_hash_canon": canon_hash,
         }
 
         write_receipt_log(output_dir / "PR_256_receipt.log", first["red"])
         write_receipt_log(output_dir / "PR_257_receipt.log", first["green"])
         write_json(output_dir / "comparison_report.json", comparison_report)
+        write_json(output_dir / "determinism_proof.json", determinism_proof)
         write_json(output_dir / "replay_manifest.json", manifest)
 
         if args.verbose:
             print(json.dumps(manifest, sort_keys=True, indent=2))
 
         return int(first["exit_code"])
-    except Exception as exc:  # noqa: BLE001 - CLI must convert all failures to exit 3.
+    except Exception as exc:
         sys.stderr.write(f"HARNESS_INTERNAL_ERROR: {exc}\n")
         return EXIT_INTERNAL_ERROR
 

--- a/tools/replay_membrane.py
+++ b/tools/replay_membrane.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Dual-witness replay membrane runner.
+
+Implements DUAL_WITNESS_REPLAY_RUNNER_SPEC_V1 as a deterministic CLI.
+Authority: NONE. This runner validates only replay-visible receipt shape and
+lineage binding. It does not claim social, legal, or cryptographic authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+EXPECTED_RED = "PR_256"
+EXPECTED_GREEN = "PR_257"
+ISSUER_ID = "membrane/preflight/v1"
+INVARIANT_SET = {
+    "version": "DUAL_WITNESS_INVARIANT_SET_V1",
+    "invariants": [
+        "LINEAGE_PROVENANCE_INVARIANT",
+        "FAIL_CLOSED_INVARIANT",
+        "REPLAY_IDENTITY_INVARIANT",
+        "RECEIPT_BINDING_INVARIANT",
+    ],
+}
+
+EXIT_SUCCESS = 0
+EXIT_RED_FALSE_POSITIVE = 1
+EXIT_GREEN_FALSE_NEGATIVE = 2
+EXIT_INTERNAL_ERROR = 3
+EXIT_NON_DETERMINISM = 4
+
+
+@dataclass(frozen=True)
+class PRInput:
+    pr: str
+    payload_path: str
+    payload_bytes: bytes
+    receipt_path: Optional[str]
+    receipt: Optional[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class Decision:
+    pr: str
+    decision: str
+    reason: str
+    receipt_present: bool
+    payload_hash: str
+    expected_lineage_hash: str
+    receipt_lineage_hash: Optional[str]
+
+
+def sha256_hex(data: bytes) -> str:
+    return "0x" + hashlib.sha256(data).hexdigest()
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def invariant_set_hash() -> str:
+    return sha256_hex(canonical_json_bytes(INVARIANT_SET))
+
+
+def read_bytes(path: str) -> bytes:
+    return Path(path).read_bytes()
+
+
+def read_receipt(path: Optional[str]) -> Optional[dict[str, Any]]:
+    if path is None:
+        return None
+    with Path(path).open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError("receipt must be a JSON object")
+    return value
+
+
+def validate_receipt_shape(receipt: dict[str, Any]) -> tuple[bool, str]:
+    required = ["id", "lineage_hash", "issued_at", "issuer_id", "signature"]
+    missing = [field for field in required if field not in receipt]
+    if missing:
+        return False, "RECEIPT_MISSING_FIELDS:" + ",".join(missing)
+    if receipt.get("issuer_id") != ISSUER_ID:
+        return False, "RECEIPT_ISSUER_MISMATCH"
+    for field in required:
+        if not isinstance(receipt.get(field), str) or not receipt.get(field):
+            return False, "RECEIPT_FIELD_INVALID:" + field
+    return True, "RECEIPT_SHAPE_VALID"
+
+
+def validate_pr(pr_input: PRInput) -> Decision:
+    payload_hash = sha256_hex(pr_input.payload_bytes)
+    expected_lineage_hash = payload_hash
+
+    if pr_input.receipt is None:
+        return Decision(
+            pr=pr_input.pr,
+            decision="REJECT",
+            reason="MISSING_PREFLIGHT_RECEIPT",
+            receipt_present=False,
+            payload_hash=payload_hash,
+            expected_lineage_hash=expected_lineage_hash,
+            receipt_lineage_hash=None,
+        )
+
+    shape_ok, shape_reason = validate_receipt_shape(pr_input.receipt)
+    receipt_lineage_hash = pr_input.receipt.get("lineage_hash")
+    if not shape_ok:
+        return Decision(
+            pr=pr_input.pr,
+            decision="REJECT",
+            reason=shape_reason,
+            receipt_present=True,
+            payload_hash=payload_hash,
+            expected_lineage_hash=expected_lineage_hash,
+            receipt_lineage_hash=receipt_lineage_hash if isinstance(receipt_lineage_hash, str) else None,
+        )
+
+    if receipt_lineage_hash != expected_lineage_hash:
+        return Decision(
+            pr=pr_input.pr,
+            decision="REJECT",
+            reason="LINEAGE_HASH_MISMATCH",
+            receipt_present=True,
+            payload_hash=payload_hash,
+            expected_lineage_hash=expected_lineage_hash,
+            receipt_lineage_hash=receipt_lineage_hash,
+        )
+
+    return Decision(
+        pr=pr_input.pr,
+        decision="ADMIT",
+        reason="VALID_PREFLIGHT_LINEAGE_RECEIPT",
+        receipt_present=True,
+        payload_hash=payload_hash,
+        expected_lineage_hash=expected_lineage_hash,
+        receipt_lineage_hash=receipt_lineage_hash,
+    )
+
+
+def run_once(red: PRInput, green: PRInput) -> dict[str, Any]:
+    red_decision = validate_pr(red)
+    green_decision = validate_pr(green)
+
+    if red_decision.decision == "ADMIT":
+        exit_code = EXIT_RED_FALSE_POSITIVE
+        exit_reason = "RED_PATH_FALSE_POSITIVE"
+    elif green_decision.decision == "REJECT":
+        exit_code = EXIT_GREEN_FALSE_NEGATIVE
+        exit_reason = "GREEN_PATH_FALSE_NEGATIVE"
+    else:
+        exit_code = EXIT_SUCCESS
+        exit_reason = "DUAL_WITNESS_SUCCESS"
+
+    return {
+        "exit_code": exit_code,
+        "exit_reason": exit_reason,
+        "red": asdict(red_decision),
+        "green": asdict(green_decision),
+        "invariant_set_hash": invariant_set_hash(),
+    }
+
+
+def stable_projection(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "exit_code": result["exit_code"],
+        "exit_reason": result["exit_reason"],
+        "red": result["red"],
+        "green": result["green"],
+        "invariant_set_hash": result["invariant_set_hash"],
+    }
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def write_receipt_log(path: Path, decision: dict[str, Any]) -> None:
+    path.write_text(json.dumps(decision, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def build_inputs(args: argparse.Namespace) -> tuple[PRInput, PRInput]:
+    if args.red != EXPECTED_RED:
+        raise ValueError(f"--red must be {EXPECTED_RED}")
+    if args.green != EXPECTED_GREEN:
+        raise ValueError(f"--green must be {EXPECTED_GREEN}")
+
+    red = PRInput(
+        pr=args.red,
+        payload_path=args.red_payload,
+        payload_bytes=read_bytes(args.red_payload),
+        receipt_path=args.red_receipt,
+        receipt=read_receipt(args.red_receipt),
+    )
+    green = PRInput(
+        pr=args.green,
+        payload_path=args.green_payload,
+        payload_bytes=read_bytes(args.green_payload),
+        receipt_path=args.green_receipt,
+        receipt=read_receipt(args.green_receipt),
+    )
+    return red, green
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="replay_membrane")
+    parser.add_argument("--red", required=True)
+    parser.add_argument("--green", required=True)
+    parser.add_argument("--red-payload", required=True)
+    parser.add_argument("--green-payload", required=True)
+    parser.add_argument("--red-receipt")
+    parser.add_argument("--green-receipt")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    try:
+        args = parse_args(argv)
+        red, green = build_inputs(args)
+        first = run_once(red, green)
+        second = run_once(red, green)
+
+        deterministic = stable_projection(first) == stable_projection(second)
+        if not deterministic:
+            first = dict(first)
+            first["exit_code"] = EXIT_NON_DETERMINISM
+            first["exit_reason"] = "NON_DETERMINISM_DETECTED"
+
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        manifest = {
+            "run_id": "replay-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
+            "cli": "replay_membrane",
+            "exit_code": first["exit_code"],
+            "exit_reason": first["exit_reason"],
+            "red": first["red"],
+            "green": first["green"],
+            "invariant_set_hash": first["invariant_set_hash"],
+            "deterministic": deterministic,
+        }
+
+        comparison_report = {
+            "proof": "SAME_INVARIANT_SET_HANDLED_BOTH_PATHS",
+            "red_decision": first["red"]["decision"],
+            "green_decision": first["green"]["decision"],
+            "opposite_lawful_outcomes": first["red"]["decision"] == "REJECT" and first["green"]["decision"] == "ADMIT",
+            "authority": False,
+            "interpretation": False,
+            "invariant_set_hash": first["invariant_set_hash"],
+        }
+
+        write_receipt_log(output_dir / "PR_256_receipt.log", first["red"])
+        write_receipt_log(output_dir / "PR_257_receipt.log", first["green"])
+        write_json(output_dir / "comparison_report.json", comparison_report)
+        write_json(output_dir / "replay_manifest.json", manifest)
+
+        if args.verbose:
+            print(json.dumps(manifest, sort_keys=True, indent=2))
+
+        return int(first["exit_code"])
+    except Exception as exc:  # noqa: BLE001 - CLI must convert all failures to exit 3.
+        sys.stderr.write(f"HARNESS_INTERNAL_ERROR: {exc}\n")
+        return EXIT_INTERNAL_ERROR
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Merges the constitution v1.0.0 replay membrane implementation into master.

Includes:
- profile-bound replay runner
- public verifier
- invariant/canon profiles
- constitution profile registry
- determinism audit protocol
- public verifier spec

## Boundary

Authority: NONE
Interpretation: NONE
Purpose: produce and verify replay-visible evidence.

## Tag note

Do not recreate `constitution-v1.0.0` until this PR is merged and master contains the implementation files.