### PR TITLE
Add continuity world map and index

### DIFF
--- a/CONTINUITY_INDEX.json
+++ b/CONTINUITY_INDEX.json
@@ -1,0 +1,104 @@
+{
+  "schema": "jsonwisdom_continuity_index_v0_1",
+  "status": "OPEN_PR_UNVERIFIED",
+  "root_repo": "jsonwisdom/AL",
+  "principle": "Cumulative Existence",
+  "branch": "continuity-world-map-v0-1",
+  "authority": "NOT_GREEN_UNTIL_MERGED",
+  "foundation": {
+    "family": {
+      "role": "Layer 0"
+    },
+    "alms": {
+      "role": "Trust Engine",
+      "rules": [
+        "No Anchor without Proof",
+        "No Fake Green",
+        "Receipts over Narrative"
+      ]
+    },
+    "pdf_empire": {
+      "role": "Source Asset",
+      "scope": [
+        "Minnesota records",
+        "city records",
+        "public documents",
+        "future state expansion"
+      ]
+    }
+  },
+  "active_consumers": {
+    "goblin_court": {
+      "role": "Funny proof receipt consumer",
+      "files": [
+        "index.html"
+      ],
+      "status": "WORKING_TREE_OBSERVED",
+      "commit_hash": "PENDING_MAIN_MERGE"
+    },
+    "meme_court": {
+      "role": "Shareability and meme review layer",
+      "status": "CONTINUITY_ANCHOR"
+    },
+    "clown_court": {
+      "role": "Absurdity review layer",
+      "status": "CONTINUITY_ANCHOR"
+    },
+    "ztvs": {
+      "role": "Replay map and verification surface",
+      "files": [
+        "docs/index.html"
+      ],
+      "status": "WORKING_TREE_OBSERVED",
+      "commit_hash": "PENDING_MAIN_MERGE"
+    },
+    "payment_adapter": {
+      "role": "One cent goblin rendering unlock surface",
+      "files": [
+        "site/data/payment-config.json",
+        "docs/index.html"
+      ],
+      "pr": 364,
+      "branch": "goblin-payment-adapter-v0-1",
+      "status": "OPEN_PR"
+    },
+    "minnesota_docket": {
+      "role": "PDF Empire consumer docket",
+      "files": [
+        "site/data/states/mn.index.json"
+      ],
+      "status": "WORKING_TREE_OBSERVED"
+    }
+  },
+  "public_artifacts": {
+    "github_pages": {
+      "role": "Public display layer",
+      "status": "REQUIRES_LIVE_VERIFICATION"
+    },
+    "zora": {
+      "role": "Public artifact and distribution layer",
+      "status": "CONTINUITY_ANCHOR"
+    },
+    "ens_base": {
+      "identity_anchor": [
+        "jaywisdom.eth",
+        "jaywisdom.base.eth"
+      ]
+    }
+  },
+  "continuity_gaps": [
+    {
+      "id": "ANCHOR_001",
+      "target": "jsonwisdom/Welcome-to-JSONWISDOM",
+      "status": "BROKEN_OR_PRIVATE",
+      "risk": "Root verifier lineage is not publicly replayable until restored or mirrored."
+    }
+  ],
+  "next_actions": [
+    "Merge continuity-world-map-v0-1 after review",
+    "Update this file with the actual merge commit SHA",
+    "Restore or mirror Anchor 001",
+    "Link GitHub Pages to WORLD_MAP.md",
+    "Update PR 364 after payment adapter verification"
+  ]
+}

