### PR TITLE
docs: add PR #260-bounded Replay Node v0.1 spec

### DIFF
--- a/specs/replay_node_v0.1/membrane_test.md
+++ b/specs/replay_node_v0.1/membrane_test.md
@@ -1,0 +1,56 @@
+# Replay Node v0.1 — Membrane Test
+
+Status: PR #260-bounded membrane verification
+Authority: false
+Merge permission: false
+
+## 1. Objective
+
+Prove that the operator layer cannot mutate runtime semantics.
+
+Every operator-layer claim must map directly to a runtime step, runtime scope item, fail-closed condition, or receipt field.
+
+## 2. Claim Mapping Table
+
+| Operator Claim | Runtime Anchor | Result |
+|---|---|---|
+| fetches one official public PDF URL | runtime_spec.md Section 2 item 1 | PASS |
+| computes PDF SHA256 | runtime_spec.md Section 2 item 2 | PASS |
+| identity gate by expected date plus proceedings/minutes text | runtime_spec.md Section 2 item 3 | PASS |
+| extracts text with `pdftotext -layout` | runtime_spec.md Section 2 item 4 | PASS |
+| computes extracted text SHA256 | runtime_spec.md Section 2 item 5 | PASS |
+| emits deterministic rows | runtime_spec.md Section 2 item 6 | PASS |
+| computes output CSV SHA256 | runtime_spec.md Section 2 item 7 | PASS |
+| compares output CSV SHA256 to claimed CSV SHA256 | runtime_spec.md Section 2 item 8 | PASS |
+| emits receipt JSON only on MATCH | runtime_spec.md Section 2 item 9 | PASS |
+| fails closed on dependency mismatch | runtime_spec.md Section 2 item 10 | PASS |
+| fails closed on identity mismatch | runtime_spec.md Section 2 item 11 | PASS |
+| fails closed on output hash mismatch | runtime_spec.md Section 2 item 12 | PASS |
+| authority remains false | runtime_spec.md Section 2 item 13 | PASS |
+| merge_permission remains false | runtime_spec.md Section 2 item 14 | PASS |
+
+## 3. Explicit Scope Rejection
+
+The following claims are rejected because they are not part of the PR #260-bounded runtime:
+
+- CSV source ingestion
+- crawler behavior
+- daily ingestion
+- timeout guarantees
+- size guarantees
+- debug flags
+- soft failure continuation
+- merge authority assignment
+- institutional certification
+
+## 4. Membrane Result
+
+PASS.
+
+No narrative mutation detected.
+
+## 5. Enforcement Rule
+
+PR body claims must match diff surface.
+
+Any future PR that changes the operator brief must preserve runtime anchoring for every operator-layer claim.

--- a/specs/replay_node_v0.1/operator_brief.md
+++ b/specs/replay_node_v0.1/operator_brief.md
@@ -1,0 +1,70 @@
+# Replay Node v0.1 — Operator Brief
+
+Status: PR #260-bounded operator explanation
+Authority: false
+Merge permission: false
+
+## 1. What Replay Node v0.1 Does
+
+Replay Node v0.1 replays one official public civic PDF source through a deterministic extraction pipeline.
+
+It:
+
+- fetches one official public PDF URL
+- computes PDF SHA256
+- verifies identity using expected date plus proceedings/minutes text
+- extracts text with `pdftotext -layout`
+- computes extracted text SHA256
+- emits deterministic rows
+- computes output CSV SHA256
+- compares output CSV SHA256 against the claimed CSV SHA256
+- emits receipt JSON only on MATCH
+- fails closed on dependency, identity, or hash mismatch
+
+## 2. What Replay Node v0.1 Does Not Do
+
+Replay Node v0.1 does not:
+
+- ingest CSV source inputs
+- crawl websites
+- perform daily ingestion
+- assign merge authority
+- certify institutions
+- summarize civic content
+- continue after hash mismatch
+- continue after identity mismatch
+- expose debug or mutation flags
+
+## 3. Authority Posture
+
+Replay Node v0.1 is verification infrastructure.
+
+It preserves:
+
+```json
+{
+  "authority": false,
+  "merge_permission": false
+}
+```
+
+The node may emit receipts.
+
+A reviewer decides whether to trust, reject, rerun, or merge based on those receipts.
+
+## 4. Fail-Closed Behavior
+
+Replay Node v0.1 fails closed under:
+
+- missing dependency
+- PDF fetch failure
+- identity mismatch
+- output CSV SHA256 mismatch
+
+The runtime would rather emit uncertainty than produce unverifiable output.
+
+## 5. Membrane Rule
+
+NO_NARRATIVE_MUTATION_OF_RUNTIME.
+
+Every statement in this brief maps back to a runtime step, runtime scope item, fail-closed condition, or receipt field in `runtime_spec.md`.

