### PR TITLE
Add Goblin Court v1 gated bundle check for MN-STEARNS-003

### DIFF
--- a/goblin-court-v1/payment/README_PAYMENT_PASS_003.md
+++ b/goblin-court-v1/payment/README_PAYMENT_PASS_003.md
@@ -1,0 +1,69 @@
+# PAYMENT_PASS_003 — Live Gate Scaffold
+
+**Status:** PAYMENT PASS STARTED  
+**Branch:** `gc-v1-pass-003`  
+**Canonical Demo:** `MN-STEARNS-003`  
+**Builder Code:** `bc_j1200j64`
+
+---
+
+## Purpose
+
+This pass wires the signed payment boundary into a small, reviewable enforcement scaffold for the canonical demo case.
+
+Target flow:
+
+```text
+Receipt -> Replay -> Score 78 -> Payment Required -> Prompt Pack Unit
+```
+
+---
+
+## Boundary
+
+This pass does not add:
+
+- DDL
+- migrations
+- subscriptions
+- marketplace behavior
+- generated images
+- agent workflows
+- additional seed cases
+
+---
+
+## Enforcement Rule
+
+Before serving the paid Prompt Pack Unit, the service must validate:
+
+```text
+docket_id = MN-STEARNS-003
+receipt_id = r_mn_stearns_003_v1
+nutrition_score = 78
+replay_url = https://goblin.court/replay/mn-stearns-003
+builder_code = bc_j1200j64
+artifact_count = 7
+```
+
+The paid artifact must not be served if any lineage field mismatches the signed fixture.
+
+---
+
+## Files
+
+```text
+goblin-court-v1/payment/
+  README_PAYMENT_PASS_003.md
+  payment_boundary_003.json
+  gate_003.js
+  route_example_003.js
+```
+
+---
+
+## Live Middleware Note
+
+`route_example_003.js` is a framework-neutral example route. It marks where a production x402 verifier/facilitator integration must be attached.
+
+The fixture gate is deliberately separated from network settlement so the lineage rules can be reviewed without touching database or deployment state.

