### PR TITLE
feat(v1.1): add strict did:key Ed25519 decoder

### DIFF
--- a/.github/workflows/verify-receipts.yml
+++ b/.github/workflows/verify-receipts.yml
@@ -34,5 +34,5 @@ jobs:
       - name: V1.1 did:key decoder fixtures
         run: |
           pip install base58
-          python tools/check_did_key_fixtures.py
+          PYTHONPATH=. python tools/check_did_key_fixtures.py
           node tools/check_did_key_fixtures.js

--- a/.github/workflows/verify-receipts.yml
+++ b/.github/workflows/verify-receipts.yml
@@ -30,3 +30,9 @@ jobs:
 
       - name: Node Parity
         run: node tools/verify_fixture.js testdata/v1/valid/receipt-public-key-valid.json testdata/v1/valid/binding.json testdata/v1/valid/policy.json
+
+      - name: V1.1 did:key decoder fixtures
+        run: |
+          pip install base58
+          python tools/check_did_key_fixtures.py
+          node tools/check_did_key_fixtures.js

--- a/docs/specs/AGENT_DELEGATION_RECEIPT_V1.md
+++ b/docs/specs/AGENT_DELEGATION_RECEIPT_V1.md
@@ -7,11 +7,11 @@
 ## Key Addition
 Per-receipt identity material in `proof`:
 - `public_key` (preferred, 64-char hex)
-- `did` (optional, stub for now)
+- `did` (optional, strict did:key decoder in V1.1)
 
 ## Resolution Order
 1. proof.public_key
-2. proof.did (did:key stub)
+2. proof.did
 3. V0 fallback key
 
 ## Errors
@@ -24,6 +24,79 @@ Per-receipt identity material in `proof`:
 Valid: receipt-public-key-valid.json (real vector)
 Invalid: missing-key, invalid-public-key, unsupported-did, tampered-signature
 
-Builds on #294. Part of #295.
+## V1.1 did:key Ed25519 decoding
+
+V1.1 introduces a strict, replay-verifiable decoder for `did:key` identifiers representing Ed25519 public keys.
+
+### Accepted form
+
+A valid Ed25519 DID key must have the form:
+
+```text
+did:key:z<base58btc>
+```
+
+Where:
+
+- `<base58btc>` decodes to exactly 34 bytes
+- the first two bytes are the Ed25519 multicodec prefix `0xed 0x01`
+- the remaining 32 bytes are the raw Ed25519 public key
+
+### Decoding pipeline
+
+The decoder performs the following steps:
+
+1. Require prefix `did:key:z`
+2. Extract the base58btc payload
+3. Decode using base58btc
+4. Require decoded length = 34 bytes
+5. Require multicodec prefix = `ed01`
+6. Return the final 32 bytes as the Ed25519 public key
+
+No fallback. No inference. No normalization. No alternative multicodecs. No alternative multibase prefixes.
+
+### Rejected forms
+
+The decoder rejects:
+
+- wrong-prefix: any DID not starting with `did:key:z`
+- wrong-multibase: any DID using a multibase prefix other than `z`
+- wrong-keytype: any multicodec prefix other than `ed01`
+- truncated: base58btc payload decoding to fewer than 34 bytes
+- extra-bytes: base58btc payload decoding to more than 34 bytes
+- empty: empty string or empty payload after `did:key:`
+- missing-z: `did:key:` followed directly by base58btc without the `z` multibase prefix
+
+### Canonical decoder errors
+
+V1.1 decoder errors are deterministic and enforced by CI in Python and JavaScript:
+
+- `invalid did:key prefix`
+- `missing base58btc payload`
+- `invalid base58btc payload`
+- `invalid multicodec length`
+- `invalid multicodec prefix`
+
+### Language parity
+
+V1.1 requires strict Python and JavaScript parity:
+
+- same valid inputs produce the same 32-byte output
+- same invalid inputs produce the same error string
+- no language-specific normalization
+- no language-specific fallback behavior
+
+Parity is enforced by CI using the canonical fixture corpus.
+
+### Fixture corpus
+
+The V1.1 decoder is tested against:
+
+- one canonical valid fixture generated from a deterministic raw Ed25519 key
+- seven invalid fixtures, each isolating a single failure mode
+
+These fixtures are part of the V1.1 replay surface and must not be altered without a new replay loop.
+
+Builds on #294. Part of #295 and #298.
 
 Do not inherit trust. Replay it.

