### PR TITLE
add treasury live capture spec v0.1

### DIFF
--- a/policy/treasury-live-capture/TREASURY_LIVE_CAPTURE_SPEC_V0_1.md
+++ b/policy/treasury-live-capture/TREASURY_LIVE_CAPTURE_SPEC_V0_1.md
@@ -33,7 +33,7 @@ external_source
   -> normalized_payload
   -> normalized_payload_hash
   -> unsigned_receipt_canonical_json
-  -> witness_keystore_sign(receipt_hash, key_id)
+  -> witness_signer_attest(receipt_hash, key_id)
   -> signed_receipt
   -> trust_bundle_verify(policy/witnesses/witnesses.yaml)
   -> quorum_check(2-of-N)

--- a/policy/treasury-live-capture/TREASURY_LIVE_CAPTURE_SPEC_V0_1.md
+++ b/policy/treasury-live-capture/TREASURY_LIVE_CAPTURE_SPEC_V0_1.md
@@ -1,0 +1,74 @@
+# Treasury Live Capture Spec v0.1
+
+## Status
+
+DRAFT_FOR_REVIEW
+
+## Dependencies
+
+TREASURY_VERIFIER_V0_2 = SEALED
+WITNESS_KEY_ROTATION_V0_1 = SEALED
+TRUST_ROOT_POLICY = LANDED
+PROD_WITNESS_QUORUM = 2-of-N
+NO_FAKE_GREEN = ACTIVE
+
+## Purpose
+
+Define the live Treasury capture flow from external source payload to normalized payload, signed receipt, witness quorum verification, and strict promotion eligibility.
+
+## Non-Negotiable Boundary
+
+No source fetch means no real capture.
+
+No real capture means no real genesis.
+
+A blocked or failed fetch may produce a failure receipt, but it must not produce a real capture receipt.
+
+## Flow
+
+external_source
+  -> raw_payload
+  -> raw_payload_hash
+  -> deterministic_normalizer
+  -> normalized_payload
+  -> normalized_payload_hash
+  -> unsigned_receipt_canonical_json
+  -> witness_keystore_sign(receipt_hash, key_id)
+  -> signed_receipt
+  -> trust_bundle_verify(policy/witnesses/witnesses.yaml)
+  -> quorum_check(2-of-N)
+  -> treasury-verifier strict
+  -> PASS = eligible_real_capture_receipt
+  -> FAIL = failure_receipt_only
+
+## Strict Verification Must Fail If
+
+- source fetch is missing
+- fetch status is FETCH_BLOCKED or FETCH_ERROR
+- raw payload hash is missing for REAL mode
+- normalized payload hash is missing for REAL mode
+- receipt hash mismatch occurs
+- trust bundle is missing
+- quorum is not satisfied
+- any signing key is revoked
+- any signing key is simulated or staging
+- witness public key is not active
+- signature verification fails
+- timestamp drift exceeds configured limit
+
+## Audit Mode
+
+Audit mode may preserve failed capture evidence.
+
+Audit mode must not promote.
+
+## Acceptance
+
+LIVE_CAPTURE_SPEC_V0_1 = REVIEWED
+TRUST_BUNDLE_LOADED = TRUE
+PROD_WITNESS_KEYS_ONLY = TRUE
+QUORUM = 2-of-N
+FETCH_BLOCKED_STRICT_FAIL = TRUE
+FAILURE_RECEIPTS_ALLOWED = TRUE
+REAL_GENESIS = BLOCKED_UNTIL_FIRST_STRICT_PASS
+NO_FAKE_GREEN = ACTIVE

--- a/receipts/treasury-live-capture/LIVE_CAPTURE_SPEC_REVIEW_RECEIPT_V0_1.md
+++ b/receipts/treasury-live-capture/LIVE_CAPTURE_SPEC_REVIEW_RECEIPT_V0_1.md
@@ -1,0 +1,32 @@
+# Live Capture Spec Review Receipt v0.1
+
+## Status
+
+DRAFT_FOR_REVIEW
+
+## Dependency Chain
+
+TREASURY_VERIFIER_V0_2 = SEALED
+WITNESS_KEY_ROTATION_V0_1 = SEALED
+TRUST_ROOT_POLICY = LANDED
+LIVE_CAPTURE_SPEC_V0_1 = DRAFT
+REAL_GENESIS = BLOCKED
+NO_FAKE_GREEN = ACTIVE
+
+## First Test Vector
+
+01_fetch_blocked_failure_receipt.json
+
+## Expected Behavior
+
+FETCH_BLOCKED -> FAILURE_RECEIPT_ALLOWED
+FETCH_BLOCKED -> STRICT_FAIL
+FETCH_BLOCKED -> PROMOTION_BLOCKED
+
+## Ruling
+
+The system may preserve blocked-fetch evidence.
+
+The system must not convert blocked-fetch evidence into a real capture.
+
+No fake green.

