### PR TITLE
Make live root homepage Goblin Court

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,18 +1,80 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
-  <meta charset="utf-8">
-  <title>AL Trinity Mission</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Goblin Court — Zero Trust Website</title>
+  <meta name="description" content="Government documents on trial. Replay the receipt. Roast the bureaucracy." />
+  <style>
+    :root{--ink:#1b1410;--paper:#f4e2b8;--red:#a52222;--purple:#46226b;--gold:#b9872c;--green:#1f6b42;--shadow:rgba(27,20,16,.24)}
+    *{box-sizing:border-box} body{margin:0;background:radial-gradient(circle at 20% 0%,rgba(165,34,34,.22),transparent 30%),radial-gradient(circle at 85% 10%,rgba(70,34,107,.22),transparent 28%),linear-gradient(135deg,#fff0c9,var(--paper));color:var(--ink);font-family:Georgia,'Times New Roman',serif}.ticker{background:var(--ink);color:#ffe7a0;padding:.75rem 1rem;font:800 .86rem ui-monospace,SFMono-Regular,Menlo,monospace;white-space:nowrap;overflow:hidden}.wrap{width:min(1120px,calc(100% - 32px));margin:auto}header{padding:38px 0 24px}.seal{display:inline-block;border:2px solid var(--purple);color:var(--purple);border-radius:999px;padding:.45rem .8rem;font:900 .82rem ui-monospace,SFMono-Regular,Menlo,monospace;background:rgba(255,255,255,.35);box-shadow:0 6px 0 rgba(70,34,107,.15)}h1{font-size:clamp(3.4rem,13vw,9rem);line-height:.82;margin:22px 0 12px;text-transform:uppercase;letter-spacing:-.08em}.subtitle{font-size:clamp(1.25rem,3.4vw,2.55rem);line-height:1.05;max-width:900px;font-weight:900;margin:0 0 24px}.rules{display:grid;grid-template-columns:repeat(4,1fr);border:3px solid var(--ink);box-shadow:9px 9px 0 var(--shadow);background:var(--gold);margin:24px 0}.rules div{padding:14px;border-right:2px solid var(--ink);font:900 .82rem ui-monospace,SFMono-Regular,Menlo,monospace;text-transform:uppercase}.rules div:last-child{border-right:0}.hero{display:grid;grid-template-columns:1.35fr .65fr;gap:22px}.panel,.card,.side,.docket{background:rgba(255,248,226,.8);border:3px solid var(--ink);box-shadow:8px 8px 0 var(--shadow)}.panel,.side,.card{padding:20px}.btns{display:flex;flex-wrap:wrap;gap:12px;margin-top:18px}.btn{display:inline-flex;align-items:center;justify-content:center;min-height:46px;padding:.75rem 1rem;border:2px solid var(--ink);border-radius:10px;background:var(--red);color:#fff5d0;text-decoration:none;font-weight:900;text-transform:uppercase;box-shadow:4px 4px 0 var(--ink)}.btn.alt{background:var(--purple)}.btn.light{background:#fff2c8;color:var(--ink)}section{margin:34px 0}.title{display:flex;align-items:center;justify-content:space-between;gap:16px;border-bottom:4px double var(--ink);margin-bottom:16px}h2{font-size:clamp(1.8rem,4vw,3.4rem);line-height:.95;margin:0 0 10px;text-transform:uppercase}.verdict{display:inline-block;border:3px solid var(--red);color:var(--red);background:rgba(255,255,255,.5);font-weight:900;text-transform:uppercase;padding:.25rem .5rem;transform:rotate(-2deg)}.grid4{display:grid;grid-template-columns:repeat(4,1fr);gap:18px}.grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}.tag{display:inline-block;color:var(--red);font:900 .78rem ui-monospace,SFMono-Regular,Menlo,monospace;text-transform:uppercase;margin-bottom:10px}.card h3{font-size:1.5rem;line-height:1;margin:0 0 10px}.card p,.panel p,.side p{line-height:1.35}.meter{border:2px solid var(--ink);height:26px;background:#fff2c8;margin:12px 0 18px}.meter span{display:block;height:100%;width:92%;background:linear-gradient(90deg,var(--green),var(--gold),var(--red))}.docket{width:100%;border-collapse:collapse}.docket th,.docket td{border-bottom:2px solid rgba(27,20,16,.24);padding:12px;text-align:left;vertical-align:top}.docket th{background:var(--ink);color:#ffe7a0;font:900 .78rem ui-monospace,SFMono-Regular,Menlo,monospace;text-transform:uppercase}.states{display:flex;flex-wrap:wrap;gap:10px}.state{border:2px solid var(--ink);border-radius:999px;padding:.65rem .85rem;background:#fff2c8;font:900 .9rem ui-monospace,SFMono-Regular,Menlo,monospace}.state.active{background:var(--green);color:#fff5d0}footer{margin-top:40px;background:var(--ink);color:#ffe7a0;padding:28px 0 42px}footer .wrap{display:grid;grid-template-columns:1fr 1fr;gap:20px}@media(max-width:880px){.hero,.grid4,.grid3,footer .wrap{grid-template-columns:1fr}.rules{grid-template-columns:1fr 1fr}.docket{font-size:.9rem}}
+  </style>
 </head>
 <body>
-  <h1>AL</h1>
-  <h2>Trinity Mission for the Girls</h2>
-  <p>Part of Jay Wisdom's 3 Daughters Trinity.</p>
-  <ul>
-    <li>AL</li>
-    <li>JOY</li>
-    <li>COMPUTERWISDOM</li>
-  </ul>
-  <p><strong>Rule:</strong> No fake green. Build. Seal. Verify. Repeat.</p>
+  <div class="ticker">BREAKING: GOVERNMENT DOCUMENT ENTERED THE GROUP CHAT · REPLAY THE RECEIPT · ROAST THE BUREAUCRACY · MINNESOTA FIRST · EVERY STATE LATER</div>
+
+  <header class="wrap">
+    <div class="seal">⚖️🧌 COURT IN SESSION · ZERO TRUST WEBSITE</div>
+    <h1>Goblin Court</h1>
+    <p class="subtitle">Government documents on trial. Replay the receipt. Roast the bureaucracy.</p>
+    <div class="rules"><div>UI is presentation</div><div>Sources are clickable</div><div>Receipts are discoverable</div><div>Replay is proof</div></div>
+    <div class="hero">
+      <div class="panel">
+        <h2>File the PDF. Summon the Goblin.</h2>
+        <p>Goblin Court is a funny, intelligently built zero-trust website for public records. It starts with Minnesota documents, turns them into clickable exhibits, and keeps jokes separate from evidence.</p>
+        <div class="btns">
+          <a class="btn" href="#mn-docket">Replay Minnesota</a>
+          <a class="btn alt" href="docs/ztvs/replay-map/index.html">Open Replay Map</a>
+          <a class="btn light" href="site/goblin-court/case-004-green/index.html">Enter Goblin Court</a>
+          <a class="btn light" href="site/meme-court/wfg-0001.html">Meme Court</a>
+        </div>
+      </div>
+      <aside class="side">
+        <span class="tag">Boss Bre lane</span>
+        <h3>Roast-O-Meter</h3>
+        <div class="meter"><span></span></div>
+        <p><strong>Status:</strong> Funny enough to click. Legal enough to survive cross-examination.</p>
+        <p><strong>Librarian lane:</strong> source links, docket metadata, receipts, state index.</p>
+      </aside>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <section>
+      <div class="title"><h2>The Four Courts</h2><span class="verdict">All legal · all legit · all lethal</span></div>
+      <div class="grid4">
+        <article class="card"><span class="tag">🧌 Goblin Court</span><h3>PDF said what now?</h3><p>Government documents get dragged into court and forced to show receipts.</p><a class="btn light" href="site/goblin-court/case-004-green/index.html">Open case</a></article>
+        <article class="card"><span class="tag">😂 Meme Court</span><h3>Verdict: extremely postable.</h3><p>Turns source-backed claims into jokes, tweets, and meme-ready exhibits.</p><a class="btn light" href="site/meme-court/wfg-0001.html">Open meme court</a></article>
+        <article class="card"><span class="tag">🌆 Cyberpunk Court</span><h3>Neon receipts.</h3><p>Machine-speed due process with the lights turned purple and citations intact.</p><a class="btn light" href="docs/ztvs/replay-map/index.html">Open replay map</a></article>
+        <article class="card"><span class="tag">🤡 Clown Court</span><h3>Honk if the record is incomplete.</h3><p>For bureaucracy that trips over its own clipboard and calls it procedure.</p><a class="btn light" href="#mn-docket">View docket</a></article>
+      </div>
+    </section>
+
+    <section id="mn-docket">
+      <div class="title"><h2>Minnesota Docket</h2><span class="verdict">MN active · more states queued</span></div>
+      <table class="docket"><thead><tr><th>Exhibit</th><th>Agency / Source</th><th>Verdict</th><th>Actions</th></tr></thead><tbody>
+        <tr><td><strong>MN Fiscal Replay</strong><br>Budget goblin smells a spreadsheet.</td><td>Public fiscal documents · source-ready lane</td><td><span class="verdict">Suspicious</span></td><td><a href="projects/mn-fiscal-replay/">Read the receipt →</a></td></tr>
+        <tr><td><strong>ZTVS Replay Map</strong><br>The map says: no fake green.</td><td>Zero-trust verification lane</td><td><span class="verdict">Admissible</span></td><td><a href="docs/ztvs/replay-map/index.html">Replay →</a></td></tr>
+        <tr><td><strong>Goblin Stack</strong><br>Court goblin demands metadata.</td><td>Goblin Court receipts and truth reports</td><td><span class="verdict">Guilty of vibes</span></td><td><a href="docs/goblin_court/metadata_fetcher_v0_patch.md">Read →</a></td></tr>
+        <tr><td><strong>Meme Court Case</strong><br>The joke is funny. The source still matters.</td><td>Meme Court docket and case files</td><td><span class="verdict">Postable</span></td><td><a href="alms/meme_court/cases/MC-0001.json">Receipt →</a></td></tr>
+      </tbody></table>
+    </section>
+
+    <section>
+      <div class="title"><h2>State Index</h2><span class="verdict">Minnesota first</span></div>
+      <div class="states"><span class="state active">MN · active</span><span class="state">WI · queued</span><span class="state">IA · queued</span><span class="state">NY · queued</span><span class="state">AL · queued</span><span class="state">CA · queued</span><span class="state">TX · queued</span><span class="state">FL · queued</span></div>
+    </section>
+
+    <section>
+      <div class="title"><h2>Share Tools</h2><span class="verdict">Jokes are jokes, not evidence</span></div>
+      <div class="grid3">
+        <article class="card"><span class="tag">Make Tweet</span><h3>Copy the roast.</h3><p>“Government document entered Goblin Court. Replay says: citation needed.”</p><a class="btn" href="https://twitter.com/intent/tweet?text=Government%20document%20entered%20Goblin%20Court.%20Replay%20says%3A%20citation%20needed.%20Built%20by%20jaywisdom.base.eth">Tweet it</a></article>
+        <article class="card"><span class="tag">Make Image</span><h3>Screenshot bait.</h3><p>Use the verdict cards as meme panels. Stamp-red badges included at no extra charge.</p><a class="btn alt" href="#mn-docket">Pick exhibit</a></article>
+        <article class="card"><span class="tag">Copy Joke</span><h3>For the group chat.</h3><p>“Your honor, the spreadsheet is acting suspicious.”</p><a class="btn light" href="#mn-docket">Copy manually</a></article>
+      </div>
+    </section>
+  </main>
+
+  <footer><div class="wrap"><div><strong>Built by Jaywisdom.eth</strong><br>Powered by jaywisdom.base.eth · JSONwisdom source tree</div><div>Goblin Court is parody, product, and public-records infrastructure. The fun UI never outranks the receipts.</div></div></footer>
 </body>
 </html>


### PR DESCRIPTION
Replaces the root index.html served by GitHub Pages with the Goblin Court Zero Trust Website homepage.

This fixes the live page showing the old plain AL Trinity page.

Scope: root index.html only.