--- a/replayloop/__init__.py
+++ b/replayloop/__init__.py
@@ -1,0 +1,1 @@
+# Replay Loop package marker.

--- a/replayloop/did.js
+++ b/replayloop/did.js
@@ -1,0 +1,77 @@
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const BASE = 58n;
+
+class DidKeyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'DidKeyError';
+  }
+}
+
+function base58Decode(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new DidKeyError('invalid base58btc payload');
+  }
+
+  let num = 0n;
+  for (const char of value) {
+    const index = ALPHABET.indexOf(char);
+    if (index === -1) {
+      throw new DidKeyError('invalid base58btc payload');
+    }
+    num = num * BASE + BigInt(index);
+  }
+
+  const bytes = [];
+  while (num > 0n) {
+    bytes.push(Number(num % 256n));
+    num = num / 256n;
+  }
+  bytes.reverse();
+
+  for (const char of value) {
+    if (char === '1') {
+      bytes.unshift(0);
+    } else {
+      break;
+    }
+  }
+
+  return Buffer.from(bytes);
+}
+
+function decodeDidKey(did) {
+  const prefix = 'did:key:z';
+
+  if (typeof did !== 'string') {
+    throw new DidKeyError('did must be a string');
+  }
+
+  if (!did.startsWith(prefix)) {
+    throw new DidKeyError('invalid did:key prefix');
+  }
+
+  const payload = did.slice(prefix.length);
+  if (!payload) {
+    throw new DidKeyError('missing base58btc payload');
+  }
+
+  const data = base58Decode(payload);
+
+  if (data.length !== 34) {
+    throw new DidKeyError('invalid multicodec length');
+  }
+
+  if (data[0] !== 0xed || data[1] !== 0x01) {
+    throw new DidKeyError('invalid multicodec prefix');
+  }
+
+  const raw32 = data.slice(2);
+  if (raw32.length !== 32) {
+    throw new DidKeyError('invalid key length');
+  }
+
+  return raw32;
+}
+
+module.exports = { decodeDidKey, DidKeyError, base58Decode };

--- a/replayloop/did.py
+++ b/replayloop/did.py
@@ -1,0 +1,45 @@
+import base58
+
+
+class DidKeyError(ValueError):
+    pass
+
+
+def decode_did_key(did: str) -> bytes:
+    """Decode did:key Ed25519 into a raw 32-byte public key.
+
+    V1.1 decoder law:
+    - DID must start with did:key:z
+    - Payload must be base58btc
+    - Decoded payload must be exactly 34 bytes
+    - First two bytes must be ed01
+    - Remaining 32 bytes are the Ed25519 public key
+    """
+    prefix = "did:key:z"
+
+    if not isinstance(did, str):
+        raise DidKeyError("did must be a string")
+
+    if not did.startswith(prefix):
+        raise DidKeyError("invalid did:key prefix")
+
+    payload = did[len(prefix):]
+    if not payload:
+        raise DidKeyError("missing base58btc payload")
+
+    try:
+        data = base58.b58decode(payload)
+    except Exception as exc:
+        raise DidKeyError("invalid base58btc payload") from exc
+
+    if len(data) != 34:
+        raise DidKeyError("invalid multicodec length")
+
+    if data[0] != 0xED or data[1] != 0x01:
+        raise DidKeyError("invalid multicodec prefix")
+
+    raw32 = data[2:]
+    if len(raw32) != 32:
+        raise DidKeyError("invalid key length")
+
+    return raw32