--- a/schemas/treasury-live-capture/normalized_payload.schema.v0.1.yaml
+++ b/schemas/treasury-live-capture/normalized_payload.schema.v0.1.yaml
@@ -1,0 +1,28 @@
+schema_version: treasury-live-capture-normalized-payload/v0.1
+required:
+  - schema_version
+  - capture_id
+  - source
+  - raw_payload_hash
+  - normalizer
+  - normalized_payload_hash
+  - normalized_payload
+source:
+  required:
+    - name
+    - url
+    - fetched_at_utc
+    - fetch_status
+  allowed_fetch_status:
+    - PASS
+    - FETCH_BLOCKED
+    - FETCH_ERROR
+normalizer:
+  required:
+    - name
+    - version
+    - code_hash
+normalized_payload:
+  required:
+    - target_date
+    - observations

--- a/schemas/treasury-live-capture/signed_receipt.schema.v0.1.yaml
+++ b/schemas/treasury-live-capture/signed_receipt.schema.v0.1.yaml
@@ -1,0 +1,40 @@
+schema_version: treasury-live-capture-signed-receipt/v0.1
+required:
+  - schema_version
+  - receipt_id
+  - capture_id
+  - mode
+  - authority_level
+  - trust_policy
+  - trust_bundle_path
+  - quorum
+  - receipt_hash
+  - signatures
+  - verification
+allowed_modes:
+  - REAL
+  - FAILURE
+allowed_authority_levels:
+  - LIVE_CAPTURE
+quorum:
+  required:
+    - threshold
+    - satisfied
+    - active_signature_count
+signature:
+  required:
+    - key_id
+    - algorithm
+    - signature
+    - signed_at_utc
+    - witness_role
+  allowed_algorithms:
+    - ed25519
+verification:
+  required:
+    - strict_status
+    - audit_status
+    - revoked_key_present
+    - staging_key_present
+    - no_fake_green
+    - promotion_eligible

--- a/tests/fixtures/treasury-live-capture/v0.1/01_fetch_blocked_expected.txt
+++ b/tests/fixtures/treasury-live-capture/v0.1/01_fetch_blocked_expected.txt
@@ -1,0 +1,10 @@
+TEST_VECTOR=01_fetch_blocked_failure_receipt
+STRICT=FAIL
+AUDIT=PASS_WITH_WARNINGS
+PROMOTION=BLOCKED
+REASON=FETCH_BLOCKED
+NO_FAKE_GREEN=ACTIVE
+
+A blocked fetch may produce a failure receipt.
+A blocked fetch must not produce a real capture receipt.
+A blocked fetch must not satisfy real-genesis promotion.

--- a/tests/fixtures/treasury-live-capture/v0.1/01_fetch_blocked_failure_receipt.json
+++ b/tests/fixtures/treasury-live-capture/v0.1/01_fetch_blocked_failure_receipt.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "treasury-live-capture-receipt/v0.1",
+  "receipt_id": "live-capture-fetch-blocked-v0-1-001",
+  "capture_id": "treasury-live-capture-v0-1-001",
+  "mode": "FAILURE",
+  "authority_level": "LIVE_CAPTURE",
+  "trust_policy": "WITNESS_KEY_ROTATION_POLICY_V0_1",
+  "trust_bundle_path": "policy/witnesses/witnesses.yaml",
+  "source": {
+    "name": "FiscalData Treasury API",
+    "url": "https://api.fiscaldata.treasury.gov/services/api/fiscal_service/",
+    "fetched_at_utc": "2026-06-21T00:00:00Z",
+    "fetch_status": "FETCH_BLOCKED",
+    "failure_reason": "network_or_source_unavailable"
+  },
+  "raw_payload_hash": null,
+  "normalizer": {
+    "name": "treasury-live-capture-normalizer",
+    "version": "v0.1",
+    "code_hash": null
+  },
+  "normalized_payload_hash": null,
+  "receipt_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "quorum": {
+    "threshold": 2,
+    "satisfied": false,
+    "active_signature_count": 0
+  },
+  "signatures": [],
+  "verification": {
+    "strict_status": "FAIL",
+    "audit_status": "PASS_WITH_WARNINGS",
+    "revoked_key_present": false,
+    "staging_key_present": false,
+    "no_fake_green": "ACTIVE",
+    "promotion_eligible": false,
+    "failure_receipt_allowed": true
+  },
+  "expected_result": {
+    "strict": "FAIL",
+    "audit": "PASS_WITH_WARNINGS",
+    "promotion": "BLOCKED",
+    "reason": "FETCH_BLOCKED"
+  }
+}

--- a/tools/treasury-live-capture/witness_signer.interface.md
+++ b/tools/treasury-live-capture/witness_signer.interface.md
@@ -1,0 +1,23 @@
+# Witness Signer Interface v0.1
+
+The capture tool must not handle secret signing material directly.
+
+## Command
+
+witness_signer sign \
+  --key-id <prod-witness-id> \
+  --message-hash sha256:<receipt_hash> \
+  --purpose live_capture_attestation
+
+## Response
+
+key_id: prod-witness-001
+algorithm: ed25519
+message_hash: sha256:<receipt_hash>
+signature: base64:<signature>
+signed_at_utc: <iso8601>
+signer_backend: offline | age_encrypted | hsm | kms
+
+## Boundary
+
+Signer must reject revoked, simulated, staging, unknown, inactive, or unauthorized keys.


### PR DESCRIPTION
Adds Treasury live capture spec v0.1 skeleton with normalized payload flow, signed receipt flow, witness signer interface, and first fetch-blocked failure test vector. Live capture remains blocked. Real genesis remains blocked. NO_FAKE_GREEN active.