### PR TITLE
Add live x402 settlement pass for MN-STEARNS-003

### DIFF
--- a/goblin-court-v1/live/.env.example
+++ b/goblin-court-v1/live/.env.example
@@ -1,0 +1,31 @@
+# Goblin Court v1 — MN-STEARNS-003 live x402 pass
+
+# Server
+PORT=4021
+
+# Safety default: Base Sepolia testnet
+GC_X402_NETWORK=eip155:84532
+GC_X402_FACILITATOR_URL=https://x402.org/facilitator
+
+# Production Base mainnet values, only after testnet works:
+# GC_X402_NETWORK=eip155:8453
+# GC_X402_FACILITATOR_URL=https://api.cdp.coinbase.com/platform/v2/x402
+
+# Receiving wallet for x402 payments.
+# Use a real wallet you control. Required.
+GC_X402_PAY_TO=0xYourReceivingWalletAddress
+
+# Price must keep the dollar prefix.
+GC_X402_PRICE=$2.00
+
+# Product lineage
+GC_BUILDER_CODE=bc_j1200j64
+GC_DOCKET_ID=MN-STEARNS-003
+GC_RECEIPT_ID=r_mn_stearns_003_v1
+GC_NUTRITION_SCORE=78
+GC_REPLAY_URL=https://goblin.court/replay/mn-stearns-003
+
+# CDP production facilitator auth is required for mainnet.
+# Add only through deployment secrets, never commit real keys.
+# CDP_API_KEY_ID=
+# CDP_API_KEY_SECRET=

--- a/goblin-court-v1/live/README_LIVE_003.md
+++ b/goblin-court-v1/live/README_LIVE_003.md
@@ -1,0 +1,103 @@
+# LIVE_003 — x402 Network Settlement Pass
+
+**Status:** LIVE SETTLEMENT PASS STARTED  
+**Branch:** `gc-v1-live-003`  
+**Canonical Demo:** `MN-STEARNS-003`  
+**Builder Code:** `bc_j1200j64`
+
+---
+
+## Purpose
+
+This pass attaches a real x402 middleware boundary in front of the already-merged paid Prompt Pack Unit gate.
+
+Target flow:
+
+```text
+Receipt -> Replay -> Score 78 -> x402 Payment Required -> Gate -> Prompt Pack Unit
+```
+
+---
+
+## What This Adds
+
+```text
+goblin-court-v1/live/
+  README_LIVE_003.md
+  package.json
+  .env.example
+  server.mjs
+  lineage_live_003.test.mjs
+```
+
+The live server protects one route:
+
+```text
+GET /api/mn-stearns-003/prompt-pack
+```
+
+The route returns the paid `PROMPT_PACK_UNIT_V0_1` only after:
+
+1. x402 middleware accepts payment for the protected route.
+2. The existing `gate_003.js` lineage check passes.
+
+---
+
+## Boundaries Preserved
+
+This pass does not add:
+
+- DDL
+- migrations
+- database state
+- subscriptions
+- marketplace behavior
+- generated images
+- agents
+- additional seed cases
+
+---
+
+## Default Safety Mode
+
+The default `.env.example` uses Base Sepolia:
+
+```text
+GC_X402_NETWORK=eip155:84532
+GC_X402_FACILITATOR_URL=https://x402.org/facilitator
+```
+
+For production Base mainnet, switch to:
+
+```text
+GC_X402_NETWORK=eip155:8453
+GC_X402_FACILITATOR_URL=https://api.cdp.coinbase.com/platform/v2/x402
+```
+
+Production CDP facilitator usage requires CDP API keys and a real receiving wallet address. Do not test mainnet with large amounts.
+
+---
+
+## Local Test
+
+```bash
+cd goblin-court-v1/live
+npm install
+npm test
+npm start
+```
+
+Expected test output:
+
+```text
+PASS live lineage fixture test
+```
+
+---
+
+## Core Invariant
+
+```text
+Network settlement unlocks access.
+Lineage gate still decides whether the paid artifact may be served.
+```

