### PR TITLE
Add ZTVS Replay Map index card

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -42,6 +42,12 @@
             <p>A clear summary of the doctrine, the two-track framework, and what the framework does and does not claim.</p>
             <div class="btns"><a class="btn" href="#press">Open summary</a></div>
           </div>
+          <div class="card">
+            <span class="tag">Infrastructure · Replay · Verification</span>
+            <h3>ZTVS Replay Map</h3>
+            <p>Static replay map for the zero-trust verification lane: UI is presentation, receipts are authority, replay is proof.</p>
+            <div class="btns"><a class="btn" href="ztvs/replay-map/index.html">Open replay map</a></div>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Adds one static card/link to docs/index.html for ztvs/replay-map/index.html. Scope: webpage index only.