### PR TITLE
docs: bind ALMS Base MCP send_calls doctrine v0.1

### DIFF
--- a/docs/alms_base_mcp_send_calls_plugin_doctrine_v0_1.md
+++ b/docs/alms_base_mcp_send_calls_plugin_doctrine_v0_1.md
@@ -1,0 +1,84 @@
+# ALMS Base MCP send_calls Plugin Doctrine V0.1
+
+Status: DRAFT_BINDING_NOTE
+Authority: false
+Mutation model: append-only
+Membrane: HOLDS
+
+## Purpose
+
+This note binds `JOY_ALMS_BASE_MCP_PLUGIN_V0_1` to the existing AL Base MCP and ALMS memory surfaces. It is not a new doctrine island.
+
+A Base MCP plugin is treated as an untrusted compiler from user intent to unsigned calldata. It does not own keys, does not broadcast transactions, does not adjudicate truth, and does not mutate prior receipts.
+
+## Parent artifacts
+
+This note must be read as a child of:
+
+- `docs/BASE_MCP_ENGINE_AUDIT_V0_1.md`
+- `docs/base-mcp-scaffold-audit-receipt.md`
+- `schemas/base_mcp_witness.v0_1.schema.json`
+- `schemas/mcp_engine_audit_receipt.v0_1.schema.json`
+- `agents/base_mcp/schemas/action_receipt.schema.json`
+- `agents/base_mcp/schemas/session_log.schema.json`
+- `agents/base_mcp/schemas/permission_policy.schema.json`
+- `agents/base_mcp/examples/intent_receipt.example.json`
+
+## Role split
+
+```json
+{
+  "plugin_role": "untrusted_compiler",
+  "wallet_role": "approval_boundary",
+  "base_mcp_role": "transport_runtime",
+  "chain_role": "receipt_surface",
+  "authority": false
+}
+```
+
+## Allowed primitive mapping
+
+- `read`: display receipt DAG state only
+- `anchor`: prepare unsigned calldata for a claim anchor
+- `dispute`: prepare unsigned calldata challenging an existing claim
+- `witness`: prepare unsigned calldata attaching testimony to a claim or dispute
+
+## Blocked transitions
+
+The plugin must not:
+
+- claim custody
+- execute without wallet approval
+- invent deployed contract addresses
+- emit executable-looking placeholder calldata
+- overwrite prior receipts
+- declare truth, fraud, verification, falsity, or adjudication
+- create a new witness taxonomy that bypasses `schemas/base_mcp_witness.v0_1.schema.json`
+
+## Truth-status boundary
+
+Allowed statuses for plugin-prepared records are limited to non-adjudicative states:
+
+```json
+[
+  "CLAIM_ANCHORED_NOT_PROVEN",
+  "DISPUTE_RECORDED_NOT_ADJUDICATED",
+  "WITNESS_RECORDED_NOT_VERDICT"
+]
+```
+
+No plugin response may use `VERIFIED`, `FALSE`, `FRAUD`, or `ADJUDICATED` unless a separate higher-authority resolution receipt exists and is explicitly referenced as a receipt, not as plugin authority.
+
+## Final invariant
+
+```json
+{
+  "mutation_model": "append_only",
+  "plugin_role": "untrusted_compiler",
+  "wallet_role": "approval_boundary",
+  "base_mcp_role": "transport_runtime",
+  "chain_role": "receipt_surface",
+  "authority": false,
+  "membrane": "HOLDS"
+}
+```

--- a/docs/alms_base_mcp_send_calls_plugin_doctrine_v0_1.md
+++ b/docs/alms_base_mcp_send_calls_plugin_doctrine_v0_1.md
@@ -1,5 +1,20 @@
 # ALMS Base MCP send_calls Plugin Doctrine V0.1
 