--- a/goblin-court-v1/live/lineage_live_003.test.mjs
+++ b/goblin-court-v1/live/lineage_live_003.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { mayServePromptPack } = require("../payment/gate_003.js");
+const promptPack = require("../fixtures/mn-stearns-003/prompt_pack_unit.json");
+
+const validPaymentContext = {
+  payment_valid: true,
+  builder_code: "bc_j1200j64",
+  docket_id: "MN-STEARNS-003",
+  receipt_id: "r_mn_stearns_003_v1",
+  nutrition_score: 78,
+  replay_url: "https://goblin.court/replay/mn-stearns-003"
+};
+
+const result = mayServePromptPack(validPaymentContext, promptPack);
+assert.deepEqual(result, {
+  ok: true,
+  payment_errors: [],
+  prompt_pack_errors: []
+});
+
+const wrongBuilderCode = {
+  ...validPaymentContext,
+  builder_code: "wrong_builder_code"
+};
+
+const denied = mayServePromptPack(wrongBuilderCode, promptPack);
+assert.equal(denied.ok, false);
+assert.ok(denied.payment_errors.includes("builder_code_mismatch"));
+
+console.log("PASS live lineage fixture test");

--- a/goblin-court-v1/live/lineage_live_003.test.mjs
+++ b/goblin-court-v1/live/lineage_live_003.test.mjs
@@ -30,4 +30,35 @@ const denied = mayServePromptPack(wrongBuilderCode, promptPack);
 assert.equal(denied.ok, false);
 assert.ok(denied.payment_errors.includes("builder_code_mismatch"));
 
+const { createApp, getLiveConfig, ROUTE } = await import("./server.mjs");
+
+assert.ok(createApp);
+assert.equal(typeof createApp, "function");
+assert.equal(ROUTE, "/api/mn-stearns-003/prompt-pack");
+
+const env = {
+  PORT: "4021",
+  GC_X402_NETWORK: "eip155:84532",
+  GC_X402_FACILITATOR_URL: "https://x402.org/facilitator",
+  GC_X402_PAY_TO: "0x0000000000000000000000000000000000000001",
+  GC_X402_PRICE: "$2.00",
+  GC_BUILDER_CODE: "bc_j1200j64",
+  GC_DOCKET_ID: "MN-STEARNS-003",
+  GC_RECEIPT_ID: "r_mn_stearns_003_v1",
+  GC_NUTRITION_SCORE: "78",
+  GC_REPLAY_URL: "https://goblin.court/replay/mn-stearns-003"
+};
+
+const config = getLiveConfig(env);
+assert.equal(config.network, "eip155:84532");
+assert.equal(config.builder_code, "bc_j1200j64");
+assert.equal(config.pay_to, "0x0000000000000000000000000000000000000001");
+
+const created = createApp(env);
+assert.ok(created.app);
+assert.equal(created.config.docket_id, "MN-STEARNS-003");
+assert.equal(created.config.receipt_id, "r_mn_stearns_003_v1");
+assert.equal(created.config.nutrition_score, 78);
+assert.equal(created.config.replay_url, "https://goblin.court/replay/mn-stearns-003");
+
 console.log("PASS live lineage fixture test");

