### PR TITLE
scaffold prod witnesses and real capture flow v0.1

### DIFF
--- a/policy/witnesses/witnesses.yaml
+++ b/policy/witnesses/witnesses.yaml
@@ -13,36 +13,36 @@ quorum:
 witnesses:
   - key_id: prod-witness-001
     algorithm: ed25519
-    public_key: TODO_GENERATE_PUBLIC_KEY
+    public_key: PLACEHOLDER_FILL_LOCALLY_PROD_WITNESS_001_PUBLIC
     role: treasury_capture_witness
-    active_from: TODO_UTC
+    active_from: PLACEHOLDER_FILL_LOCALLY_ACTIVE_FROM_Z
     active_until: null
-    status: active
-    custody: offline_or_hsm
+    status: pending_local_fill
+    custody: external_signer_backend
     allowed_actions:
       - live_capture_attestation
       - real_treasury_genesis_promotion
 
   - key_id: prod-witness-002
     algorithm: ed25519
-    public_key: TODO_GENERATE_PUBLIC_KEY
+    public_key: PLACEHOLDER_FILL_LOCALLY_PROD_WITNESS_002_PUBLIC
     role: treasury_capture_witness
-    active_from: TODO_UTC
+    active_from: PLACEHOLDER_FILL_LOCALLY_ACTIVE_FROM_Z
     active_until: null
-    status: active
-    custody: offline_or_hsm
+    status: pending_local_fill
+    custody: external_signer_backend
     allowed_actions:
       - live_capture_attestation
       - real_treasury_genesis_promotion
 
   - key_id: prod-witness-003
     algorithm: ed25519
-    public_key: TODO_GENERATE_PUBLIC_KEY
+    public_key: PLACEHOLDER_FILL_LOCALLY_PROD_WITNESS_003_PUBLIC
     role: treasury_capture_witness
-    active_from: TODO_UTC
+    active_from: PLACEHOLDER_FILL_LOCALLY_ACTIVE_FROM_Z
     active_until: null
-    status: active
-    custody: offline_or_hsm
+    status: pending_local_fill
+    custody: external_signer_backend
     allowed_actions:
       - live_capture_attestation
       - real_treasury_genesis_promotion
@@ -52,6 +52,6 @@ revoked:
     algorithm: ed25519_or_placeholder
     public_key: simulated_or_unknown
     reason: simulated_genesis
-    revoked_at: TODO_UTC
+    revoked_at: PLACEHOLDER_FILL_LOCALLY_REVOCATION_TIME_Z
     effect: fail_strict_and_promotion
-    notes: Sim-era/staging material has no production witness authority.
+    notes: Sim-era material has no production witness authority.

--- a/receipts/treasury-live-capture/PROD_WITNESS_REAL_FLOW_HARNESS_V0_1.md
+++ b/receipts/treasury-live-capture/PROD_WITNESS_REAL_FLOW_HARNESS_V0_1.md
@@ -1,0 +1,27 @@
+# Prod Witness Real-Flow Harness v0.1
+
+## Status
+
+DRAFT_FOR_REVIEW
+
+## Purpose
+
+Prepare the next Treasury live capture vector without claiming real genesis.
+
+## Boundary
+
+Placeholder witness values are not production authority.
+
+The real-flow template is not promotable until:
+
+- live source fetch succeeds
+- raw payload hash is present
+- normalized payload hash is present
+- canonical receipt hash is present
+- 2-of-N production witness signatures verify
+- strict verifier passes
+
+## Ruling
+
+REAL_GENESIS = BLOCKED
+NO_FAKE_GREEN = ACTIVE

