### PR TITLE
Epstein provenance graph v0.2

### DIFF
--- a/_truth/federal_epstein_mission/ENTITY_GRAPH_002.json
+++ b/_truth/federal_epstein_mission/ENTITY_GRAPH_002.json
@@ -44,7 +44,7 @@
     {
       "id": "MISSION_BRIEF_V0_1",
       "type": "ARTIFACT",
-      "path": "_truth/federal_epstein_mission/MISSION_BRIEF_v0.1.md",
+      "path": "_truth/federal_epstein_mission/MISSION_BRIEF_V0_1.json",
       "introduced_in": "PR_261"
     },
     {

--- a/_truth/federal_epstein_mission/ENTITY_GRAPH_002.json
+++ b/_truth/federal_epstein_mission/ENTITY_GRAPH_002.json
@@ -1,0 +1,135 @@
+{
+  "artifact": "ENTITY_GRAPH",
+  "graph_id": "ENTITY_GRAPH_002",
+  "version": "0.2-provenance",
+  "authority": false,
+  "custody_gate": "CLOSED",
+  "scope": "PROVENANCE_ONLY",
+  "created_at": "2026-06-04T00:00:00Z",
+  "boundaries": [
+    "No person nodes",
+    "No ACCUSES/IMPLICATES/CLIENT_OF/ASSOCIATED_WITH edges",
+    "No SUPPRESSED/ALTERED_BY claims",
+    "Repo artifacts and PR lineage only",
+    "PUBLIC_OUTPUT_REVIEW_ONLY"
+  ],
+  "nodes": [
+    {
+      "id": "PR_261",
+      "type": "PULL_REQUEST",
+      "repo": "jsonwisdom/AL",
+      "number": 261,
+      "state": "MERGED"
+    },
+    {
+      "id": "PR_288",
+      "type": "PULL_REQUEST",
+      "repo": "jsonwisdom/AL",
+      "number": 288,
+      "state": "OPEN_DRAFT",
+      "head_sha": "ec764c14e516711374b77d0ac7a500e34845e717"
+    },
+    {
+      "id": "MERGE_COMMIT_a6ea550",
+      "type": "COMMIT",
+      "sha": "a6ea550cbe395565dccb30f9549e2ca0c8cb352d",
+      "pr": "PR_261"
+    },
+    {
+      "id": "COMMIT_ec764c1",
+      "type": "COMMIT",
+      "sha": "ec764c14e516711374b77d0ac7a500e34845e717",
+      "pr": "PR_288"
+    },
+    {
+      "id": "MISSION_BRIEF_V0_1",
+      "type": "ARTIFACT",
+      "path": "_truth/federal_epstein_mission/MISSION_BRIEF_v0.1.md",
+      "introduced_in": "PR_261"
+    },
+    {
+      "id": "EPSTEIN_EXISTING_ARTIFACT_INDEX_001",
+      "type": "ARTIFACT",
+      "path": "_truth/federal_epstein_mission/EPSTEIN_EXISTING_ARTIFACT_INDEX_001.json",
+      "checksum_sha256": "a7872d8d3e2116ced29e3d490f47cf6af8383cd039673319ae7406185157bd4d",
+      "introduced_in": "PR_288"
+    },
+    {
+      "id": "EPSTEIN_DELTA_LEDGER_001",
+      "type": "ARTIFACT",
+      "path": "_truth/federal_epstein_mission/EPSTEIN_DELTA_LEDGER_001.json",
+      "checksum_sha256": "c0e45bd0f8bcbc34fd1796d90929526644c0456080490c219325c8735b35b378",
+      "introduced_in": "PR_288"
+    },
+    {
+      "id": "README",
+      "type": "ARTIFACT",
+      "path": "_truth/federal_epstein_mission/README.md",
+      "checksum_sha256": "0fc8e0784686f1ce7e0e112d1d6165b16d17e352abc3a9d484100a0039a0fabd",
+      "introduced_in": "PR_288"
+    }
+  ],
+  "edges": [
+    {
+      "from": "PR_261",
+      "to": "MERGE_COMMIT_a6ea550",
+      "type": "MERGED_AS"
+    },
+    {
+      "from": "PR_288",
+      "to": "COMMIT_ec764c1",
+      "type": "CONTAINS"
+    },
+    {
+      "from": "PR_288",
+      "to": "EPSTEIN_EXISTING_ARTIFACT_INDEX_001",
+      "type": "CONTAINS"
+    },
+    {
+      "from": "PR_288",
+      "to": "EPSTEIN_DELTA_LEDGER_001",
+      "type": "CONTAINS"
+    },
+    {
+      "from": "PR_288",
+      "to": "README",
+      "type": "CONTAINS"
+    },
+    {
+      "from": "EPSTEIN_EXISTING_ARTIFACT_INDEX_001",
+      "to": "EPSTEIN_EXISTING_ARTIFACT_INDEX_001",
+      "type": "HAS_CHECKSUM",
+      "value": "a7872d8d3e2116ced29e3d490f47cf6af8383cd039673319ae7406185157bd4d"
+    },
+    {
+      "from": "EPSTEIN_DELTA_LEDGER_001",
+      "to": "EPSTEIN_DELTA_LEDGER_001",
+      "type": "HAS_CHECKSUM",
+      "value": "c0e45bd0f8bcbc34fd1796d90929526644c0456080490c219325c8735b35b378"
+    },
+    {
+      "from": "README",
+      "to": "README",
+      "type": "HAS_CHECKSUM",
+      "value": "0fc8e0784686f1ce7e0e112d1d6165b16d17e352abc3a9d484100a0039a0fabd"
+    },
+    {
+      "from": "EPSTEIN_DELTA_LEDGER_001",
+      "to": "EPSTEIN_EXISTING_ARTIFACT_INDEX_001",
+      "type": "REFERENCES",
+      "field": "base_index"
+    },
+    {
+      "from": "EPSTEIN_DELTA_LEDGER_001",
+      "to": "MERGE_COMMIT_a6ea550",
+      "type": "REFERENCES",
+      "field": "deltas.merge_commit"
+    },
+    {
+      "from": "EPSTEIN_EXISTING_ARTIFACT_INDEX_001",
+      "to": "MISSION_BRIEF_V0_1",
+      "type": "DERIVED_FROM",
+      "note": "scaffold lineage"
+    }
+  ]
+}

--- a/_truth/federal_epstein_mission/ENTITY_GRAPH_002.json.sha256
+++ b/_truth/federal_epstein_mission/ENTITY_GRAPH_002.json.sha256
@@ -1,0 +1,1 @@
+63618ab59a17f6f8068ff6221883737f97751c07b971e37ac93d8dec0726dcce  _truth/federal_epstein_mission/ENTITY_GRAPH_002.json


### PR DESCRIPTION
Adds ENTITY_GRAPH_002 and checksum sidecar. Scope: PROVENANCE_ONLY. Authority: false. Custody gate: CLOSED. No person nodes, accusation edges, client-list claims, suppression claims, alteration claims, or semantic conclusions.