--- a/WORLD_MAP.md
+++ b/WORLD_MAP.md
@@ -1,0 +1,101 @@
+# JSONWisdom World Map
+
+Status: DRAFT ON BRANCH
+
+This file exists to prevent continuity loss across GitHub, ChatGPT, Pages, receipts, and public artifacts.
+
+## Current World State
+
+### Layer 0: Family
+
+Family remains the root layer. Project narratives do not outrank family.
+
+### Layer 1: Trust and Source Foundation
+
+- **ALMS** — Trust Engine
+  - Role: provenance, verification, receipt authority, replay discipline
+  - Core rule: no anchor without proof
+  - Core rule: no fake green
+
+- **PDF Empire** — Source Asset
+  - Role: public-record source layer
+  - Scope: Minnesota records, city records, fiscal records, meeting minutes, future state expansion
+  - Consumers depend on this layer for source material
+
+### Layer 2: Consumers
+
+- **Goblin Court**
+  - Role: funny proof receipt consumer
+  - Output: Goblin Docket Receipts and shareable proof cards
+
+- **Meme Court**
+  - Role: shareability and meme-review layer
+  - Rule: the joke is funny, the source still matters
+
+- **Clown Court**
+  - Role: absurdity review layer
+  - Rule: bureaucracy may be ridiculous without being promoted to unsupported claims
+
+- **ZTVS Replay Map**
+  - Role: zero-trust replay and verification surface
+  - Rule: replay proves; dashboard display does not confer authority
+
+### Layer 3: Public Artifacts
+
+- Receipts
+- Replay maps
+- Goblin receipt images
+- GitHub Pages surfaces
+- Zora artifacts
+- Public identity anchors
+
+## Active Identities
+
+- Jason Wisdom
+- Jay Wisdom
+- JSONWisdom
+- jaywisdom.eth
+- jaywisdom.base.eth
+
+## Known Continuity Anchors
+
+- Receipts over Narrative
+- Replay First
+- No Fake Green
+- Layer 0 Family
+- Cumulative Existence
+
+## Current Working Files in jsonwisdom/AL
+
+- `index.html` — current Goblin Court / PDF Empire receipt factory surface
+- `docs/index.html` — docs homepage and Goblin Rendering adapter surface in PR work
+- `site/data/payment-config.json` — Goblin Rendering configuration in PR work
+- `site/data/states/mn.index.json` — Minnesota docket data
+- `site/data/audits/` — audit data lane
+
+## Current Open PRs
+
+- PR #364 — Add Goblin Rendering payment adapter v0.1
+  - Branch: `goblin-payment-adapter-v0-1`
+  - Status: OPEN_PR
+  - Green status: NOT MERGED
+
+## Continuity Gaps
+
+- Anchor 001 / `jsonwisdom/Welcome-to-JSONWISDOM`
+  - Status: BROKEN_OR_PRIVATE
+  - Risk: root verifier lineage is not publicly replayable until restored or mirrored
+
+## Replay Rule
+
+Before creating new work, replay this map and ask:
+
+1. What already exists?
+2. What changed?
+3. What is active?
+4. What is stale?
+5. What should be continued rather than rebuilt?
+
+## Authority Status
+
+This file is a continuity map. It becomes authority only when committed and referenced by a real commit SHA.


### PR DESCRIPTION
## Summary

Adds the first explicit continuity bridge for the JSONWisdom / AL ecosystem:

- `WORLD_MAP.md`
- `CONTINUITY_INDEX.json`

## Purpose

Prevent reset/amnesia failure by making the current ecosystem visible to GitHub, ChatGPT, crawlers, and future replay sessions.

## Continuity structure

- Layer 0: Family
- Layer 1: ALMS + PDF Empire
- Layer 2: Goblin Court, Meme Court, Clown Court, ZTVS
- Layer 3: Receipts, replay maps, images, Zora artifacts, public pages

## No Fake Green

This PR does not claim main authority until merged.

Current status in `CONTINUITY_INDEX.json` is:

- `OPEN_PR_UNVERIFIED`
- `NOT_GREEN_UNTIL_MERGED`
- commit hashes remain pending until merge receipt exists.

## Continuity gaps tracked

- Anchor 001 / `jsonwisdom/Welcome-to-JSONWISDOM` marked `BROKEN_OR_PRIVATE`.

No fake green.