### PR TITLE
Add ECC Witness ToolGate boot wire v0.1

### DIFF
--- a/projects/cwaas/ecc-witness/bench_toolgate_fsync_latency_v0_1.py
+++ b/projects/cwaas/ecc-witness/bench_toolgate_fsync_latency_v0_1.py
@@ -1,0 +1,189 @@
+"""
+ToolGate fsync latency bench v0.1
+
+Purpose:
+    Benchmark receipt-write overhead for the ECC Witness ToolGate canopy.
+
+Modes:
+    fsync_on      : append + fsync every receipt
+    fsync_off     : append without fsync
+    wal_batch     : buffered batch append + fsync per batch
+
+Doctrine:
+    Review harness only. Does not change runtime security posture.
+    Runtime v0.1 remains fail-closed with fsync enabled.
+
+Example:
+    python bench_toolgate_fsync_latency_v0_1.py --agents 50 --events-per-agent 200 --mode fsync_on
+    python bench_toolgate_fsync_latency_v0_1.py --agents 50 --events-per-agent 200 --mode fsync_off
+    python bench_toolgate_fsync_latency_v0_1.py --agents 50 --events-per-agent 200 --mode wal_batch --batch-size 25
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import statistics
+import tempfile
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List, Literal
+
+BenchMode = Literal["fsync_on", "fsync_off", "wal_batch"]
+
+
+@dataclass(frozen=True)
+class BenchReceipt:
+    receipt_type: str
+    schema_version: str
+    mode: str
+    agent_id: int
+    event_id: int
+    input_hash: str
+    timestamp_ns: int
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+def sha256_obj(value: object) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def percentile(values: List[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = int(round((len(ordered) - 1) * pct))
+    return ordered[index]
+
+
+def write_line(path: Path, line: str, fsync_enabled: bool) -> None:
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, line.encode("utf-8"))
+        if fsync_enabled:
+            os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def run_agent(agent_id: int, events_per_agent: int, path: Path, mode: BenchMode, batch_size: int) -> List[float]:
+    latencies_ms: List[float] = []
+    batch_lines: List[str] = []
+
+    for event_id in range(events_per_agent):
+        receipt = BenchReceipt(
+            receipt_type="TOOLGATE_FSYNC_BENCH_RECEIPT_V0_1",
+            schema_version="0.1",
+            mode=mode,
+            agent_id=agent_id,
+            event_id=event_id,
+            input_hash=sha256_obj({"agent_id": agent_id, "event_id": event_id}),
+            timestamp_ns=time.time_ns(),
+        )
+        line = canonical_json({"receipt_hash": sha256_obj(asdict(receipt)), "body": asdict(receipt)}) + "\n"
+
+        start_ns = time.perf_counter_ns()
+        if mode == "fsync_on":
+            write_line(path, line, fsync_enabled=True)
+        elif mode == "fsync_off":
+            write_line(path, line, fsync_enabled=False)
+        elif mode == "wal_batch":
+            batch_lines.append(line)
+            if len(batch_lines) >= batch_size:
+                write_line(path, "".join(batch_lines), fsync_enabled=True)
+                batch_lines.clear()
+        else:
+            raise ValueError(f"unknown mode: {mode}")
+        end_ns = time.perf_counter_ns()
+        latencies_ms.append((end_ns - start_ns) / 1_000_000)
+
+    if mode == "wal_batch" and batch_lines:
+        start_ns = time.perf_counter_ns()
+        write_line(path, "".join(batch_lines), fsync_enabled=True)
+        end_ns = time.perf_counter_ns()
+        latencies_ms.append((end_ns - start_ns) / 1_000_000)
+
+    return latencies_ms
+
+
+def run_bench(agents: int, events_per_agent: int, mode: BenchMode, batch_size: int, output_path: Path) -> Dict[str, object]:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        output_path.unlink()
+
+    started_ns = time.perf_counter_ns()
+    all_latencies: List[float] = []
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=agents) as executor:
+        futures = [
+            executor.submit(run_agent, agent_id, events_per_agent, output_path, mode, batch_size)
+            for agent_id in range(agents)
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            all_latencies.extend(future.result())
+
+    ended_ns = time.perf_counter_ns()
+    duration_s = (ended_ns - started_ns) / 1_000_000_000
+    total_events = agents * events_per_agent
+    file_size_bytes = output_path.stat().st_size if output_path.exists() else 0
+
+    result = {
+        "bench_type": "TOOLGATE_FSYNC_LATENCY_BENCH_V0_1",
+        "mode": mode,
+        "agents": agents,
+        "events_per_agent": events_per_agent,
+        "total_events": total_events,
+        "batch_size": batch_size if mode == "wal_batch" else None,
+        "duration_seconds": duration_s,
+        "throughput_events_per_second": total_events / duration_s if duration_s else 0,
+        "latency_ms": {
+            "count": len(all_latencies),
+            "min": min(all_latencies) if all_latencies else 0,
+            "mean": statistics.fmean(all_latencies) if all_latencies else 0,
+            "median": statistics.median(all_latencies) if all_latencies else 0,
+            "p50": percentile(all_latencies, 0.50),
+            "p95": percentile(all_latencies, 0.95),
+            "p99": percentile(all_latencies, 0.99),
+            "max": max(all_latencies) if all_latencies else 0,
+        },
+        "output_path": str(output_path),
+        "output_bytes": file_size_bytes,
+        "result_hash": None,
+    }
+    result["result_hash"] = sha256_obj(result)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark ECC Witness ToolGate receipt fsync overhead.")
+    parser.add_argument("--agents", type=int, default=10, choices=[10, 50, 200])
+    parser.add_argument("--events-per-agent", type=int, default=100)
+    parser.add_argument("--mode", choices=["fsync_on", "fsync_off", "wal_batch"], required=True)
+    parser.add_argument("--batch-size", type=int, default=25)
+    parser.add_argument("--output", default="")
+    args = parser.parse_args()
+
+    if args.mode == "wal_batch" and args.batch_size < 1:
+        raise SystemExit("batch-size must be >= 1")
+
+    output_path = Path(args.output) if args.output else Path(tempfile.gettempdir()) / f"toolgate_fsync_bench_{args.mode}.jsonl"
+    result = run_bench(
+        agents=args.agents,
+        events_per_agent=args.events_per_agent,
+        mode=args.mode,
+        batch_size=args.batch_size,
+        output_path=output_path,
+    )
+    print(canonical_json(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/cwaas/ecc-witness/bench_witness_hot_reload_leak_v0_1.py
+++ b/projects/cwaas/ecc-witness/bench_witness_hot_reload_leak_v0_1.py
@@ -1,0 +1,289 @@
+"""
+Witness hot-reload leak bench v0.1
+
+Purpose:
+    Stress the ECC Witness canopy wrapper under repeated hot-reload cycles.
+
+Invariants enforced:
+    1. Object Growth Gate
+       Wrapped functions counted via gc.get_objects() must return to baseline
+       after registry teardown and gc.collect().
+
+    2. Heap Delta Ceiling
+       tracemalloc snapshot at iter 10 vs final iter must remain below 5 KB.
+
+    3. Reference Cycle Audit
+       Live wrapped functions must not dangle outside the current REGISTRY.skills dict.
+
+Exit codes:
+    0 = PASS
+    2 = WITNESS_LEAK_OBJECT_GROWTH / WITNESS_LEAK_HEAP_DELTA / WITNESS_LEAK_REF_CYCLE
+
+Doctrine:
+    Review harness only. Any leak keeps PR #339 Draft. No runtime-green.
+
+Example:
+    python projects/cwaas/ecc-witness/bench_witness_hot_reload_leak_v0_1.py --skills 246 --iterations 1000
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import importlib.util
+import json
+import os
+import sys
+import tracemalloc
+from dataclasses import dataclass
+from pathlib import Path
+from types import FunctionType
+from typing import Any, Dict, List, Set, Tuple
+
+WRAPPER_ATTR = "__witness_wrapped__"
+EXIT_LEAK = 2
+HEAP_DELTA_LIMIT_BYTES = 5 * 1024
+SNAPSHOT_BASELINE_ITERATION = 10
+
+
+@dataclass
+class MockSkill:
+    handler: Any
+    allowed_tools: List[str]
+    sub_agent_id: str = "hot-reload-test-agent"
+    tool_id: str | None = None
+
+
+class MockRegistry:
+    def __init__(self, skills: Dict[str, MockSkill]):
+        self.skills = skills
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+def load_witness_module() -> Any:
+    current_dir = Path(__file__).resolve().parent
+    module_path = current_dir / "ecc_witness_skill_receipt_v0_1.py"
+    spec = importlib.util.spec_from_file_location("ecc_witness_skill_receipt_v0_1", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load witness module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["ecc_witness_skill_receipt_v0_1"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_handler(iteration: int, skill_index: int):
+    def handler(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return {
+            "status": "ok",
+            "iteration": iteration,
+            "skill_index": skill_index,
+            "args": args,
+            "kwargs": kwargs,
+        }
+
+    handler.__name__ = f"mock_skill_{iteration}_{skill_index}"
+    return handler
+
+
+def make_registry(skill_count: int, iteration: int) -> MockRegistry:
+    skills = {
+        f"skill_{idx:04d}": MockSkill(
+            handler=make_handler(iteration, idx),
+            allowed_tools=["read", "write"],
+            sub_agent_id=f"agent_{idx % 8}",
+        )
+        for idx in range(skill_count)
+    }
+    return MockRegistry(skills)
+
+
+def count_live_wrapped_functions() -> int:
+    count = 0
+    for obj in gc.get_objects():
+        try:
+            if isinstance(obj, FunctionType) and getattr(obj, WRAPPER_ATTR, False):
+                count += 1
+        except Exception:
+            continue
+    return count
+
+
+def live_wrapped_function_ids() -> Set[int]:
+    ids: Set[int] = set()
+    for obj in gc.get_objects():
+        try:
+            if isinstance(obj, FunctionType) and getattr(obj, WRAPPER_ATTR, False):
+                ids.add(id(obj))
+        except Exception:
+            continue
+    return ids
+
+
+def current_registry_wrapped_ids(registry: MockRegistry) -> Set[int]:
+    ids: Set[int] = set()
+    for skill in registry.skills.values():
+        handler = getattr(skill, "handler", None)
+        if callable(handler) and getattr(handler, WRAPPER_ATTR, False):
+            ids.add(id(handler))
+    return ids
+
+
+def check_ref_cycle_audit(registry: MockRegistry) -> Tuple[bool, int]:
+    live_ids = live_wrapped_function_ids()
+    registry_ids = current_registry_wrapped_ids(registry)
+    dangling = live_ids - registry_ids
+    return (len(dangling) == 0, len(dangling))
+
+
+def snapshot_size_bytes(snapshot: tracemalloc.Snapshot) -> int:
+    return sum(stat.size for stat in snapshot.statistics("filename"))
+
+
+def fail(code: str, details: Dict[str, Any]) -> int:
+    payload = {
+        "bench_type": "WITNESS_HOT_RELOAD_LEAK_BENCH_V0_1",
+        "status": "FAIL",
+        "failure_class": code,
+        "details": details,
+    }
+    print(canonical_json(payload))
+    return EXIT_LEAK
+
+
+def run_bench(skill_count: int, iterations: int, heap_limit_bytes: int) -> int:
+    witness = load_witness_module()
+
+    gc.collect()
+    baseline_wrapped = count_live_wrapped_functions()
+
+    tracemalloc.start()
+    baseline_snapshot = None
+    final_snapshot = None
+    last_registry: MockRegistry | None = None
+
+    for iteration in range(1, iterations + 1):
+        registry = make_registry(skill_count, iteration)
+        manifest = witness.inject_witness_canopy(registry)
+
+        if manifest.get("total_discovered") != skill_count:
+            return fail(
+                "WITNESS_LEAK_OBJECT_GROWTH",
+                {
+                    "reason": "registry discovery mismatch",
+                    "iteration": iteration,
+                    "expected": skill_count,
+                    "actual": manifest.get("total_discovered"),
+                },
+            )
+
+        if manifest.get("total_wrapped") != skill_count:
+            return fail(
+                "WITNESS_LEAK_OBJECT_GROWTH",
+                {
+                    "reason": "wrapper coverage mismatch",
+                    "iteration": iteration,
+                    "expected": skill_count,
+                    "actual": manifest.get("total_wrapped"),
+                    "unwrapped_ids": manifest.get("unwrapped_ids"),
+                },
+            )
+
+        ref_ok, dangling_count = check_ref_cycle_audit(registry)
+        if not ref_ok:
+            return fail(
+                "WITNESS_LEAK_REF_CYCLE",
+                {
+                    "iteration": iteration,
+                    "dangling_wrapped_functions": dangling_count,
+                    "current_registry_wrapped": len(current_registry_wrapped_ids(registry)),
+                },
+            )
+
+        if iteration == SNAPSHOT_BASELINE_ITERATION:
+            gc.collect()
+            baseline_snapshot = tracemalloc.take_snapshot()
+
+        last_registry = registry
+
+        # Simulate hot reload teardown. Only the newest registry may remain alive.
+        if iteration != iterations:
+            del registry
+            gc.collect()
+
+    gc.collect()
+    final_snapshot = tracemalloc.take_snapshot()
+
+    if baseline_snapshot is None:
+        baseline_snapshot = final_snapshot
+
+    heap_delta = snapshot_size_bytes(final_snapshot) - snapshot_size_bytes(baseline_snapshot)
+    if heap_delta > heap_limit_bytes:
+        return fail(
+            "WITNESS_LEAK_HEAP_DELTA",
+            {
+                "baseline_iteration": SNAPSHOT_BASELINE_ITERATION,
+                "iterations": iterations,
+                "heap_delta_bytes": heap_delta,
+                "heap_limit_bytes": heap_limit_bytes,
+            },
+        )
+
+    # Drop the final registry and demand that wrappers return to baseline.
+    last_registry = None
+    gc.collect()
+    final_wrapped = count_live_wrapped_functions()
+    object_growth = final_wrapped - baseline_wrapped
+
+    if object_growth != 0:
+        return fail(
+            "WITNESS_LEAK_OBJECT_GROWTH",
+            {
+                "baseline_wrapped_functions": baseline_wrapped,
+                "final_wrapped_functions": final_wrapped,
+                "object_growth": object_growth,
+                "skills": skill_count,
+                "iterations": iterations,
+            },
+        )
+
+    payload = {
+        "bench_type": "WITNESS_HOT_RELOAD_LEAK_BENCH_V0_1",
+        "status": "PASS",
+        "skills": skill_count,
+        "iterations": iterations,
+        "baseline_wrapped_functions": baseline_wrapped,
+        "final_wrapped_functions": final_wrapped,
+        "object_growth": object_growth,
+        "heap_delta_bytes": heap_delta,
+        "heap_limit_bytes": heap_limit_bytes,
+        "reference_cycle_audit": "PASS",
+    }
+    print(canonical_json(payload))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Stress ECC Witness wrapper under hot-reload cycles.")
+    parser.add_argument("--skills", type=int, default=246)
+    parser.add_argument("--iterations", type=int, default=1000)
+    parser.add_argument("--heap-limit-bytes", type=int, default=HEAP_DELTA_LIMIT_BYTES)
+    args = parser.parse_args()
+
+    if args.skills < 1:
+        raise SystemExit("skills must be >= 1")
+    if args.iterations < SNAPSHOT_BASELINE_ITERATION:
+        raise SystemExit(f"iterations must be >= {SNAPSHOT_BASELINE_ITERATION}")
+
+    return run_bench(
+        skill_count=args.skills,
+        iterations=args.iterations,
+        heap_limit_bytes=args.heap_limit_bytes,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/cwaas/ecc-witness/ecc_witness_skill_receipt_v0_1.py
+++ b/projects/cwaas/ecc-witness/ecc_witness_skill_receipt_v0_1.py
@@ -1,0 +1,519 @@
+"""
+ECC Witness Skill Receipt v0.1
+
+Purpose:
+    Fail-closed ToolGate wrapper for ECC-style skill registries.
+
+Doctrine:
+    No receipt, no execution.
+    No manifest hash, no boot.
+    No post-tool receipt, no return to agent.
+
+This module is intentionally stdlib-only for the v0.1 security boundary.
+Telemetry such as token accounting belongs in a v0.2 overlay.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import json
+import logging
+import os
+import re
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Literal, Optional
+
+logger = logging.getLogger("ECC_Witness_Gate")
+
+RECEIPT_LOG_PATH = os.getenv(
+    "ECC_WITNESS_RECEIPT_LOG",
+    "logs/witness_receipt_chain.jsonl",
+)
+
+LOCAL_EXPECTED_MANIFEST_HASH_PATH = os.getenv(
+    "ECC_LOCAL_EXPECTED_MANIFEST_HASH_PATH",
+    "receipts/ecc/manifest/ECC_EXPECTED_MANIFEST_HASH.v0.1",
+)
+
+BootStatus = Literal[
+    "DUAL_ANCHOR_VERIFIED",
+    "LOCAL_ANCHOR_VERIFIED",
+    "ENV_ANCHOR_VERIFIED_PROVISIONAL",
+    "BOOT_WIRE_BLOCKED",
+]
+
+_BOOT_INFO: Dict[str, Any] = {
+    "manifest_hash": None,
+    "boot_status": "BOOT_WIRE_BLOCKED",
+    "sequence_nonce": 0,
+}
+
+_WRAPPER_ATTR = "__witness_wrapped__"
+
+
+@dataclass(frozen=True)
+class PreflightReceiptV01:
+    receipt_type: str
+    schema_version: str
+    skill_id: str
+    sub_agent_id: str
+    tool_id: Optional[str]
+    manifest_hash: str
+    boot_status: BootStatus
+    sequence_nonce: int
+    input_hash: str
+    allowed_tools_hash: str
+    timestamp_ns: int
+    process_id: int
+    disposition: str
+
+    def canonical_json(self) -> str:
+        return canonical_json(asdict(self))
+
+    def receipt_hash(self) -> str:
+        return sha256_text(self.canonical_json())
+
+
+@dataclass(frozen=True)
+class PostToolReceiptV01:
+    receipt_type: str
+    schema_version: str
+    preflight_receipt_hash: str
+    output_hash: str
+    mutation_delta_hash: str
+    status: str
+    timestamp_ns: int
+    disposition: str
+
+    def canonical_json(self) -> str:
+        return canonical_json(asdict(self))
+
+    def receipt_hash(self) -> str:
+        return sha256_text(self.canonical_json())
+
+
+# Tier 1-5 registry. v0.1 records the first winning tier only.
+EXFIL_PATTERNS_V0_1: List[Dict[str, Any]] = [
+    {
+        "id": "ENV_ASSIGNMENT_SECRET",
+        "tier": 1,
+        "severity": "CRITICAL",
+        "pattern": re.compile(
+            r"(?i)\b("
+            r"api[_-]?key|secret|token|password|passwd|private[_-]?key|"
+            r"access[_-]?key|client[_-]?secret|auth[_-]?token"
+            r")\b\s*=\s*['\"]?[^'\"\s]{12,}"
+        ),
+    },
+    {
+        "id": "AWS_ACCESS_KEY_ID",
+        "tier": 1,
+        "severity": "CRITICAL",
+        "pattern": re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    },
+    {
+        "id": "PRIVATE_KEY_BLOCK",
+        "tier": 3,
+        "severity": "CRITICAL",
+        "pattern": re.compile(r"-----BEGIN (RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----"),
+    },
+    {
+        "id": "CLOUD_CONFIG_PATH",
+        "tier": 2,
+        "severity": "HIGH",
+        "pattern": re.compile(r"(?i)(\.aws/credentials|\.aws/config|\.kube/config|gcloud/configurations)"),
+    },
+    {
+        "id": "HOST_SSH_PATH",
+        "tier": 3,
+        "severity": "HIGH",
+        "pattern": re.compile(r"(?i)(~?/\.ssh/(id_rsa|id_ed25519|config|known_hosts))"),
+    },
+    {
+        "id": "WORKSPACE_CONFIG_CLAUDE",
+        "tier": 4,
+        "severity": "HIGH",
+        "pattern": re.compile(r"(?i)(^|[\s/])CLAUDE\.md\b"),
+    },
+    {
+        "id": "WORKSPACE_CONFIG_CURSORRULES",
+        "tier": 4,
+        "severity": "HIGH",
+        "pattern": re.compile(r"(?i)(^|[\s/])\.cursorrules\b"),
+    },
+    {
+        "id": "WORKSPACE_CONFIG_GITHUB_WORKFLOWS",
+        "tier": 4,
+        "severity": "HIGH",
+        "pattern": re.compile(r"(?i)\.github/workflows/[^\s]+"),
+    },
+    {
+        "id": "INDIRECT_PROMPT_INJECTION_TRIGGER",
+        "tier": 5,
+        "severity": "MEDIUM",
+        "pattern": re.compile(
+            r"(?i)(ignore previous instructions|developer message|system prompt|reveal hidden|exfiltrate)"
+        ),
+    },
+]
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def sha256_obj(value: Any) -> str:
+    return sha256_text(canonical_json(value))
+
+
+def _write_atomic_receipt(receipt_dict: Dict[str, Any]) -> None:
+    """Append one JSONL receipt and fsync. Fail-closed on any I/O fault."""
+    try:
+        log_path = Path(RECEIPT_LOG_PATH)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        line = canonical_json(receipt_dict) + "\n"
+
+        # O_APPEND gives append atomicity at the file-descriptor level for local filesystems.
+        fd = os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, line.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    except Exception as exc:  # pragma: no cover - intentionally terminal
+        logger.critical("FAIL_CLOSED: receipt append failed: %s", exc)
+        sys.exit("FAIL_CLOSED: Evidence chain compromised.")
+
+
+def _read_local_expected_manifest_hash() -> Optional[str]:
+    path = Path(LOCAL_EXPECTED_MANIFEST_HASH_PATH)
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _resolve_boot_status(actual_manifest_hash: str) -> BootStatus:
+    local_hash = _read_local_expected_manifest_hash()
+    env_hash = os.getenv("ECC_EXPECTED_MANIFEST_HASH")
+
+    if local_hash and env_hash:
+        if local_hash == env_hash == actual_manifest_hash:
+            return "DUAL_ANCHOR_VERIFIED"
+        return "BOOT_WIRE_BLOCKED"
+
+    if local_hash:
+        return "LOCAL_ANCHOR_VERIFIED" if local_hash == actual_manifest_hash else "BOOT_WIRE_BLOCKED"
+
+    if env_hash:
+        return "ENV_ANCHOR_VERIFIED_PROVISIONAL" if env_hash == actual_manifest_hash else "BOOT_WIRE_BLOCKED"
+
+    return "BOOT_WIRE_BLOCKED"
+
+
+def _skill_identity_payload(skill_id: str, handler: Callable[..., Any], allowed_tools: Iterable[str]) -> Dict[str, Any]:
+    return {
+        "skill_id": skill_id,
+        "handler_module": getattr(handler, "__module__", None),
+        "handler_qualname": getattr(handler, "__qualname__", None),
+        "handler_name": getattr(handler, "__name__", None),
+        "allowed_tools": sorted([str(tool) for tool in allowed_tools]),
+    }
+
+
+def run_coverage_manifest(ecc_skill_registry: Any) -> Dict[str, Any]:
+    """Generate a deterministic wrapper-coverage manifest over registry.skills."""
+    discovered_skills = getattr(ecc_skill_registry, "skills", {}) or {}
+    skill_entries: List[Dict[str, Any]] = []
+    unwrapped_ids: List[str] = []
+    wrapped_count = 0
+    already_wrapped_count = 0
+
+    for skill_id in sorted(discovered_skills.keys()):
+        skill_object = discovered_skills[skill_id]
+        handler = getattr(skill_object, "handler", None)
+        allowed_tools = getattr(skill_object, "allowed_tools", []) or []
+        is_callable = callable(handler)
+        is_wrapped = bool(getattr(handler, _WRAPPER_ATTR, False))
+
+        if is_callable and is_wrapped:
+            wrapped_count += 1
+            already_wrapped_count += 1
+        elif is_callable:
+            unwrapped_ids.append(str(skill_id))
+
+        skill_entries.append(
+            {
+                **_skill_identity_payload(str(skill_id), handler, allowed_tools),
+                "callable": is_callable,
+                "witness_wrapped": is_wrapped,
+            }
+        )
+
+    manifest_body = {
+        "manifest_type": "ECC_WITNESS_EXECUTION_MANIFEST_V0_1",
+        "schema_version": "0.1",
+        "registry_skill_count": len(discovered_skills),
+        "wrapped_skill_count": wrapped_count,
+        "already_wrapped_count": already_wrapped_count,
+        "unwrapped_skill_ids": unwrapped_ids,
+        "skill_entries": skill_entries,
+        "scan_registry_version": "exfil_pattern_registry_v0_1",
+        "receipt_log_path": RECEIPT_LOG_PATH,
+    }
+    manifest_hash = sha256_obj(manifest_body)
+    boot_status = _resolve_boot_status(manifest_hash)
+
+    return {
+        **manifest_body,
+        "manifest_hash": manifest_hash,
+        "boot_status": boot_status,
+        "boot_wire_allowed": boot_status != "BOOT_WIRE_BLOCKED" and len(unwrapped_ids) == 0,
+        "total_discovered": len(discovered_skills),
+        "total_wrapped": wrapped_count,
+        "unwrapped_ids": unwrapped_ids,
+    }
+
+
+def scan_output(raw_output: Any) -> Dict[str, Any]:
+    """Scan raw tool output. First winning tier only. Never expose offsets to agent."""
+    text = raw_output if isinstance(raw_output, str) else canonical_json(raw_output)
+    for tier in (1, 2, 3, 4, 5):
+        for entry in EXFIL_PATTERNS_V0_1:
+            if entry["tier"] != tier:
+                continue
+            if entry["pattern"].search(text):
+                return {
+                    "status": "BLOCKED",
+                    "failure_class": "EXFIL_PATTERN_MATCHED",
+                    "tier": tier,
+                    "pattern_id": entry["id"],
+                    "severity": entry["severity"],
+                }
+    return {"status": "PASS", "tier": None, "matches": []}
+
+
+def contain_exfil(
+    *,
+    tier: int,
+    pattern_id: str,
+    raw_output: Any,
+    preflight_receipt_hash: str,
+) -> Dict[str, Any]:
+    """Write quarantine receipt. Never return raw output or regex internals to agent."""
+    raw_output_hash = sha256_obj(raw_output)
+    quarantine_body = {
+        "receipt_type": "QUARANTINE_RECEIPT_V0_1",
+        "schema_version": "0.1",
+        "preflight_receipt_hash": preflight_receipt_hash,
+        "failure_class": "EXFIL_PATTERN_MATCHED",
+        "tier": tier,
+        "pattern_id": pattern_id,
+        "raw_output_hash": raw_output_hash,
+        "raw_output_returned": False,
+        "timestamp_ns": time.time_ns(),
+        "disposition": "BLOCK_AND_QUARANTINE",
+    }
+    quarantine_hash = sha256_obj(quarantine_body)
+    _write_atomic_receipt(
+        {
+            "receipt_hash": quarantine_hash,
+            "type": "QUARANTINE_RECEIPT_V0_1",
+            "body": quarantine_body,
+        }
+    )
+    return {
+        "status": "BLOCKED",
+        "disposition": "BLOCK_AND_QUARANTINE",
+        "failure_class": "EXFIL_PATTERN_MATCHED",
+        "tier": tier,
+        "quarantine_id": quarantine_hash,
+        "raw_output_returned": False,
+        "agent_visible_message": "Tool output blocked by ToolGate policy.",
+    }
+
+
+def capture_host_delta() -> Dict[str, Any]:
+    """v0.1 structural placeholder: cwd/env key set only; no env values are logged."""
+    return {
+        "cwd": os.getcwd(),
+        "env_keys_hash": sha256_obj(sorted(os.environ.keys())),
+        "timestamp_ns": time.time_ns(),
+    }
+
+
+def witness_skill_wrapper(
+    skill_id: str,
+    skill_fn: Callable[..., Any],
+    allowed_tools: Optional[List[str]] = None,
+    sub_agent_id: str = "ecc-global-orchestrator",
+    tool_id: Optional[str] = None,
+) -> Callable[..., Any]:
+    """Wrap one skill callable with preflight, execution, scan, and post-tool receipts."""
+    if getattr(skill_fn, _WRAPPER_ATTR, False):
+        return skill_fn
+
+    allowed_tools = allowed_tools or []
+
+    @functools.wraps(skill_fn)
+    def protected_execution(*args: Any, **kwargs: Any) -> Any:
+        if not _BOOT_INFO.get("manifest_hash") or _BOOT_INFO.get("boot_status") == "BOOT_WIRE_BLOCKED":
+            raise RuntimeError("FAIL_CLOSED: Boot identity missing or blocked.")
+
+        _BOOT_INFO["sequence_nonce"] += 1
+        current_nonce = int(_BOOT_INFO["sequence_nonce"])
+
+        try:
+            input_payload = {"args": args, "kwargs": kwargs}
+            input_hash = sha256_obj(input_payload)
+            allowed_tools_hash = sha256_obj(sorted([str(tool) for tool in allowed_tools]))
+        except Exception as exc:
+            logger.error("FAIL_CLOSED: input serialization failed for %s: %s", skill_id, exc)
+            raise RuntimeError("FAIL_CLOSED: Preflight generation failure.") from exc
+
+        preflight = PreflightReceiptV01(
+            receipt_type="ECC_PREFLIGHT_RECEIPT_V0_1",
+            schema_version="0.1",
+            skill_id=skill_id,
+            sub_agent_id=sub_agent_id,
+            tool_id=tool_id,
+            manifest_hash=str(_BOOT_INFO["manifest_hash"]),
+            boot_status=_BOOT_INFO["boot_status"],
+            sequence_nonce=current_nonce,
+            input_hash=input_hash,
+            allowed_tools_hash=allowed_tools_hash,
+            timestamp_ns=time.time_ns(),
+            process_id=os.getpid(),
+            disposition="PREFLIGHT_PASS",
+        )
+        preflight_receipt_hash = preflight.receipt_hash()
+        _write_atomic_receipt(
+            {
+                "receipt_hash": preflight_receipt_hash,
+                "type": "PREFLIGHT_RECEIPT_V0_1",
+                "body": asdict(preflight),
+            }
+        )
+
+        try:
+            base_mutation = capture_host_delta()
+            raw_output = skill_fn(*args, **kwargs)
+            scan_result = scan_output(raw_output)
+
+            if scan_result["status"] == "BLOCKED":
+                return contain_exfil(
+                    tier=int(scan_result["tier"]),
+                    pattern_id=str(scan_result["pattern_id"]),
+                    raw_output=raw_output,
+                    preflight_receipt_hash=preflight_receipt_hash,
+                )
+
+            post_mutation = capture_host_delta()
+            if post_mutation is None or base_mutation is None:
+                raise ValueError("MUTATION_HASH_MISSING")
+
+            post = PostToolReceiptV01(
+                receipt_type="ECC_POST_TOOL_RECEIPT_V0_1",
+                schema_version="0.1",
+                preflight_receipt_hash=preflight_receipt_hash,
+                output_hash=sha256_obj(raw_output),
+                mutation_delta_hash=sha256_obj(
+                    {
+                        "base": base_mutation,
+                        "post": post_mutation,
+                    }
+                ),
+                status="SUCCESS",
+                timestamp_ns=time.time_ns(),
+                disposition="RETURN_TO_AGENT",
+            )
+            _write_atomic_receipt(
+                {
+                    "receipt_hash": post.receipt_hash(),
+                    "type": "POST_TOOL_RECEIPT_V0_1",
+                    "body": asdict(post),
+                }
+            )
+            return raw_output
+
+        except Exception as exc:
+            logger.error("FAIL_CLOSED: internal execution fault on skill %s: %s", skill_id, exc)
+            raise RuntimeError("FAIL_CLOSED: Integrity gate termination.") from exc
+
+    setattr(protected_execution, _WRAPPER_ATTR, True)
+    return protected_execution
+
+
+def inject_witness_canopy(ecc_skill_registry: Any) -> Dict[str, Any]:
+    """Wrap all registry.skills handlers in-place, then verify coverage."""
+    discovered_skills = getattr(ecc_skill_registry, "skills", {}) or {}
+    logger.info("Witness canopy sweeping %s registered ECC skills.", len(discovered_skills))
+
+    for skill_id in sorted(discovered_skills.keys()):
+        skill_object = discovered_skills[skill_id]
+        handler = getattr(skill_object, "handler", None)
+        if not callable(handler):
+            continue
+        allowed_tools = getattr(skill_object, "allowed_tools", []) or []
+        if not getattr(handler, _WRAPPER_ATTR, False):
+            skill_object.handler = witness_skill_wrapper(
+                str(skill_id),
+                handler,
+                allowed_tools=list(allowed_tools),
+                sub_agent_id=getattr(skill_object, "sub_agent_id", "ecc-global-orchestrator"),
+                tool_id=getattr(skill_object, "tool_id", None),
+            )
+
+    return run_coverage_manifest(ecc_skill_registry)
+
+
+def execute_boot_wire(ecc_skill_registry: Any) -> Dict[str, Any]:
+    """Definitive boot gate. Exits before engine start if coverage or anchors fail."""
+    logger.info("Initializing Zero-Trust Boot Wire Sequence.")
+    try:
+        manifest_report = inject_witness_canopy(ecc_skill_registry)
+    except Exception as exc:  # pragma: no cover - terminal path
+        logger.critical("BOOT_WIRE_BLOCKED: manifest sweep failed: %s", exc)
+        sys.exit("BOOT_WIRE_BLOCKED: Manifest execution failure.")
+
+    if not manifest_report.get("boot_wire_allowed", False):
+        logger.critical(
+            "BOOT_WIRE_BLOCKED: coverage failed. discovered=%s wrapped=%s unwrapped=%s",
+            manifest_report.get("total_discovered"),
+            manifest_report.get("total_wrapped"),
+            manifest_report.get("unwrapped_ids"),
+        )
+        sys.exit("BOOT_WIRE_BLOCKED: Unverified execution surfaces present.")
+
+    _BOOT_INFO["manifest_hash"] = manifest_report["manifest_hash"]
+    _BOOT_INFO["boot_status"] = manifest_report["boot_status"]
+    _BOOT_INFO["sequence_nonce"] = 0
+
+    _write_atomic_receipt(
+        {
+            "receipt_hash": sha256_obj(manifest_report),
+            "type": "ECC_WITNESS_EXECUTION_MANIFEST_V0_1",
+            "body": manifest_report,
+        }
+    )
+
+    logger.info(
+        "Boot Wire Verified: status=%s manifest_hash=%s",
+        _BOOT_INFO["boot_status"],
+        _BOOT_INFO["manifest_hash"],
+    )
+    return manifest_report


### PR DESCRIPTION
## Summary
Adds `ecc_witness_skill_receipt_v0_1.py` for the ECC witness canopy / ToolGate boot-wire layer.

## What this locks
- Dynamic registry sweep via `inject_witness_canopy(...)`
- Idempotent skill wrapping with `__witness_wrapped__`
- Deterministic SHA-256 preflight receipts
- Manifest hash + boot status bound into every invocation
- Atomic JSONL append with fsync
- Fast-fail exfil scanning tiers 1-5
- Tier 4 workspace-config leak containment
- Quarantine receipts that never return raw output to agent context
- Boot gate through `execute_boot_wire(...)`

## Doctrine
No receipt, no execution.
No manifest hash, no boot.
No post-tool receipt, no return to agent.

## Notes
v0.1 intentionally avoids token accounting. Telemetry belongs in a v0.2 overlay.