--- a/goblin-court-v1/live/package.json
+++ b/goblin-court-v1/live/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "goblin-court-v1-live-003",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Live x402 settlement pass for Goblin Court MN-STEARNS-003.",
+  "scripts": {
+    "start": "node server.mjs",
+    "test": "node lineage_live_003.test.mjs"
+  },
+  "dependencies": {
+    "@x402/core": "latest",
+    "@x402/evm": "latest",
+    "@x402/express": "latest",
+    "express": "latest"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/goblin-court-v1/live/server.mjs
+++ b/goblin-court-v1/live/server.mjs
@@ -1,5 +1,7 @@
 import express from "express";
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import { paymentMiddleware, x402ResourceServer } from "@x402/express";
 import { ExactEvmScheme } from "@x402/evm/exact/server";
 import { HTTPFacilitatorClient } from "@x402/core/server";
@@ -8,95 +10,117 @@ const require = createRequire(import.meta.url);
 const { mayServePromptPack } = require("../payment/gate_003.js");
 const promptPack = require("../fixtures/mn-stearns-003/prompt_pack_unit.json");
 
-const REQUIRED = Object.freeze({
-  docket_id: process.env.GC_DOCKET_ID || "MN-STEARNS-003",
-  receipt_id: process.env.GC_RECEIPT_ID || "r_mn_stearns_003_v1",
-  nutrition_score: Number(process.env.GC_NUTRITION_SCORE || 78),
-  replay_url: process.env.GC_REPLAY_URL || "https://goblin.court/replay/mn-stearns-003",
-  builder_code: process.env.GC_BUILDER_CODE || "bc_j1200j64"
-});
+export const ROUTE = "/api/mn-stearns-003/prompt-pack";
 
-const PORT = Number(process.env.PORT || 4021);
-const NETWORK = process.env.GC_X402_NETWORK || "eip155:84532";
-const FACILITATOR_URL = process.env.GC_X402_FACILITATOR_URL || "https://x402.org/facilitator";
-const PRICE = process.env.GC_X402_PRICE || "$2.00";
-const PAY_TO = process.env.GC_X402_PAY_TO;
-const ROUTE = "/api/mn-stearns-003/prompt-pack";
-
-if (!PAY_TO || PAY_TO === "0xYourReceivingWalletAddress") {
-  throw new Error("GC_X402_PAY_TO must be set to a receiving wallet address before starting the live server.");
+export function getLiveConfig(env = process.env) {
+  return Object.freeze({
+    docket_id: env.GC_DOCKET_ID || "MN-STEARNS-003",
+    receipt_id: env.GC_RECEIPT_ID || "r_mn_stearns_003_v1",
+    nutrition_score: Number(env.GC_NUTRITION_SCORE || 78),
+    replay_url: env.GC_REPLAY_URL || "https://goblin.court/replay/mn-stearns-003",
+    builder_code: env.GC_BUILDER_CODE || "bc_j1200j64",
+    port: Number(env.PORT || 4021),
+    network: env.GC_X402_NETWORK || "eip155:84532",
+    facilitator_url: env.GC_X402_FACILITATOR_URL || "https://x402.org/facilitator",
+    price: env.GC_X402_PRICE || "$2.00",
+    pay_to: env.GC_X402_PAY_TO
+  });
 }
 
-const app = express();
-
-const facilitatorClient = new HTTPFacilitatorClient({
-  url: FACILITATOR_URL
-});
-
-const resourceServer = new x402ResourceServer(facilitatorClient)
-  .register(NETWORK, new ExactEvmScheme());
-
-app.get("/health", (_req, res) => {
-  res.json({
-    ok: true,
-    service: "goblin-court-v1-live-003",
-    docket_id: REQUIRED.docket_id,
-    receipt_id: REQUIRED.receipt_id,
-    builder_code: REQUIRED.builder_code,
-    network: NETWORK,
-    authority: false,
-    truth_claims: "prohibited"
-  });
-});
-
-app.use(
-  paymentMiddleware(
-    {
-      [`GET ${ROUTE}`]: {
-        accepts: [
-          {
-            scheme: "exact",
-            price: PRICE,
-            network: NETWORK,
-            payTo: PAY_TO
-          }
-        ],
-        description: "Goblin Court MN-STEARNS-003 paid Prompt Pack Unit",
-        mimeType: "application/json"
-      }
-    },
-    resourceServer
-  )
-);
-
-app.get(ROUTE, (_req, res) => {
-  // If this route is reached, the x402 middleware accepted the payment for this resource.
-  // The local lineage gate still decides whether the paid artifact is safe to serve.
-  const paymentContext = {
-    payment_valid: true,
-    builder_code: REQUIRED.builder_code,
-    docket_id: REQUIRED.docket_id,
-    receipt_id: REQUIRED.receipt_id,
-    nutrition_score: REQUIRED.nutrition_score,
-    replay_url: REQUIRED.replay_url
-  };
-
-  const result = mayServePromptPack(paymentContext, promptPack);
-
-  if (!result.ok) {
-    return res.status(403).json({
-      error: "paid_artifact_gate_failed",
-      payment_errors: result.payment_errors,
-      prompt_pack_errors: result.prompt_pack_errors
-    });
+export function assertLiveConfig(config) {
+  if (!config.pay_to || config.pay_to === "0xYourReceivingWalletAddress") {
+    throw new Error("GC_X402_PAY_TO must be set to a receiving wallet address before starting the live server.");
   }
+}
 
-  return res.json(promptPack);
-});
+export function createApp(env = process.env) {
+  const config = getLiveConfig(env);
+  assertLiveConfig(config);
 
-app.listen(PORT, () => {
-  console.log(`Goblin Court live 003 server listening on port ${PORT}`);
-  console.log(`Protected route: GET ${ROUTE}`);
-  console.log(`Network: ${NETWORK}`);
-  console.log(`Price: ${PRICE}`);
-});
+  const app = express();
+
+  const facilitatorClient = new HTTPFacilitatorClient({
+    url: config.facilitator_url
+  });
+
+  const resourceServer = new x402ResourceServer(facilitatorClient)
+    .register(config.network, new ExactEvmScheme());
+
+  app.get("/health", (_req, res) => {
+    res.json({
+      ok: true,
+      service: "goblin-court-v1-live-003",
+      docket_id: config.docket_id,
+      receipt_id: config.receipt_id,
+      builder_code: config.builder_code,
+      network: config.network,
+      authority: false,
+      truth_claims: "prohibited"
+    });
+  });
+
+  app.use(
+    paymentMiddleware(
+      {
+        [`GET ${ROUTE}`]: {
+          accepts: [
+            {
+              scheme: "exact",
+              price: config.price,
+              network: config.network,
+              payTo: config.pay_to
+            }
+          ],
+          description: "Goblin Court MN-STEARNS-003 paid Prompt Pack Unit",
+          mimeType: "application/json"
+        }
+      },
+      resourceServer
+    )
+  );
+
+  app.get(ROUTE, (_req, res) => {
+    // If this route is reached, the x402 middleware accepted the payment for this resource.
+    // The local lineage gate still decides whether the paid artifact is safe to serve.
+    const paymentContext = {
+      payment_valid: true,
+      builder_code: config.builder_code,
+      docket_id: config.docket_id,
+      receipt_id: config.receipt_id,
+      nutrition_score: config.nutrition_score,
+      replay_url: config.replay_url
+    };
+
+    const result = mayServePromptPack(paymentContext, promptPack);
+
+    if (!result.ok) {
+      return res.status(403).json({
+        error: "paid_artifact_gate_failed",
+        payment_errors: result.payment_errors,
+        prompt_pack_errors: result.prompt_pack_errors
+      });
+    }
+
+    return res.json(promptPack);
+  });
+
+  return { app, config };
+}
+
+export function startServer(env = process.env) {
+  const { app, config } = createApp(env);
+
+  return app.listen(config.port, () => {
+    console.log(`Goblin Court live 003 server listening on port ${config.port}`);
+    console.log(`Protected route: GET ${ROUTE}`);
+    console.log(`Network: ${config.network}`);
+    console.log(`Price: ${config.price}`);
+  });
+}
+
+const thisFile = fileURLToPath(import.meta.url);
+const invokedFile = process.argv[1] ? resolve(process.argv[1]) : "";
+
+if (thisFile === invokedFile) {
+  startServer();
+}

--- a/goblin-court-v1/live/server.mjs
+++ b/goblin-court-v1/live/server.mjs
@@ -1,0 +1,102 @@
+import express from "express";
+import { createRequire } from "node:module";
+import { paymentMiddleware, x402ResourceServer } from "@x402/express";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+
+const require = createRequire(import.meta.url);
+const { mayServePromptPack } = require("../payment/gate_003.js");
+const promptPack = require("../fixtures/mn-stearns-003/prompt_pack_unit.json");
+
+const REQUIRED = Object.freeze({
+  docket_id: process.env.GC_DOCKET_ID || "MN-STEARNS-003",
+  receipt_id: process.env.GC_RECEIPT_ID || "r_mn_stearns_003_v1",
+  nutrition_score: Number(process.env.GC_NUTRITION_SCORE || 78),
+  replay_url: process.env.GC_REPLAY_URL || "https://goblin.court/replay/mn-stearns-003",
+  builder_code: process.env.GC_BUILDER_CODE || "bc_j1200j64"
+});
+
+const PORT = Number(process.env.PORT || 4021);
+const NETWORK = process.env.GC_X402_NETWORK || "eip155:84532";
+const FACILITATOR_URL = process.env.GC_X402_FACILITATOR_URL || "https://x402.org/facilitator";
+const PRICE = process.env.GC_X402_PRICE || "$2.00";
+const PAY_TO = process.env.GC_X402_PAY_TO;
+const ROUTE = "/api/mn-stearns-003/prompt-pack";
+
+if (!PAY_TO || PAY_TO === "0xYourReceivingWalletAddress") {
+  throw new Error("GC_X402_PAY_TO must be set to a receiving wallet address before starting the live server.");
+}
+
+const app = express();
+
+const facilitatorClient = new HTTPFacilitatorClient({
+  url: FACILITATOR_URL
+});
+
+const resourceServer = new x402ResourceServer(facilitatorClient)
+  .register(NETWORK, new ExactEvmScheme());
+
+app.get("/health", (_req, res) => {
+  res.json({
+    ok: true,
+    service: "goblin-court-v1-live-003",
+    docket_id: REQUIRED.docket_id,
+    receipt_id: REQUIRED.receipt_id,
+    builder_code: REQUIRED.builder_code,
+    network: NETWORK,
+    authority: false,
+    truth_claims: "prohibited"
+  });
+});
+
+app.use(
+  paymentMiddleware(
+    {
+      [`GET ${ROUTE}`]: {
+        accepts: [
+          {
+            scheme: "exact",
+            price: PRICE,
+            network: NETWORK,
+            payTo: PAY_TO
+          }
+        ],
+        description: "Goblin Court MN-STEARNS-003 paid Prompt Pack Unit",
+        mimeType: "application/json"
+      }
+    },
+    resourceServer
+  )
+);
+
+app.get(ROUTE, (_req, res) => {
+  // If this route is reached, the x402 middleware accepted the payment for this resource.
+  // The local lineage gate still decides whether the paid artifact is safe to serve.
+  const paymentContext = {
+    payment_valid: true,
+    builder_code: REQUIRED.builder_code,
+    docket_id: REQUIRED.docket_id,
+    receipt_id: REQUIRED.receipt_id,
+    nutrition_score: REQUIRED.nutrition_score,
+    replay_url: REQUIRED.replay_url
+  };
+
+  const result = mayServePromptPack(paymentContext, promptPack);
+
+  if (!result.ok) {
+    return res.status(403).json({
+      error: "paid_artifact_gate_failed",
+      payment_errors: result.payment_errors,
+      prompt_pack_errors: result.prompt_pack_errors
+    });
+  }
+
+  return res.json(promptPack);
+});
+
+app.listen(PORT, () => {
+  console.log(`Goblin Court live 003 server listening on port ${PORT}`);
+  console.log(`Protected route: GET ${ROUTE}`);
+  console.log(`Network: ${NETWORK}`);
+  console.log(`Price: ${PRICE}`);
+});


### PR DESCRIPTION
## Summary

Starts the live x402 network settlement pass for the canonical Goblin Court v1 demo case `MN-STEARNS-003`.

This PR adds an isolated live server package under `goblin-court-v1/live/` that protects one route:

```text
GET /api/mn-stearns-003/prompt-pack
```

The route serves the paid Prompt Pack Unit only after:

1. x402 middleware accepts payment for the protected route.
2. The existing `gate_003.js` lineage gate passes.

## Added

- `goblin-court-v1/live/README_LIVE_003.md`
- `goblin-court-v1/live/package.json`
- `goblin-court-v1/live/.env.example`
- `goblin-court-v1/live/server.mjs`
- `goblin-court-v1/live/lineage_live_003.test.mjs`

## Defaults

Safety default uses Base Sepolia:

```text
GC_X402_NETWORK=eip155:84532
GC_X402_FACILITATOR_URL=https://x402.org/facilitator
```

Production Base mainnet requires switching to:

```text
GC_X402_NETWORK=eip155:8453
GC_X402_FACILITATOR_URL=https://api.cdp.coinbase.com/platform/v2/x402
```

and adding CDP production credentials as deployment secrets.

## Preserved boundaries

- No DDL
- No migration
- No database state
- No subscriptions
- No marketplace
- No generated images
- No agents
- No additional seed cases

## Test

```bash
cd goblin-court-v1/live
npm install
npm test
```

Expected:

```text
PASS live lineage fixture test
```