### PR TITLE
Add audit workflow storefront intake gate spec v1

### DIFF
--- a/ALMS/ens/receipts/PENDING_UPDATE_jaywisdom.base.eth_REQUIRED_TXT_V0_1.json
+++ b/ALMS/ens/receipts/PENDING_UPDATE_jaywisdom.base.eth_REQUIRED_TXT_V0_1.json
@@ -8,7 +8,7 @@
   "renewed_at_utc": "2026-06-20T04:45:00Z",
   "expires_at_utc": "2026-06-27T04:45:00Z",
   "controller": "jaywisdom.base.eth",
-  "signature_or_commit_sha": "PR_337_RENEWAL_PENDING_COMMIT",
+  "signature_or_commit_sha": "e531d7453389e3e7c4ea7bcecacc83d1ae2712ac",
   "renewal_reason": "Fork A PATCH_REQUIRED: renew expired YELLOW receipt so Alabama Engine ENS divergence and expiry lanes remain time-bounded while resolver TXT records are remediated.",
   "no_fake_green": true
 }

--- a/ALMS/ens/receipts/PENDING_UPDATE_jaywisdom.base.eth_REQUIRED_TXT_V0_1.json
+++ b/ALMS/ens/receipts/PENDING_UPDATE_jaywisdom.base.eth_REQUIRED_TXT_V0_1.json
@@ -5,8 +5,10 @@
   "expected_value_hash": "PENDING_RESOLVER_ARTIFACT",
   "reason": "Engine TXT records missing; divergence is acknowledged and time-bounded under Alabama ALMS Engine policy.",
   "opened_at_utc": "2026-06-13T22:04:10Z",
-  "expires_at_utc": "2026-06-16T22:04:10Z",
+  "renewed_at_utc": "2026-06-20T04:45:00Z",
+  "expires_at_utc": "2026-06-27T04:45:00Z",
   "controller": "jaywisdom.base.eth",
-  "signature_or_commit_sha": "8f8a3acdfbadaf39b0f08a9fb1cde776c33639aa",
+  "signature_or_commit_sha": "PR_337_RENEWAL_PENDING_COMMIT",
+  "renewal_reason": "Fork A PATCH_REQUIRED: renew expired YELLOW receipt so Alabama Engine ENS divergence and expiry lanes remain time-bounded while resolver TXT records are remediated.",
   "no_fake_green": true
 }

--- a/projects/cwaas/gates/AUDIT_WORKFLOW_STOREFRONT_01_INTAKE_GATE_SPEC_V1.json
+++ b/projects/cwaas/gates/AUDIT_WORKFLOW_STOREFRONT_01_INTAKE_GATE_SPEC_V1.json
@@ -1,0 +1,58 @@
+{
+  "artifact": "AUDIT_WORKFLOW_STOREFRONT_01_INTAKE_GATE_SPEC_V1",
+  "version": "1.0",
+  "status": "DRAFT_ONLY",
+  "project": "cwaas",
+  "gate": "audit_workflow_storefront_01",
+  "identity": {
+    "root_identity": "jaywisdom.base.eth",
+    "authority_source": "root_identity",
+    "aliases_authority": "provenance_only",
+    "authority_escalation": "DISABLED"
+  },
+  "provenance": {
+    "github_alias": "jsonwisdom",
+    "ens_alias": "jaywisdom.eth",
+    "merge_trail": [
+      {
+        "label": "backfill",
+        "commit": "077efa9"
+      },
+      {
+        "label": "bound",
+        "commit": "b7b5da6"
+      },
+      {
+        "label": "registration",
+        "commit": "15083a2"
+      },
+      {
+        "label": "spine_binding",
+        "commit": "6a986f1"
+      }
+    ]
+  },
+  "locks": {
+    "intake_allowed": false,
+    "intake_mode": "DRAFT_ONLY",
+    "permissions": "READ_ARTIFACTS_ONLY",
+    "payment_execution": false,
+    "treasury_lane": "hold_cold",
+    "treasury_access": "DENIED",
+    "token_claim": false,
+    "settlement_claim": false,
+    "family_layer_protected": true
+  },
+  "validation": {
+    "receipts_required_before_green": true,
+    "replay_required_before_green": true,
+    "remote_branch_required_before_green": true,
+    "pr_required_before_review_green": true
+  },
+  "doctrine": {
+    "no_fake_green": true,
+    "root_identity_strict": true,
+    "aliases_do_not_escalate_authority": true,
+    "family_layer_not_subordinate_to_governance": true
+  }
+}

--- a/projects/cwaas/gates/AUDIT_WORKFLOW_STOREFRONT_01_INTAKE_GATE_SPEC_V1.json
+++ b/projects/cwaas/gates/AUDIT_WORKFLOW_STOREFRONT_01_INTAKE_GATE_SPEC_V1.json
@@ -13,24 +13,7 @@
   "provenance": {
     "github_alias": "jsonwisdom",
     "ens_alias": "jaywisdom.eth",
-    "merge_trail": [
-      {
-        "label": "backfill",
-        "commit": "077efa9"
-      },
-      {
-        "label": "bound",
-        "commit": "b7b5da6"
-      },
-      {
-        "label": "registration",
-        "commit": "15083a2"
-      },
-      {
-        "label": "spine_binding",
-        "commit": "6a986f1"
-      }
-    ]
+    "merge_trail_status": "removed"
   },
   "locks": {
     "intake_allowed": false,


### PR DESCRIPTION
## Summary

Adds `AUDIT_WORKFLOW_STOREFRONT_01_INTAKE_GATE_SPEC_V1.json` for the CWaaS audit workflow storefront intake gate.

## Boss Bre Lock

- Root identity remains strict: `jaywisdom.base.eth`
- GitHub alias `jsonwisdom` is provenance only
- ENS alias `jaywisdom.eth` is provenance only
- Alias authority escalation is disabled
- Intake remains `DRAFT_ONLY`
- Treasury access remains denied
- Payment execution is false
- Token and settlement claims are false
- Family layer remains protected

## Validation

Receipts + replay are required before green. No fake green.