--- a/testdata/v1/did-key-valid.json
+++ b/testdata/v1/did-key-valid.json
@@ -1,0 +1,8 @@
+{
+  "type": "did-key-ed25519-v1.1",
+  "raw_public_key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+  "multicodec_prefix_hex": "ed01",
+  "prefixed_public_key_hex": "ed01000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+  "base58btc": "6MkeTGwHmLmuCmgg4ABYhzWVh6ZX7hTwWt8gguAretUfc9c",
+  "did": "did:key:z6MkeTGwHmLmuCmgg4ABYhzWVh6ZX7hTwWt8gguAretUfc9c"
+}

--- a/testdata/v1/invalid/did-key/empty.json
+++ b/testdata/v1/invalid/did-key/empty.json
@@ -1,0 +1,1 @@
+{"type":"did-key-invalid-v1.1","case":"empty","did":"","expected_error":"invalid did:key prefix"}

--- a/testdata/v1/invalid/did-key/extra-bytes.json
+++ b/testdata/v1/invalid/did-key/extra-bytes.json
@@ -1,0 +1,1 @@
+{"type":"did-key-invalid-v1.1","case":"extra-bytes","did":"did:key:z6MkeTGwHmLmuCmgg4ABYhzWVh6ZX7hTwWt8gguAretUfc9c11","expected_error":"invalid multicodec length"}

--- a/testdata/v1/invalid/did-key/missing-z.json
+++ b/testdata/v1/invalid/did-key/missing-z.json
@@ -1,0 +1,1 @@
+{"type":"did-key-invalid-v1.1","case":"missing-z","did":"did:key:6MkeTGwHmLmuCmgg4ABYhzWVh6ZX7hTwWt8gguAretUfc9c","expected_error":"invalid did:key prefix"}

--- a/testdata/v1/invalid/did-key/truncated.json
+++ b/testdata/v1/invalid/did-key/truncated.json
@@ -1,0 +1,1 @@
+{"type":"did-key-invalid-v1.1","case":"truncated","did":"did:key:z6MkeTGwHmLmuCmgg4ABYhzWVh6ZX7hTwWt8gguAretUfc","expected_error":"invalid multicodec length"}

--- a/testdata/v1/invalid/did-key/wrong-keytype.json
+++ b/testdata/v1/invalid/did-key/wrong-keytype.json
@@ -1,0 +1,1 @@
+{"type":"did-key-invalid-v1.1","case":"wrong-keytype","did":"did:key:z6LSbgC4DpuCf7zxewhFPnYcyBm3YgxjEEovsehvWqZzTm8z","expected_error":"invalid multicodec prefix"}

--- a/testdata/v1/invalid/did-key/wrong-multibase.json
+++ b/testdata/v1/invalid/did-key/wrong-multibase.json
@@ -1,0 +1,1 @@
+{"type":"did-key-invalid-v1.1","case":"wrong-multibase","did":"did:key:x6MkeTGwHmLmuCmgg4ABYhzWVh6ZX7hTwWt8gguAretUfc9c","expected_error":"invalid did:key prefix"}

--- a/testdata/v1/invalid/did-key/wrong-prefix.json
+++ b/testdata/v1/invalid/did-key/wrong-prefix.json
@@ -1,0 +1,1 @@
+{"type":"did-key-invalid-v1.1","case":"wrong-prefix","did":"did:keyx:z6MkeTGwHmLmuCmgg4ABYhzWVh6ZX7hTwWt8gguAretUfc9c","expected_error":"invalid did:key prefix"}