--- a/tests/fixtures/treasury-live-capture/v0.1/02_real_capture_flow_expected.txt
+++ b/tests/fixtures/treasury-live-capture/v0.1/02_real_capture_flow_expected.txt
@@ -1,0 +1,13 @@
+TEST_VECTOR=02_real_capture_flow_template
+STATUS=TEMPLATE_ONLY
+STRICT_BEFORE_LOCAL_FILL=FAIL
+PROMOTION_BEFORE_LOCAL_FILL=BLOCKED
+REQUIRES_LIVE_FETCH=TRUE
+REQUIRES_RAW_PAYLOAD_HASH=TRUE
+REQUIRES_NORMALIZED_PAYLOAD_HASH=TRUE
+REQUIRES_RECEIPT_HASH=TRUE
+REQUIRES_PROD_WITNESS_QUORUM=2-of-N
+NO_FAKE_GREEN=ACTIVE
+
+This template is not a real capture.
+This template becomes eligible only after local fill, live fetch evidence, deterministic normalization, and strict verification.

--- a/tests/fixtures/treasury-live-capture/v0.1/02_real_capture_flow_template.json
+++ b/tests/fixtures/treasury-live-capture/v0.1/02_real_capture_flow_template.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "treasury-live-capture-receipt/v0.1",
+  "receipt_id": "live-capture-real-flow-v0-1-template",
+  "capture_id": "treasury-live-capture-real-flow-v0-1-template",
+  "mode": "REAL",
+  "authority_level": "LIVE_CAPTURE",
+  "trust_policy": "WITNESS_KEY_ROTATION_POLICY_V0_1",
+  "trust_bundle_path": "policy/witnesses/witnesses.yaml",
+  "source": {
+    "name": "FiscalData Treasury API",
+    "url": "PLACEHOLDER_FILL_WITH_EXACT_LIVE_ENDPOINT",
+    "fetched_at_utc": "PLACEHOLDER_FILL_WITH_FETCH_TIME_Z",
+    "fetch_status": "PASS"
+  },
+  "raw_payload_hash": "sha256:PLACEHOLDER_FILL_WITH_RAW_PAYLOAD_HASH",
+  "normalizer": {
+    "name": "treasury-live-capture-normalizer",
+    "version": "v0.1",
+    "code_hash": "sha256:PLACEHOLDER_FILL_WITH_NORMALIZER_CODE_HASH"
+  },
+  "normalized_payload_hash": "sha256:PLACEHOLDER_FILL_WITH_NORMALIZED_PAYLOAD_HASH",
+  "receipt_hash": "sha256:PLACEHOLDER_FILL_WITH_CANONICAL_RECEIPT_HASH",
+  "quorum": {
+    "threshold": 2,
+    "satisfied": false,
+    "active_signature_count": 0
+  },
+  "signatures": [
+    {
+      "key_id": "prod-witness-001",
+      "algorithm": "ed25519",
+      "signature": "base64:PLACEHOLDER_FILL_LOCALLY_SIGNATURE_001",
+      "signed_at_utc": "PLACEHOLDER_FILL_LOCALLY_SIGNED_TIME_Z",
+      "witness_role": "treasury_capture_witness"
+    },
+    {
+      "key_id": "prod-witness-002",
+      "algorithm": "ed25519",
+      "signature": "base64:PLACEHOLDER_FILL_LOCALLY_SIGNATURE_002",
+      "signed_at_utc": "PLACEHOLDER_FILL_LOCALLY_SIGNED_TIME_Z",
+      "witness_role": "treasury_capture_witness"
+    }
+  ],
+  "verification": {
+    "strict_status": "PENDING_NOT_EXECUTED",
+    "audit_status": "PENDING_NOT_EXECUTED",
+    "revoked_key_present": false,
+    "staging_key_present": false,
+    "no_fake_green": "ACTIVE",
+    "promotion_eligible": false,
+    "failure_receipt_allowed": false
+  },
+  "expected_result": {
+    "before_local_fill": "STRICT_FAIL",
+    "after_local_fill_with_live_fetch_and_2_signatures": "STRICT_PASS_CANDIDATE",
+    "promotion": "BLOCKED_UNTIL_VERIFIER_PASS",
+    "reason": "PLACEHOLDERS_NOT_PROMOTABLE"
+  }
+}


### PR DESCRIPTION
Adds scanner-safe prod witness placeholders and real capture flow template. No real genesis is claimed. Placeholders remain non-promotable until live fetch, hashes, 2-of-N witness signatures, and strict verification pass. NO_FAKE_GREEN active.