+## Doctrine Preamble V0.1
+
+Binary systems decide too soon.  
+Trinity systems preserve replay.
+
+A claim must be allowed to stand.  
+A challenge must be allowed to answer.  
+A witness must be allowed to preserve context.
+
+Memory precedes verdict.  
+Continuity precedes closure.  
+Authority remains false.
+
+Installation semantics: non-binding, non-authoritative, non-executing, non-promotional, non-merging, non-review-advancing.
+
 Status: DRAFT_BINDING_NOTE
 Authority: false
 Mutation model: append-only

--- a/docs/trinity_architecture_canon_v0_1.md
+++ b/docs/trinity_architecture_canon_v0_1.md
@@ -1,0 +1,88 @@
+# Trinity Architecture Canon V0.1
+
+Status: DRAFT_SCOPED_CONSTITUTIONAL_GEOMETRY
+Authority: false
+Execution: none
+Membrane: HOLDS
+
+## Purpose
+
+This canon provides the review geometry for the AL / JOY / COMPUTERWISDOM trinity without creating a merge, verdict, or authority surface.
+
+Binary systems decide too soon. Trinity systems preserve replay.
+
+## Binary collapse surfaces
+
+The following surfaces collapse context prematurely when treated as final verdicts:
+
+- true / false
+- pass / fail
+- verified / unverified
+- merge / reject
+- ready / not ready
+
+These may appear only as review mechanics, never as truth authority.
+
+## Trinity preservation surfaces
+
+The trinity preserves replay by separating:
+
+- claim: the proposed world
+- challenge: the adversarial answer
+- witness: context preserved for future replay
+- memory: the read surface that prevents premature closure
+
+## Repo mapping
+
+```json
+{
+  "AL": "doctrine_membrane",
+  "JOY": "meaning_continuity",
+  "COMPUTERWISDOM": "machine_runtime",
+  "authority": false
+}
+```
+
+## Three-daughters priority
+
+```json
+{
+  "first": "protect",
+  "second": "preserve",
+  "third": "expand"
+}
+```
+
+No review action may invert that ordering.
+
+## Review semantics
+
+Reviewers may:
+
+- read
+- audit
+- trace
+- verify presence
+- check invariants
+- request clarification
+
+Reviewers may not:
+
+- assert truth
+- adjudicate fraud
+- treat readiness as merge
+- treat a claim as verified by plugin output
+- treat a dispute as proof of falsity
+- bypass witness/context replay
+
+## Final invariant
+
+```json
+{
+  "canon": "TRINITY_ARCHITECTURE_CANON_V0_1",
+  "classification": "draft_scoped_interpretive_lens",
+  "execution": "none",
+  "authority": false,
+  "membrane": "HOLDS"
+}
+```


### PR DESCRIPTION
## Summary

Adds a lineage-aware binding note for `JOY_ALMS_BASE_MCP_PLUGIN_V0_1`.

This does not create a new doctrine island. It binds the plugin compiler model to existing AL Base MCP audit, scaffold, witness schema, MCP audit receipt schema, and action/session/permission receipt surfaces.

## Lineage

Parent references include:

- `docs/BASE_MCP_ENGINE_AUDIT_V0_1.md`
- `docs/base-mcp-scaffold-audit-receipt.md`
- `schemas/base_mcp_witness.v0_1.schema.json`
- `schemas/mcp_engine_audit_receipt.v0_1.schema.json`
- `agents/base_mcp/schemas/action_receipt.schema.json`
- `agents/base_mcp/schemas/session_log.schema.json`
- `agents/base_mcp/schemas/permission_policy.schema.json`

## Invariant

```json
{
  "mutation_model": "append_only",
  "plugin_role": "untrusted_compiler",
  "wallet_role": "approval_boundary",
  "base_mcp_role": "transport_runtime",
  "chain_role": "receipt_surface",
  "authority": false,
  "membrane": "HOLDS"
}
```

No executable calldata. No deployed contract address claimed. No truth/adjudication/fraud claims.