--- a/specs/replay_node_v0.1/runtime_spec.md
+++ b/specs/replay_node_v0.1/runtime_spec.md
@@ -1,0 +1,112 @@
+# Replay Node v0.1 — Runtime Specification
+
+Status: PR #260-bounded specification
+Scope: civic-document replay only
+Authority: false
+Merge permission: false
+
+## 1. Purpose
+
+Replay Node v0.1 replays one official public civic PDF source through a deterministic extraction and hashing pipeline.
+
+It verifies whether the emitted output CSV hash matches the claimed CSV hash under the declared runtime steps.
+
+It does not adjudicate, certify, merge, crawl, summarize, or assign authority.
+
+## 2. In Scope
+
+Replay Node v0.1 includes only the behavior proven by PR #260:
+
+1. fetch official public PDF URL
+2. compute PDF SHA256
+3. identity gate by expected date plus proceedings/minutes text
+4. extract text with `pdftotext -layout`
+5. compute text SHA256
+6. emit deterministic rows
+7. compute output CSV SHA256
+8. compare output CSV SHA256 to claimed CSV hash
+9. emit receipt JSON on MATCH
+10. fail closed on missing dependency
+11. fail closed on identity mismatch
+12. fail closed on output hash mismatch
+13. preserve `authority: false`
+14. preserve `merge_permission: false`
+
+## 3. Explicitly Not In Scope
+
+Replay Node v0.1 does not include:
+
+- PDF hash comparison to a claimed source hash
+- CSV source input
+- daily ingestion
+- crawler behavior
+- size limit guarantees
+- timeout guarantees
+- debug flags
+- soft failure continuation
+- cross-jurisdiction joins
+- institutional certification
+- merge authority assignment
+- narrative summary generation
+
+## 4. Accepted Inputs
+
+| Input | Format | Rule |
+|---|---|---|
+| Official public PDF URL | HTTPS URL | Must identify a documented civic source system or relevant government publication surface |
+| Expected date | YYYY-MM-DD rendered to display date | Used by the identity gate |
+| Expected document type text | proceedings or minutes text | Used by the identity gate |
+| Claimed CSV SHA256 | lowercase SHA256 hex | Compared only against emitted output CSV SHA256 |
+
+## 5. Runtime Steps
+
+1. Fetch the PDF from the official public URL.
+2. Compute the SHA256 hash of the downloaded PDF bytes.
+3. Check that `pdftotext` is available.
+4. Extract the first page.
+5. Apply the identity gate using expected date plus proceedings/minutes text.
+6. Extract full text with `pdftotext -layout`.
+7. Compute the SHA256 hash of the extracted text.
+8. Run the deterministic row emitter.
+9. Compute the SHA256 hash of the emitted output CSV.
+10. Compare the output CSV SHA256 to the claimed CSV SHA256.
+11. Emit receipt JSON only on MATCH.
+12. Exit with failure on missing dependency, identity mismatch, or hash mismatch.
+
+## 6. Fail-Closed Conditions
+
+| Condition | Result |
+|---|---|
+| `pdftotext` missing | fail closed |
+| PDF fetch empty or unavailable | fail closed |
+| identity gate mismatch | fail closed |
+| output CSV SHA256 mismatch | fail closed |
+
+Failure does not grant authority or merge permission.
+
+## 7. Receipt Fields on MATCH
+
+A successful replay emits receipt JSON containing:
+
+```json
+{
+  "replay_result": "MATCH",
+  "authority": false,
+  "merge_permission": false,
+  "commit_hash": "git SHA",
+  "source_url": "official public PDF URL",
+  "meeting_date": "YYYY-MM-DD",
+  "expected_display_date": "Month D, YYYY",
+  "pdf_sha256": "sha256:<hex>",
+  "extracted_text_sha256": "sha256:<hex>",
+  "output_csv_sha256": "<hex>",
+  "claimed_csv_sha256": "<hex>",
+  "row_count": 0
+}
+```
+
+## 8. Membrane Rule
+
+NO_NARRATIVE_MUTATION_OF_RUNTIME.
+
+The operator layer may explain these runtime steps, but it may not add behavior, expand scope, modify verdict semantics, or imply authority not present in this specification.


### PR DESCRIPTION
Adds the PR #260-bounded Replay Node v0.1 runtime specification, operator brief, and membrane test.

This PR is limited strictly to the behavior proven by PR #260.

**Included:**
- one official public PDF URL replay
- identity gate
- pdftotext -layout extraction
- PDF/text/output CSV SHA256 generation
- output CSV hash comparison
- fail-closed runtime behavior
- authority: false
- merge_permission: false

**Explicitly excluded:**
- crawler behavior
- CSV source ingestion
- daily ingestion
- timeout guarantees
- debug flags
- merge authority
- institutional certification

**PR body claims match diff surface.**