--- a/goblin-court-v1/payment/gate_003.js
+++ b/goblin-court-v1/payment/gate_003.js
@@ -1,0 +1,134 @@
+/*
+ * Goblin Court v1 — MN-STEARNS-003 lineage gate
+ *
+ * Framework-neutral CommonJS module.
+ * This file does not perform network settlement.
+ * It validates that the paid artifact matches the signed payment boundary
+ * before a route serves PROMPT_PACK_UNIT_V0_1.
+ */
+
+const REQUIRED = Object.freeze({
+  docket_id: "MN-STEARNS-003",
+  receipt_id: "r_mn_stearns_003_v1",
+  replay_url: "https://goblin.court/replay/mn-stearns-003",
+  nutrition_score: 78,
+  builder_code: "bc_j1200j64",
+  artifact_count: 7,
+  schema: "PROMPT_PACK_UNIT_V0_1",
+  authority: false,
+  truth_claims: "prohibited"
+});
+
+const REQUIRED_ARTIFACT_KEYS = Object.freeze([
+  "poster_prompt",
+  "meme_prompt",
+  "storyboard_prompt",
+  "trading_card_prompt",
+  "court_sketch_prompt",
+  "tweet_thread",
+  "headline_pack"
+]);
+
+function countArtifactUnits(artifacts) {
+  if (!artifacts || typeof artifacts !== "object") return 0;
+  return REQUIRED_ARTIFACT_KEYS.filter((key) => Object.prototype.hasOwnProperty.call(artifacts, key)).length;
+}
+
+function validatePromptPackUnit(promptPack) {
+  const errors = [];
+
+  if (!promptPack || typeof promptPack !== "object") {
+    return { ok: false, errors: ["prompt_pack_missing"] };
+  }
+
+  for (const [key, expected] of Object.entries(REQUIRED)) {
+    if (key === "artifact_count") continue;
+    if (promptPack[key] !== expected) {
+      errors.push(`mismatch:${key}`);
+    }
+  }
+
+  const artifactCount = countArtifactUnits(promptPack.artifacts);
+  if (artifactCount !== REQUIRED.artifact_count) {
+    errors.push(`artifact_count:${artifactCount}`);
+  }
+
+  const footer = String(promptPack.lineage_footer || "");
+  for (const token of [REQUIRED.docket_id, REQUIRED.receipt_id, String(REQUIRED.nutrition_score), REQUIRED.replay_url]) {
+    if (!footer.includes(token)) {
+      errors.push(`lineage_footer_missing:${token}`);
+    }
+  }
+
+  const headlineMetadata = promptPack.artifacts && promptPack.artifacts.headline_metadata;
+  if (!headlineMetadata) {
+    errors.push("headline_metadata_missing");
+  } else {
+    for (const key of ["docket_id", "receipt_id", "nutrition_score", "replay_url"]) {
+      if (headlineMetadata[key] !== REQUIRED[key]) {
+        errors.push(`headline_metadata_mismatch:${key}`);
+      }
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors
+  };
+}
+
+function validatePaymentContext(paymentContext) {
+  const errors = [];
+
+  if (!paymentContext || typeof paymentContext !== "object") {
+    return { ok: false, errors: ["payment_context_missing"] };
+  }
+
+  if (paymentContext.builder_code !== REQUIRED.builder_code) {
+    errors.push("builder_code_mismatch");
+  }
+
+  if (paymentContext.docket_id !== REQUIRED.docket_id) {
+    errors.push("docket_id_mismatch");
+  }
+
+  if (paymentContext.receipt_id !== REQUIRED.receipt_id) {
+    errors.push("receipt_id_mismatch");
+  }
+
+  if (paymentContext.replay_url !== REQUIRED.replay_url) {
+    errors.push("replay_url_mismatch");
+  }
+
+  if (paymentContext.nutrition_score !== REQUIRED.nutrition_score) {
+    errors.push("nutrition_score_mismatch");
+  }
+
+  if (paymentContext.payment_valid !== true) {
+    errors.push("payment_not_valid");
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors
+  };
+}
+
+function mayServePromptPack(paymentContext, promptPack) {
+  const payment = validatePaymentContext(paymentContext);
+  const pack = validatePromptPackUnit(promptPack);
+
+  return {
+    ok: payment.ok && pack.ok,
+    payment_errors: payment.errors,
+    prompt_pack_errors: pack.errors
+  };
+}
+
+module.exports = {
+  REQUIRED,
+  REQUIRED_ARTIFACT_KEYS,
+  validatePromptPackUnit,
+  validatePaymentContext,
+  mayServePromptPack
+};

--- a/goblin-court-v1/payment/gate_003.test.js
+++ b/goblin-court-v1/payment/gate_003.test.js
@@ -47,4 +47,17 @@ const badPackResult = mayServePromptPack(validPaymentContext, badPack);
 assert.strictEqual(badPackResult.ok, false);
 assert.ok(badPackResult.prompt_pack_errors.includes("mismatch:receipt_id"));
 
+const shortPack = {
+  ...promptPack,
+  artifacts: {
+    ...promptPack.artifacts
+  }
+};
+
+delete shortPack.artifacts.headline_pack;
+
+const shortPackResult = mayServePromptPack(validPaymentContext, shortPack);
+assert.strictEqual(shortPackResult.ok, false);
+assert.ok(shortPackResult.prompt_pack_errors.includes("artifact_count:6"));
+
 console.log("PASS gate_003 fixture tests");

--- a/goblin-court-v1/payment/gate_003.test.js
+++ b/goblin-court-v1/payment/gate_003.test.js
@@ -1,0 +1,50 @@
+/*
+ * Minimal Node test for the MN-STEARNS-003 paid artifact gate.
+ * Run from repo root after checkout:
+ * node goblin-court-v1/payment/gate_003.test.js
+ */
+
+const assert = require("assert");
+const path = require("path");
+const { mayServePromptPack, validatePromptPackUnit } = require("./gate_003");
+
+const promptPack = require(path.join("..", "fixtures", "mn-stearns-003", "prompt_pack_unit.json"));
+
+const validPaymentContext = {
+  payment_valid: true,
+  builder_code: "bc_j1200j64",
+  docket_id: "MN-STEARNS-003",
+  receipt_id: "r_mn_stearns_003_v1",
+  nutrition_score: 78,
+  replay_url: "https://goblin.court/replay/mn-stearns-003"
+};
+
+const promptPackResult = validatePromptPackUnit(promptPack);
+assert.deepStrictEqual(promptPackResult, { ok: true, errors: [] });
+
+const serveResult = mayServePromptPack(validPaymentContext, promptPack);
+assert.deepStrictEqual(serveResult, {
+  ok: true,
+  payment_errors: [],
+  prompt_pack_errors: []
+});
+
+const badPaymentContext = {
+  ...validPaymentContext,
+  payment_valid: false
+};
+
+const deniedResult = mayServePromptPack(badPaymentContext, promptPack);
+assert.strictEqual(deniedResult.ok, false);
+assert.ok(deniedResult.payment_errors.includes("payment_not_valid"));
+
+const badPack = {
+  ...promptPack,
+  receipt_id: "wrong_receipt"
+};
+
+const badPackResult = mayServePromptPack(validPaymentContext, badPack);
+assert.strictEqual(badPackResult.ok, false);
+assert.ok(badPackResult.prompt_pack_errors.includes("mismatch:receipt_id"));
+
+console.log("PASS gate_003 fixture tests");

--- a/goblin-court-v1/payment/payment_boundary_003.json
+++ b/goblin-court-v1/payment/payment_boundary_003.json
@@ -1,0 +1,27 @@
+{
+  "schema": "PAYMENT_GATE_CONFIG_V0_1",
+  "status": "REVIEW_FIXTURE",
+  "boundary": "PAYMENT_BOUNDARY_V0_1",
+  "docket_id": "MN-STEARNS-003",
+  "receipt_id": "r_mn_stearns_003_v1",
+  "replay_id": "replay_mn_stearns_003_v1",
+  "nutrition_score": 78,
+  "nutrition_band": "GOBLIN_FEAST",
+  "replay_url": "https://goblin.court/replay/mn-stearns-003",
+  "builder_code": "bc_j1200j64",
+  "paid_output": "PROMPT_PACK_UNIT_V0_1",
+  "artifact_count": 7,
+  "authority": false,
+  "truth_claims": "prohibited",
+  "source_files": {
+    "receipt": "../fixtures/mn-stearns-003/receipt.json",
+    "replay": "../fixtures/mn-stearns-003/replay.json",
+    "payment_boundary": "../fixtures/mn-stearns-003/payment_boundary.json",
+    "prompt_pack_unit": "../fixtures/mn-stearns-003/prompt_pack_unit.json"
+  },
+  "serve_rule": "Do not serve prompt_pack_unit unless payment is valid and lineage validation passes.",
+  "refund_rule": {
+    "prompt_quality_dispute": "not_automatic_refund",
+    "receipt_mismatch": "refund"
+  }
+}

--- a/goblin-court-v1/payment/route_example_003.js
+++ b/goblin-court-v1/payment/route_example_003.js
@@ -1,0 +1,85 @@
+/*
+ * Goblin Court v1 — MN-STEARNS-003 route example
+ *
+ * This is a framework-neutral example showing where live x402 verification
+ * attaches before serving PROMPT_PACK_UNIT_V0_1.
+ *
+ * It intentionally does not import a live x402 package because this repo does
+ * not yet define an application runtime or package manager boundary.
+ */
+
+const { mayServePromptPack } = require("./gate_003");
+
+function paymentRequiredResponse() {
+  return {
+    status: 402,
+    body: {
+      error: "payment_required",
+      boundary: "PAYMENT_BOUNDARY_V0_1",
+      builder_code: "bc_j1200j64",
+      docket_id: "MN-STEARNS-003",
+      receipt_id: "r_mn_stearns_003_v1",
+      nutrition_score: 78,
+      replay_url: "https://goblin.court/replay/mn-stearns-003",
+      output: "PROMPT_PACK_UNIT_V0_1",
+      artifact_count: 7,
+      authority: false,
+      truth_claims: "prohibited"
+    }
+  };
+}
+
+function forbiddenResponse(result) {
+  return {
+    status: 403,
+    body: {
+      error: "paid_artifact_gate_failed",
+      payment_errors: result.payment_errors,
+      prompt_pack_errors: result.prompt_pack_errors
+    }
+  };
+}
+
+function okResponse(promptPack) {
+  return {
+    status: 200,
+    body: promptPack
+  };
+}
+
+/*
+ * Production adapter contract:
+ *
+ * async function verifyLivePayment(request) {
+ *   // Attach official x402/facilitator verification here.
+ *   // Must return:
+ *   // {
+ *   //   payment_valid: true,
+ *   //   builder_code: "bc_j1200j64",
+ *   //   docket_id: "MN-STEARNS-003",
+ *   //   receipt_id: "r_mn_stearns_003_v1",
+ *   //   nutrition_score: 78,
+ *   //   replay_url: "https://goblin.court/replay/mn-stearns-003"
+ *   // }
+ * }
+ */
+
+async function handlePromptPackRequest({ paymentContext, promptPack }) {
+  if (!paymentContext || paymentContext.payment_valid !== true) {
+    return paymentRequiredResponse();
+  }
+
+  const result = mayServePromptPack(paymentContext, promptPack);
+  if (!result.ok) {
+    return forbiddenResponse(result);
+  }
+
+  return okResponse(promptPack);
+}
+
+module.exports = {
+  paymentRequiredResponse,
+  forbiddenResponse,
+  okResponse,
+  handlePromptPackRequest
+};


### PR DESCRIPTION
## Summary

Adds a separate gated bundle check for canonical demo case `MN-STEARNS-003`.

This PR does not add database work or a live network package. It adds a reviewable gate layer that blocks serving the paid Prompt Pack Unit unless both entitlement context and lineage validation pass.

## Added

- `goblin-court-v1/payment/README_PAYMENT_PASS_003.md`
- `goblin-court-v1/payment/payment_boundary_003.json`
- `goblin-court-v1/payment/gate_003.js`
- `goblin-court-v1/payment/route_example_003.js`
- `goblin-court-v1/payment/gate_003.test.js`

## Preserved boundaries

- No DDL
- No migration
- No subscriptions
- No marketplace
- No generated images
- No agents
- No additional seed cases
- No package/runtime assumption

## Gate behavior

The gate requires the signed lineage fields for MN-STEARNS-003, builder code bc_j1200j64, exactly seven artifacts, and valid entitlement context.

## Test

Manual checkout test:

```bash
node goblin-court-v1/payment/gate_003.test.js
```

Expected output:

```text
PASS gate_003 fixture tests
```