### PR TITLE
Add external file-level witness Grok 002 receipt v0.1

### DIFF
--- a/receipts/witnesses/EXTERNAL_FILE_LEVEL_WITNESS_GROK_002_V0_1.md
+++ b/receipts/witnesses/EXTERNAL_FILE_LEVEL_WITNESS_GROK_002_V0_1.md
@@ -1,0 +1,60 @@
+# External File-Level Witness Receipt - Grok 002 v0.1
+
+Status: VERIFIED_FILE_LEVEL_EXTERNAL_WITNESS_NOT_PRODUCTION
+
+## Scope
+
+This receipt records an external file-level witness verification for the local public live-fetch witness message.
+
+This is not a real genesis promotion.
+This is not production quorum.
+This does not register the witness key into the production trust root.
+
+## Signed Artifact
+
+Signed file:
+
+.witness-evidence/quorum/message-to-sign.json
+
+Signed file SHA-256:
+
+c0548dd4dff4ba657dd17c48c99ef211ca7bb8b21f84514f831216116b03964a
+
+## Verification Result
+
+FILE_LEVEL_SIGNATURE = VERIFIED
+OPENSSL_VERIFY_RESULT = Signature Verified Successfully
+
+## External Witness Metadata
+
+KEY_ID = witness-prod-witness-002
+SIGNED_AT_UTC = 2026-06-21T03:43:35Z
+PUBLIC_KEY_SHA256 = 51466390000f62918ba3fc216335f114924361457f48804869a3d48f13020517
+SIGNATURE_SHA256 = 6bb147c3fbdd55d48ce7ec670b63ef228e5dcbd695f4ed844b349e990f66670a
+TRUST_ROOT_REGISTERED = FALSE
+PRODUCTION_QUORUM = FALSE
+REAL_GENESIS = BLOCKED
+NO_FAKE_GREEN = ACTIVE
+
+## Witness Statement
+
+The external witness stated:
+
+I signed the exact bytes of message-to-sign.json, not only the hash string. I independently witnessed the provided file content for live_capture_attestation. I did not share signing material. This is a witness signature only. REAL_GENESIS remains BLOCKED unless strict verification and quorum policy pass.
+
+## Local Evidence Boundary
+
+The local witness evidence directory is intentionally not committed.
+This public receipt records hashes and verification status only.
+No signer material is included in this commit.
+
+## Ruling
+
+PUBLIC_LIVE_FETCH = PASS
+STRICT_PUBLIC_FILL = PASS
+SELF_CONTROLLED_LAB_SIGNATURES = PASS_DISCLOSED
+GROK_EXTERNAL_FILE_WITNESS = VERIFIED
+TRUST_ROOT_REGISTERED = FALSE
+PRODUCTION_QUORUM = FALSE
+REAL_GENESIS = BLOCKED
+NO_FAKE_GREEN = ACTIVE


### PR DESCRIPTION
Adds a public receipt for verified external file-level witness evidence. Records hashes and status only. Does not register production trust root, does not claim production quorum, and keeps REAL_GENESIS blocked under NO_FAKE_GREEN.