--- a/tools/check_did_key_fixtures.js
+++ b/tools/check_did_key_fixtures.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const { decodeDidKey, DidKeyError } = require('../replayloop/did.js');
+
+const VALID_FIXTURE = 'testdata/v1/did-key-valid.json';
+const INVALID_DIR = 'testdata/v1/invalid/did-key';
+
+const valid = JSON.parse(fs.readFileSync(VALID_FIXTURE, 'utf8'));
+const expectedRaw = valid.raw_public_key_hex;
+const actualRaw = Buffer.from(decodeDidKey(valid.did)).toString('hex');
+
+if (actualRaw !== expectedRaw) {
+  console.error(`VALID FIXTURE FAILED: got ${actualRaw}, expected ${expectedRaw}`);
+  process.exit(1);
+}
+
+const files = fs.readdirSync(INVALID_DIR).filter(name => name.endsWith('.json')).sort();
+
+for (const file of files) {
+  const fixturePath = path.join(INVALID_DIR, file);
+  const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+  const expected = fixture.expected_error;
+
+  try {
+    decodeDidKey(fixture.did);
+    console.error(`INVALID FIXTURE DID NOT FAIL: ${fixturePath}`);
+    process.exit(1);
+  } catch (error) {
+    if (!(error instanceof DidKeyError)) {
+      console.error(`INVALID ERROR TYPE in ${fixturePath}: ${error}`);
+      process.exit(1);
+    }
+    if (error.message !== expected) {
+      console.error(
+        `INVALID FIXTURE WRONG ERROR in ${fixturePath}:\n` +
+        `  got:      ${error.message}\n` +
+        `  expected: ${expected}`
+      );
+      process.exit(1);
+    }
+  }
+}
+
+console.log('JS decoder: OK');

--- a/tools/check_did_key_fixtures.py
+++ b/tools/check_did_key_fixtures.py
@@ -1,0 +1,38 @@
+import glob
+import json
+from replayloop.did import decode_did_key, DidKeyError
+
+VALID_FIXTURE = "testdata/v1/did-key-valid.json"
+INVALID_GLOB = "testdata/v1/invalid/did-key/*.json"
+
+with open(VALID_FIXTURE, "r") as f:
+    valid = json.load(f)
+
+expected_raw = valid["raw_public_key_hex"]
+did = valid["did"]
+actual_raw = decode_did_key(did).hex()
+
+if actual_raw != expected_raw:
+    raise SystemExit(
+        f"VALID FIXTURE FAILED: got {actual_raw}, expected {expected_raw}"
+    )
+
+for path in sorted(glob.glob(INVALID_GLOB)):
+    with open(path, "r") as f:
+        fixture = json.load(f)
+
+    did = fixture["did"]
+    expected = fixture["expected_error"]
+
+    try:
+        decode_did_key(did)
+        raise SystemExit(f"INVALID FIXTURE DID NOT FAIL: {path}")
+    except DidKeyError as exc:
+        if str(exc) != expected:
+            raise SystemExit(
+                f"INVALID FIXTURE WRONG ERROR in {path}:\n"
+                f"  got:      {str(exc)}\n"
+                f"  expected: {expected}"
+            )
+
+print("Python decoder: OK")


### PR DESCRIPTION
## Summary

Adds Replay Loop V1.1 strict `did:key` Ed25519 decoding.

### Changes
- Add Python and JavaScript `did:key` decoders
- Enforce `did:key:z` + base58btc + `ed01` + 32-byte Ed25519 public key
- Add canonical generated valid fixture
- Add invalid fixture corpus for wrong prefix, wrong multibase, wrong key type, truncated payload, extra bytes, empty string, and missing `z`
- Add Python and JavaScript fixture checkers
- Wire V1.1 decoder checks into CI
- Document the V1.1 decoder contract in the V1 spec

### Validation
- Python valid fixture returns the expected raw 32-byte key
- Python invalid fixtures fail with expected deterministic errors
- JavaScript valid fixture returns the expected raw 32-byte key
- JavaScript invalid fixtures fail with expected deterministic errors
- CI green on branch run #39

Refs #298
Builds on V1 merge commit 301c38e25260636a5490fb9c7a5656d20e219b18

Do not inherit trust. Replay it.