### PR TITLE
Constitutional Receipts v0.1 — receipt-first replay architecture

### DIFF
--- a/.github/workflows/constitutional-replay-v0.1.yml
+++ b/.github/workflows/constitutional-replay-v0.1.yml
@@ -1,0 +1,29 @@
+name: Constitutional Replay v0.1
+
+on:
+  push:
+    branches: [ master, constitutional-receipts-v0.1 ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest jsonschema
+
+      - name: Run constitutional replay verifier
+        run: |
+          python verify_all.py

--- a/README.md
+++ b/README.md
@@ -49,3 +49,49 @@ Public positioning:
 
 **Boss Bre: Minnesota Fiscal Anomaly Intelligence**  
 Public PDFs. Replayable receipts. Human-reviewed audit leads.
+
+---
+
+## Constitutional Receipts v0.1
+
+This repository includes a **receipt-first replay architecture** for transparent AI and governance workflows.
+
+> **Core invariant:** Receipts prove process only. Receipts do not prove truth or grant authority.
+
+### Verify Locally
+
+```bash
+python verify_all.py
+```
+
+Expected success output:
+
+```text
+CONSTITUTIONAL_REPLAY_PASS
+```
+
+### Public Replay Surface
+
+A GitHub Action runs the full verifier on every push and pull request.
+
+Check the Actions tab for **Constitutional Replay v0.1** to inspect live replay results.
+
+### Components
+
+- `receipt.py` — receipt hashing, invariants, and attestations
+- `claim_pipeline.py` — claim verification receipt generator
+- `policy_loader.py` — immutable policy registry
+- `world_map.py` — receipt-backed projection layer
+- `map_query.py` — read-only map inspection
+- `replay_engine.py` — independent receipt replay
+- `receiptctl.py` — CLI control surface
+- `verify_all.py` — one-command verifier
+- `REPLAY_MANIFEST_V0_1.json` — canonical manifest
+
+### Authority Rule
+
+`authority` must always be `false`.
+
+Authorization is explicit, scoped, and separate from receipts. The world map consumes authorized receipts but never creates authority or decides truth.
+
+`REPLAY_MANIFEST_V0_1.json` defines the canonical entrypoints and policies for this version.

--- a/REPLAY_MANIFEST_V0_1.json
+++ b/REPLAY_MANIFEST_V0_1.json
@@ -1,0 +1,22 @@
+{
+  "system": "constitutional-receipts-v0.1",
+  "authority": false,
+  "entrypoints": [
+    "receipt.py",
+    "claim_pipeline.py",
+    "world_map.py",
+    "map_query.py",
+    "policy_loader.py",
+    "replay_engine.py",
+    "receiptctl.py",
+    "verify_all.py"
+  ],
+  "policies": [
+    "POLICY_CLAIM_VERIFICATION_V0_1",
+    "POLICY_WORLD_MAP_INGEST_V0_1"
+  ],
+  "invariant": "Receipts prove process only. Receipts do not prove truth or grant authority.",
+  "version": "0.1",
+  "replay_command": "python verify_all.py",
+  "manifest_hash": "TODO: compute on release tag"
+}

--- a/claim_pipeline.py
+++ b/claim_pipeline.py
@@ -1,0 +1,173 @@
+"""
+claim_pipeline.py — Constitutional Claim Verification Pipeline v0.1
+
+Input -> extraction -> evidence -> verification -> policy -> authorization -> receipt.
+Verified support is not truth. Receipts never grant authority.
+"""
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+from policy_loader import compute_policy_hash, load_policy
+from receipt import (
+    compute_core_hash,
+    compute_final_hash,
+    compute_section_hashes,
+    create_receipt_skeleton,
+    verify_receipt,
+)
+
+POLICY_ID = "POLICY_CLAIM_VERIFICATION_V0_1"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def simple_extract_claims(text: str) -> List[Dict[str, Any]]:
+    sentences = [s.strip() for s in text.split(".") if s.strip()]
+    return [
+        {"claim_id": f"clm_{i:03d}", "text": f"{sentence}.", "confidence": 0.85}
+        for i, sentence in enumerate(sentences)
+    ]
+
+
+def create_evidence_packet(claims: List[Dict[str, Any]], source_text: str) -> Dict[str, Any]:
+    evidence_items = []
+    for claim in claims:
+        digest = hashlib.sha256(claim["text"].encode("utf-8")).hexdigest()
+        evidence_items.append({
+            "evidence_id": f"ev_{claim['claim_id']}",
+            "type": "source_text",
+            "content_hash": f"sha256:{digest}",
+            "supports_claim": claim["claim_id"],
+            "retrieved_at": _utc_now(),
+        })
+    packet_digest = hashlib.sha256(
+        json.dumps(evidence_items, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return {
+        "packet_hash": f"sha256:{packet_digest}",
+        "items": evidence_items,
+        "source_text_hash": f"sha256:{hashlib.sha256(source_text.encode('utf-8')).hexdigest()}",
+    }
+
+
+def verify_support(evidence: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "verifier_version": "verify-v0.1",
+        "replay_class": "Level2",
+        "result": "partial" if evidence.get("items") else "fail",
+        "confidence": 0.75 if evidence.get("items") else 0.0,
+        "mismatches": [],
+    }
+
+
+def policy_check(claims: List[Dict[str, Any]], evidence: Dict[str, Any], verification: Dict[str, Any]) -> Dict[str, Any]:
+    policy_doc = load_policy(POLICY_ID)
+    rules = {
+        "at_least_one_evidence": len(evidence.get("items", [])) >= 1,
+        "every_claim_mapped": all(
+            any(item.get("supports_claim") == claim["claim_id"] for item in evidence.get("items", []))
+            for claim in claims
+        ),
+        "verification_passed": verification.get("result") in ("pass", "partial"),
+    }
+    return {
+        "policy_version": POLICY_ID,
+        "policy_hash": compute_policy_hash(policy_doc),
+        "rules_evaluated": list(rules.keys()),
+        "result": "compliant" if all(rules.values()) else "non_compliant",
+        "details": rules,
+    }
+
+
+def _add_attestations(receipt: Dict[str, Any], human_approved: bool) -> None:
+    receipt["attestations"] = [
+        {
+            "role": "extractor",
+            "identity": "did:key:z6MkClaimExtractor",
+            "signature_alg": "ed25519",
+            "signed_section": "extraction",
+            "signed_section_hash": receipt["section_hashes"]["extraction_hash"],
+            "signature": "base64:stubExtractor",
+        },
+        {
+            "role": "verifier",
+            "identity": "did:key:z6MkVerifier",
+            "signature_alg": "ed25519",
+            "signed_section": "verification",
+            "signed_section_hash": receipt["section_hashes"]["verification_hash"],
+            "signature": "base64:stubVerifier",
+        },
+    ]
+    if human_approved:
+        receipt["attestations"].append({
+            "role": "authorizer",
+            "identity": "did:key:z6MkHumanAuthorizer",
+            "signature_alg": "ed25519",
+            "signed_section": "core",
+            "signed_section_hash": receipt["section_hashes"]["core_hash"],
+            "signature": "base64:stubAuthorizer",
+        })
+
+
+def create_claim_verification_receipt(source: str | Dict[str, Any], human_approved: bool = False) -> Dict[str, Any]:
+    if isinstance(source, str):
+        text = source
+        input_data = {"hash": f"sha256:{hashlib.sha256(source.encode('utf-8')).hexdigest()}", "source_type": "text"}
+    else:
+        text = source.get("text", "")
+        input_data = source
+
+    claims = simple_extract_claims(text)
+    evidence = create_evidence_packet(claims, text)
+    verification = verify_support(evidence)
+    policy = policy_check(claims, evidence, verification)
+    authorization = {
+        "authorized_by": "human" if human_approved else "policy:pending",
+        "scope": ["publish_to_map"],
+        "result": "granted" if human_approved else "pending_human",
+    }
+
+    receipt = create_receipt_skeleton("final", input_data)
+    receipt.update({
+        "extraction": {"claims": claims},
+        "evidence": evidence,
+        "verification": verification,
+        "policy": policy,
+        "authorization": authorization,
+        "execution": {
+            "actions": [] if not human_approved else [{"type": "world_map_projection", "status": "authorized"}],
+            "status": "receipt_only" if not human_approved else "executed",
+        },
+    })
+    receipt["section_hashes"] = compute_section_hashes(receipt)
+    receipt["section_hashes"]["core_hash"] = compute_core_hash(receipt)
+    _add_attestations(receipt, human_approved)
+    receipt["final_hash"] = compute_final_hash(receipt)
+    return receipt
+
+
+def save_receipt(receipt: Dict[str, Any], output_dir: str = "receipts") -> str:
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    path = Path(output_dir) / f"{receipt['receipt_id']}.json"
+    path.write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+    print(f"Receipt saved: {path}")
+    return str(path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--text", type=str, help="Claim text to verify")
+    parser.add_argument("--approve", action="store_true", help="Simulate explicit human approval")
+    args = parser.parse_args()
+    if not args.text:
+        raise SystemExit("Usage: python claim_pipeline.py --text 'claim text' [--approve]")
+    r = create_claim_verification_receipt(args.text, human_approved=args.approve)
+    saved = save_receipt(r)
+    print(json.dumps(verify_receipt(saved), indent=2))

--- a/map_query.py
+++ b/map_query.py
@@ -1,0 +1,73 @@
+"""
+map_query.py — Constitutional World Map Query Tools v0.1
+
+Returns receipt-backed projections only. Never asserts truth. Never authorizes action.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def load_world_map(path: str | Path = "world_map.jsonl") -> List[Dict[str, Any]]:
+    p = Path(path)
+    if not p.exists():
+        return []
+    entries: List[Dict[str, Any]] = []
+    with open(p, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                entries.append(json.loads(line))
+    return entries
+
+
+def find_by_receipt_id(receipt_id: str, path: str | Path = "world_map.jsonl") -> Optional[Dict[str, Any]]:
+    for entry in load_world_map(path):
+        if entry.get("receipt_id") == receipt_id:
+            return entry
+    return None
+
+
+def find_by_claim_text(query: str, path: str | Path = "world_map.jsonl") -> List[Dict[str, Any]]:
+    q = query.lower()
+    results: List[Dict[str, Any]] = []
+    for entry in load_world_map(path):
+        for claim in entry.get("claims", []):
+            if q in claim.get("text", "").lower():
+                results.append(entry)
+                break
+    return results
+
+
+def summarize_map(path: str | Path = "world_map.jsonl") -> Dict[str, Any]:
+    entries = load_world_map(path)
+    if not entries:
+        return {"total_entries": 0, "status": "empty_map", "message": "No verified receipts ingested yet."}
+    counts: Dict[str, int] = {}
+    for entry in entries:
+        key = entry.get("verification_result", "unknown")
+        counts[key] = counts.get(key, 0) + 1
+    return {
+        "total_entries": len(entries),
+        "verification_breakdown": counts,
+        "latest_entry": entries[-1].get("created_at"),
+        "message": "Projection from verified receipts only. No truth asserted.",
+    }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Query constitutional world map")
+    parser.add_argument("--summary", action="store_true")
+    parser.add_argument("--receipt", type=str)
+    parser.add_argument("--search", type=str)
+    parser.add_argument("--map", default="world_map.jsonl")
+    args = parser.parse_args()
+    if args.summary:
+        print(json.dumps(summarize_map(args.map), indent=2))
+    elif args.receipt:
+        print(json.dumps(find_by_receipt_id(args.receipt, args.map), indent=2))
+    elif args.search:
+        print(json.dumps(find_by_claim_text(args.search, args.map), indent=2))
+    else:
+        print("Usage: python map_query.py --summary | --receipt ID | --search TEXT")

--- a/policies/POLICY_CLAIM_VERIFICATION_V0_1.json
+++ b/policies/POLICY_CLAIM_VERIFICATION_V0_1.json
@@ -1,0 +1,20 @@
+{
+  "policy_id": "POLICY_CLAIM_VERIFICATION_V0_1",
+  "version": "0.1",
+  "effective_from": "2026-06-25T00:00:00Z",
+  "supersedes": null,
+  "rules": [
+    {
+      "id": "at_least_one_evidence",
+      "description": "At least one evidence item is required."
+    },
+    {
+      "id": "every_claim_mapped",
+      "description": "Every extracted claim must map to at least one evidence item."
+    },
+    {
+      "id": "verification_not_fail",
+      "description": "Verification result must be pass or partial."
+    }
+  ]
+}

--- a/policies/POLICY_WORLD_MAP_INGEST_V0_1.json
+++ b/policies/POLICY_WORLD_MAP_INGEST_V0_1.json
@@ -1,0 +1,32 @@
+{
+  "policy_id": "POLICY_WORLD_MAP_INGEST_V0_1",
+  "version": "0.1",
+  "effective_from": "2026-06-25T00:00:00Z",
+  "supersedes": null,
+  "rules": [
+    {
+      "id": "valid_receipt",
+      "description": "Receipt must pass structural, hash, and attestation verification."
+    },
+    {
+      "id": "authority_false",
+      "description": "Receipt authority must remain false."
+    },
+    {
+      "id": "authorization_granted",
+      "description": "Authorization result must be granted."
+    },
+    {
+      "id": "execution_executed",
+      "description": "Execution status must be executed."
+    },
+    {
+      "id": "policy_compliant",
+      "description": "Receipt policy result must be compliant."
+    },
+    {
+      "id": "policy_hash_present",
+      "description": "Referenced policy hash must be embedded in the receipt."
+    }
+  ]
+}

--- a/policy_loader.py
+++ b/policy_loader.py
@@ -1,0 +1,82 @@
+"""
+policy_loader.py — Versioned, Immutable Policy Registry v0.1
+"""
+
+import json
+import hashlib
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+POLICIES_DIR = Path("policies")
+
+
+def compute_policy_hash(policy: Dict[str, Any]) -> str:
+    core = {
+        "policy_id": policy["policy_id"],
+        "version": policy["version"],
+        "rules": policy.get("rules", []),
+        "effective_from": policy.get("effective_from"),
+        "supersedes": policy.get("supersedes"),
+    }
+    canonical = json.dumps(core, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def validate_policy(policy: Dict[str, Any]) -> bool:
+    required = ["policy_id", "version", "effective_from", "rules"]
+    missing = [key for key in required if key not in policy]
+    if missing:
+        raise ValueError(f"Policy missing required fields: {missing}")
+    if not isinstance(policy["rules"], list):
+        raise ValueError("rules must be a list")
+    return True
+
+
+def load_policy(policy_version: str) -> Dict[str, Any]:
+    path = POLICIES_DIR / f"{policy_version}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Policy not found: {policy_version}")
+    with open(path, "r", encoding="utf-8") as f:
+        policy = json.load(f)
+    validate_policy(policy)
+    return policy
+
+
+def evaluate_policy(receipt: Dict[str, Any], policy: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    if policy is None:
+        policy_version = receipt.get("policy", {}).get("policy_version")
+        if not policy_version:
+            return {"result": "unknown", "reason": "no policy_version in receipt"}
+        policy = load_policy(policy_version)
+
+    embedded_version = receipt.get("policy", {}).get("policy_version")
+    if embedded_version != policy["policy_id"]:
+        return {"result": "mismatch", "reason": "policy version mismatch"}
+
+    policy_hash = compute_policy_hash(policy)
+    embedded_hash = receipt.get("policy", {}).get("policy_hash")
+    if embedded_hash != policy_hash:
+        return {"result": "mismatch", "reason": "policy hash mismatch", "policy_hash": policy_hash}
+
+    return {
+        "policy_id": policy["policy_id"],
+        "policy_hash": policy_hash,
+        "result": receipt.get("policy", {}).get("result", "unknown"),
+        "rules_evaluated": receipt.get("policy", {}).get("rules_evaluated", []),
+    }
+
+
+def list_available_policies() -> List[Dict[str, Any]]:
+    if not POLICIES_DIR.exists():
+        return []
+    out: List[Dict[str, Any]] = []
+    for path in sorted(POLICIES_DIR.glob("*.json")):
+        with open(path, "r", encoding="utf-8") as f:
+            policy = json.load(f)
+        out.append({
+            "policy_id": policy.get("policy_id"),
+            "version": policy.get("version"),
+            "effective_from": policy.get("effective_from"),
+            "policy_hash": compute_policy_hash(policy),
+        })
+    return out

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths =
+    test_receipt.py
+    test_claim_pipeline.py
+    test_world_map.py
+    test_world_map_query.py

--- a/receipt.py
+++ b/receipt.py
@@ -1,0 +1,168 @@
+"""
+receipt.py — Constitutional Receipt v0.1
+
+Receipts prove process only. Receipts never prove truth or grant authority.
+"""
+
+import json
+import hashlib
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+VALID_SIGNED_SECTIONS = {
+    "input", "extraction", "evidence", "verification",
+    "policy", "authorization", "execution", "core"
+}
+
+
+def jcs(obj: Any) -> str:
+    """Deterministic JSON canonicalization approximation for v0.1."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def sha256_jcs(obj: Any) -> str:
+    digest = hashlib.sha256(jcs(obj).encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def compute_section_hashes(receipt: Dict[str, Any]) -> Dict[str, str]:
+    sections = [
+        "input", "extraction", "evidence", "verification",
+        "policy", "authorization", "execution"
+    ]
+    out: Dict[str, str] = {}
+    for section in sections:
+        if section in receipt:
+            out[f"{section}_hash"] = sha256_jcs(receipt[section])
+    return out
+
+
+def _core_view(receipt: Dict[str, Any]) -> Dict[str, Any]:
+    core = {k: v for k, v in receipt.items() if k not in ("attestations", "final_hash")}
+    if "section_hashes" in core and isinstance(core["section_hashes"], dict):
+        core["section_hashes"] = {
+            k: v for k, v in core["section_hashes"].items() if k != "core_hash"
+        }
+    return core
+
+
+def compute_core_hash(receipt: Dict[str, Any]) -> str:
+    """core_hash = JCS(receipt minus attestations/final_hash, excluding core_hash self-reference)."""
+    return sha256_jcs(_core_view(receipt))
+
+
+def compute_final_hash(receipt: Dict[str, Any]) -> str:
+    """final_hash = JCS(receipt excluding only final_hash)."""
+    final = {k: v for k, v in receipt.items() if k != "final_hash"}
+    return sha256_jcs(final)
+
+
+def verify_hashes(receipt: Dict[str, Any]) -> bool:
+    section_hashes = receipt.get("section_hashes")
+    if not isinstance(section_hashes, dict):
+        return False
+
+    expected_sections = compute_section_hashes(receipt)
+    for key, expected in expected_sections.items():
+        if section_hashes.get(key) != expected:
+            return False
+
+    if section_hashes.get("core_hash") != compute_core_hash(receipt):
+        return False
+
+    if receipt.get("final_hash") != compute_final_hash(receipt):
+        return False
+
+    return True
+
+
+def verify_signature(identity: str, message_hash: str, signature: str) -> bool:
+    """Pluggable v0.1 signature stub. Replace with DID/Ed25519 in v0.2."""
+    return bool(identity and message_hash and signature)
+
+
+def verify_attestations(receipt: Dict[str, Any]) -> bool:
+    attestations = receipt.get("attestations")
+    if not isinstance(attestations, list) or not attestations:
+        return False
+
+    section_hashes = receipt.get("section_hashes", {})
+    for att in attestations:
+        section = att.get("signed_section")
+        if section not in VALID_SIGNED_SECTIONS:
+            return False
+        if att.get("signature_alg") != "ed25519":
+            return False
+
+        if section == "core":
+            target_hash = section_hashes.get("core_hash")
+        else:
+            target_hash = section_hashes.get(f"{section}_hash")
+        if not target_hash:
+            return False
+        if att.get("signed_section_hash") != target_hash:
+            return False
+        if not verify_signature(att.get("identity", ""), target_hash, att.get("signature", "")):
+            return False
+
+    return True
+
+
+def verify_invariants(receipt: Dict[str, Any]) -> bool:
+    if receipt.get("authority") is not False:
+        return False
+    if receipt.get("version") != "0.1":
+        return False
+    if receipt.get("canonicalization", {}).get("method") != "JCS":
+        return False
+    if receipt.get("canonicalization", {}).get("hash_alg") != "sha256":
+        return False
+    return True
+
+
+def verify_receipt(path: str | Path) -> Dict[str, Any]:
+    try:
+        with open(Path(path), "r", encoding="utf-8") as f:
+            receipt = json.load(f)
+    except Exception as exc:
+        return {"valid": False, "error": f"Failed to load: {exc}"}
+
+    checks = {
+        "invariants": verify_invariants(receipt),
+        "hashes": verify_hashes(receipt),
+        "attestations": verify_attestations(receipt),
+    }
+    valid = all(checks.values())
+    return {
+        "valid": valid,
+        "receipt_id": receipt.get("receipt_id"),
+        "receipt_type": receipt.get("receipt_type"),
+        "checks": checks,
+        "details": "All checks passed" if valid else "One or more checks failed",
+    }
+
+
+def seal_receipt(receipt: Dict[str, Any]) -> Dict[str, Any]:
+    receipt = dict(receipt)
+    receipt["section_hashes"] = compute_section_hashes(receipt)
+    receipt["section_hashes"]["core_hash"] = compute_core_hash(receipt)
+    receipt["final_hash"] = compute_final_hash(receipt)
+    return receipt
+
+
+def create_receipt_skeleton(receipt_type: str, input_data: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    suffix = secrets.token_hex(6)
+    receipt = {
+        "receipt_id": f"rec_{now.strftime('%Y%m%d')}_{suffix}",
+        "receipt_type": receipt_type,
+        "version": "0.1",
+        "timestamp": now.isoformat().replace("+00:00", "Z"),
+        "authority": False,
+        "canonicalization": {"method": "JCS", "hash_alg": "sha256"},
+    }
+    if input_data is not None:
+        receipt["input"] = input_data
+    return receipt

--- a/receiptctl.py
+++ b/receiptctl.py
@@ -1,0 +1,73 @@
+"""
+receiptctl.py — Constitutional Receipt Control Surface v0.1
+"""
+
+import argparse
+import json
+import sys
+
+from claim_pipeline import create_claim_verification_receipt, save_receipt
+from map_query import find_by_claim_text, find_by_receipt_id, summarize_map
+from receipt import verify_receipt
+from world_map import append_world_map_entry
+
+
+def cmd_verify(args) -> int:
+    result = verify_receipt(args.receipt)
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("valid") else 1
+
+
+def cmd_claim(args) -> int:
+    receipt = create_claim_verification_receipt(args.text, human_approved=args.approve)
+    saved_path = save_receipt(receipt)
+    print(f"Receipt created: {receipt['receipt_id']}")
+    print(f"Authorization: {receipt['authorization']['result']}")
+    if args.approve and args.ingest:
+        map_id = append_world_map_entry(saved_path)
+        print(f"Ingested: {map_id}" if map_id else "Ingest rejected")
+        return 0 if map_id else 1
+    if args.ingest and not args.approve:
+        print("Ingest skipped: --ingest requires explicit --approve")
+    return 0
+
+
+def cmd_map(args) -> int:
+    if args.summary:
+        print(json.dumps(summarize_map(args.map), indent=2))
+    elif args.receipt:
+        print(json.dumps(find_by_receipt_id(args.receipt, args.map), indent=2))
+    elif args.search:
+        print(json.dumps(find_by_claim_text(args.search, args.map), indent=2))
+    else:
+        print("Use --summary, --receipt, or --search")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="receiptctl", description="Constitutional Receipt CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_verify = subparsers.add_parser("verify", help="Verify a receipt")
+    p_verify.add_argument("receipt")
+    p_verify.set_defaults(func=cmd_verify)
+
+    p_claim = subparsers.add_parser("claim", help="Process a claim")
+    p_claim.add_argument("text")
+    p_claim.add_argument("--approve", action="store_true")
+    p_claim.add_argument("--ingest", action="store_true")
+    p_claim.set_defaults(func=cmd_claim)
+
+    p_map = subparsers.add_parser("map", help="Query world map")
+    p_map.add_argument("--summary", action="store_true")
+    p_map.add_argument("--receipt")
+    p_map.add_argument("--search")
+    p_map.add_argument("--map", default="world_map.jsonl")
+    p_map.set_defaults(func=cmd_map)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/replay_engine.py
+++ b/replay_engine.py
@@ -1,0 +1,72 @@
+"""
+replay_engine.py — Independent Receipt Replayer v0.1
+
+Clone repo -> replay receipt -> verify hashes, attestations, and immutable policy hash.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from policy_loader import evaluate_policy, load_policy
+from receipt import verify_receipt
+
+
+def replay_receipt(path: str | Path, expected_policy_hash: str | None = None) -> Dict[str, Any]:
+    with open(Path(path), "r", encoding="utf-8") as f:
+        receipt = json.load(f)
+
+    result: Dict[str, Any] = {
+        "receipt_id": receipt.get("receipt_id"),
+        "replay_success": False,
+        "hash_verification": False,
+        "policy_verification": False,
+        "details": {},
+    }
+
+    hash_ok = verify_receipt(path)["valid"]
+    result["hash_verification"] = hash_ok
+
+    policy_version = receipt.get("policy", {}).get("policy_version")
+    if policy_version:
+        policy_doc = load_policy(policy_version)
+        policy_hash = receipt.get("policy", {}).get("policy_hash")
+        result["details"]["policy_hash"] = policy_hash
+        if expected_policy_hash and policy_hash != expected_policy_hash:
+            result["details"]["policy_hash_mismatch"] = True
+        else:
+            policy_eval = evaluate_policy(receipt, policy_doc)
+            result["details"]["policy_eval"] = policy_eval
+            result["policy_verification"] = policy_eval.get("result") == "compliant"
+
+    result["replay_success"] = bool(hash_ok and result["policy_verification"])
+    result["message"] = "Full replay successful" if result["replay_success"] else "Replay failed — see details"
+    return result
+
+
+def batch_replay(directory: str | Path = "receipts") -> Dict[str, Any]:
+    receipts_dir = Path(directory)
+    receipts = sorted(receipts_dir.glob("*.json")) if receipts_dir.exists() else []
+    results = [replay_receipt(path) for path in receipts]
+    successful = sum(1 for item in results if item["replay_success"])
+    return {
+        "total": len(results),
+        "successful": successful,
+        "success_rate": successful / len(results) if results else 1,
+        "results": results,
+    }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("receipt", nargs="?", help="Receipt path")
+    parser.add_argument("--batch", action="store_true")
+    parser.add_argument("--directory", default="receipts")
+    args = parser.parse_args()
+    if args.batch:
+        print(json.dumps(batch_replay(args.directory), indent=2))
+    elif args.receipt:
+        print(json.dumps(replay_receipt(args.receipt), indent=2))
+    else:
+        print("Usage: python replay_engine.py <receipt> | --batch")

--- a/test_claim_pipeline.py
+++ b/test_claim_pipeline.py
@@ -1,0 +1,44 @@
+from claim_pipeline import create_claim_verification_receipt
+from receipt import verify_attestations, verify_hashes, verify_invariants
+
+
+def test_pipeline_creates_valid_receipt_without_approval():
+    r = create_claim_verification_receipt("Test claim.")
+    assert r["authority"] is False
+    assert r["authorization"]["result"] == "pending_human"
+    assert r["execution"]["actions"] == []
+    assert r["execution"]["status"] == "receipt_only"
+    assert verify_invariants(r)
+    assert verify_hashes(r)
+    assert verify_attestations(r)
+
+
+def test_pipeline_with_approval_adds_authorizer():
+    r = create_claim_verification_receipt("Test claim.", human_approved=True)
+    roles = [a["role"] for a in r["attestations"]]
+    assert "authorizer" in roles
+    assert r["authorization"]["result"] == "granted"
+    assert r["execution"]["status"] == "executed"
+    assert verify_hashes(r)
+
+
+def test_verified_support_is_not_truth():
+    r = create_claim_verification_receipt("Test claim.")
+    assert "truth" not in r
+    assert r["authority"] is False
+    assert r["verification"]["result"] in ("partial", "pass", "fail")
+
+
+def test_every_claim_has_evidence_mapping():
+    r = create_claim_verification_receipt("Claim one. Claim two.")
+    claims = r["extraction"]["claims"]
+    evidence = r["evidence"]["items"]
+    assert len(claims) == 2
+    for claim in claims:
+        assert any(item["supports_claim"] == claim["claim_id"] for item in evidence)
+
+
+def test_pipeline_embeds_policy_hash():
+    r = create_claim_verification_receipt("Test claim.")
+    assert r["policy"]["policy_version"] == "POLICY_CLAIM_VERIFICATION_V0_1"
+    assert r["policy"]["policy_hash"].startswith("sha256:")

--- a/test_receipt.py
+++ b/test_receipt.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+from receipt import verify_attestations, verify_hashes, verify_invariants
+from claim_pipeline import create_claim_verification_receipt
+
+
+def test_good_receipt_passes(tmp_path):
+    receipt = create_claim_verification_receipt("Test claim.", human_approved=True)
+    p = tmp_path / "receipt.json"
+    p.write_text(json.dumps(receipt), encoding="utf-8")
+    from receipt import verify_receipt
+    assert verify_receipt(p)["valid"] is True
+
+
+def test_authority_true_fails():
+    receipt = create_claim_verification_receipt("Test claim.", human_approved=True)
+    receipt["authority"] = True
+    assert verify_invariants(receipt) is False
+
+
+def test_bad_hash_fails():
+    receipt = create_claim_verification_receipt("Test claim.", human_approved=True)
+    receipt["final_hash"] = "sha256:" + "0" * 64
+    assert verify_hashes(receipt) is False
+
+
+def test_mutated_section_fails():
+    receipt = create_claim_verification_receipt("Test claim.", human_approved=True)
+    receipt["extraction"]["extra"] = True
+    assert verify_hashes(receipt) is False
+
+
+def test_missing_attestation_fails():
+    receipt = create_claim_verification_receipt("Test claim.", human_approved=True)
+    receipt["attestations"] = []
+    assert verify_attestations(receipt) is False
+
+
+def test_unknown_signed_section_fails():
+    receipt = create_claim_verification_receipt("Test claim.", human_approved=True)
+    receipt["attestations"][0]["signed_section"] = "truth"
+    assert verify_attestations(receipt) is False

--- a/test_world_map.py
+++ b/test_world_map.py
@@ -1,0 +1,70 @@
+import json
+
+import pytest
+
+from claim_pipeline import create_claim_verification_receipt
+from world_map import append_world_map_entry, eligible_for_ingest, load_receipt
+
+
+@pytest.fixture
+def approved_receipt(tmp_path):
+    r = create_claim_verification_receipt("Approved test claim.", human_approved=True)
+    p = tmp_path / f"{r['receipt_id']}.json"
+    p.write_text(json.dumps(r, indent=2), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def pending_receipt(tmp_path):
+    r = create_claim_verification_receipt("Pending test claim.")
+    p = tmp_path / f"{r['receipt_id']}.json"
+    p.write_text(json.dumps(r, indent=2), encoding="utf-8")
+    return p
+
+
+def test_pending_receipt_rejected(pending_receipt, tmp_path):
+    assert eligible_for_ingest(pending_receipt) is False
+    assert append_world_map_entry(pending_receipt, tmp_path / "map.jsonl") is None
+
+
+def test_approved_executed_receipt_accepted(approved_receipt, tmp_path):
+    assert eligible_for_ingest(approved_receipt) is True
+    map_id = append_world_map_entry(approved_receipt, tmp_path / "map.jsonl")
+    assert map_id is not None
+    assert map_id.startswith("wm_rec_")
+
+
+def test_authority_true_rejected(tmp_path):
+    r = create_claim_verification_receipt("Bad authority.", human_approved=True)
+    r["authority"] = True
+    p = tmp_path / "bad_authority.json"
+    p.write_text(json.dumps(r), encoding="utf-8")
+    assert eligible_for_ingest(p) is False
+
+
+def test_invalid_hash_rejected(approved_receipt, tmp_path):
+    data = load_receipt(approved_receipt)
+    data["final_hash"] = "sha256:" + "0" * 64
+    p = tmp_path / "bad_hash.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    assert eligible_for_ingest(p) is False
+
+
+def test_entry_preserves_receipt_identity(approved_receipt, tmp_path):
+    map_file = tmp_path / "world_map.jsonl"
+    append_world_map_entry(approved_receipt, map_file)
+    entry = json.loads(map_file.read_text(encoding="utf-8").splitlines()[0])
+    receipt = load_receipt(approved_receipt)
+    assert entry["receipt_id"] == receipt["receipt_id"]
+    assert entry["final_hash"] == receipt["final_hash"]
+    assert entry["authority"] is False
+    assert entry["authorization_result"] == "granted"
+
+
+def test_entry_preserves_policy_hash(approved_receipt, tmp_path):
+    map_file = tmp_path / "world_map.jsonl"
+    append_world_map_entry(approved_receipt, map_file)
+    entry = json.loads(map_file.read_text(encoding="utf-8").splitlines()[0])
+    receipt = load_receipt(approved_receipt)
+    assert entry["policy_hash"] == receipt["policy"]["policy_hash"]
+    assert entry["policy_hash"].startswith("sha256:")

--- a/test_world_map_query.py
+++ b/test_world_map_query.py
@@ -1,0 +1,51 @@
+import json
+
+import pytest
+
+from claim_pipeline import create_claim_verification_receipt
+from map_query import find_by_claim_text, find_by_receipt_id, load_world_map, summarize_map
+from world_map import append_world_map_entry
+
+
+@pytest.fixture
+def populated_map(tmp_path):
+    map_file = tmp_path / "test_map.jsonl"
+
+    r1 = create_claim_verification_receipt("Approved test claim about AI.", human_approved=True)
+    p1 = tmp_path / f"{r1['receipt_id']}.json"
+    p1.write_text(json.dumps(r1, indent=2), encoding="utf-8")
+    append_world_map_entry(p1, map_file)
+
+    r2 = create_claim_verification_receipt("Second claim on verification.", human_approved=True)
+    p2 = tmp_path / f"{r2['receipt_id']}.json"
+    p2.write_text(json.dumps(r2, indent=2), encoding="utf-8")
+    append_world_map_entry(p2, map_file)
+
+    return map_file
+
+
+def test_summary_counts_entries(populated_map):
+    summary = summarize_map(populated_map)
+    assert summary["total_entries"] == 2
+    assert summary["message"].startswith("Projection from verified")
+
+
+def test_receipt_lookup_returns_exact_entry(populated_map):
+    entries = load_world_map(populated_map)
+    rid = entries[0]["receipt_id"]
+    result = find_by_receipt_id(rid, populated_map)
+    assert result is not None
+    assert result["receipt_id"] == rid
+    assert result["authority"] is False
+
+
+def test_claim_search_returns_matching_entry(populated_map):
+    results = find_by_claim_text("AI", populated_map)
+    assert len(results) >= 1
+    assert any("AI" in c["text"] for c in results[0]["claims"])
+
+
+def test_empty_map_returns_safe_zero_summary(tmp_path):
+    summary = summarize_map(tmp_path / "empty.jsonl")
+    assert summary["total_entries"] == 0
+    assert summary["status"] == "empty_map"

--- a/verify_all.py
+++ b/verify_all.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Constitutional Receipts Independent Verifier v0.1
+
+One-command replay + policy + map verification.
+Outputs: CONSTITUTIONAL_REPLAY_PASS | CONSTITUTIONAL_REPLAY_FAIL
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_command(cmd: str, description: str) -> bool:
+    print(f"▶️  {description}")
+    try:
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).parent,
+        )
+        if result.returncode == 0:
+            print(f"✅ {description} passed")
+            if result.stdout.strip():
+                output = result.stdout.strip()
+                print(output[:500] + ("..." if len(output) > 500 else ""))
+            return True
+        print(f"❌ {description} failed")
+        if result.stdout.strip():
+            print(result.stdout)
+        if result.stderr.strip():
+            print(result.stderr)
+        return False
+    except Exception as exc:
+        print(f"💥 Error running {description}: {exc}")
+        return False
+
+
+def main() -> int:
+    print("🔍 Constitutional Receipts Replay Verifier v0.1")
+    print("Receipts prove process only. No authority granted.\n")
+
+    all_pass = True
+    all_pass = run_command("pytest -q", "Pytest suite") and all_pass
+    all_pass = run_command("python replay_engine.py --batch", "Replay engine batch") and all_pass
+    all_pass = run_command("python receiptctl.py map --summary", "Receiptctl map summary") and all_pass
+
+    print("\n" + "=" * 60)
+    if all_pass:
+        print("🎉 CONSTITUTIONAL_REPLAY_PASS")
+        print("All invariants hold. Replay is reproducible.")
+        return 0
+    print("⚠️  CONSTITUTIONAL_REPLAY_FAIL")
+    print("One or more verification steps failed.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/world_map.py
+++ b/world_map.py
@@ -1,0 +1,86 @@
+"""
+world_map.py — Constitutional World Map Ingestor v0.1
+
+World map consumes receipts. It does not create authority or decide truth.
+"""
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from receipt import verify_receipt
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_receipt(path: str | Path) -> Dict[str, Any]:
+    with open(Path(path), "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def eligible_for_ingest(path: str | Path) -> bool:
+    try:
+        receipt = load_receipt(path)
+    except Exception:
+        return False
+    checks = {
+        "valid_receipt": verify_receipt(path)["valid"],
+        "authority_false": receipt.get("authority") is False,
+        "authorization_granted": receipt.get("authorization", {}).get("result") == "granted",
+        "execution_executed": receipt.get("execution", {}).get("status") == "executed",
+        "policy_compliant": receipt.get("policy", {}).get("result") == "compliant",
+        "has_final_hash": bool(receipt.get("final_hash")),
+        "has_policy_hash": bool(receipt.get("policy", {}).get("policy_hash")),
+    }
+    return all(checks.values())
+
+
+def project_claims(receipt: Dict[str, Any]) -> list[Dict[str, Any]]:
+    return [
+        {
+            "claim_id": claim.get("claim_id"),
+            "text": claim.get("text"),
+            "original_confidence": claim.get("confidence"),
+        }
+        for claim in receipt.get("extraction", {}).get("claims", [])
+    ]
+
+
+def append_world_map_entry(path: str | Path, world_map_path: str | Path = "world_map.jsonl") -> Optional[str]:
+    try:
+        receipt = load_receipt(path)
+    except Exception:
+        return None
+    if not eligible_for_ingest(path):
+        return None
+
+    entry = {
+        "map_entry_id": f"wm_{receipt['receipt_id']}",
+        "receipt_id": receipt["receipt_id"],
+        "final_hash": receipt["final_hash"],
+        "policy_hash": receipt.get("policy", {}).get("policy_hash"),
+        "claims": project_claims(receipt),
+        "verification_result": receipt.get("verification", {}).get("result"),
+        "policy_result": receipt.get("policy", {}).get("result"),
+        "authorization_result": receipt.get("authorization", {}).get("result"),
+        "authority": receipt["authority"],
+        "created_at": _utc_now(),
+    }
+    out = Path(world_map_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, sort_keys=True) + "\n")
+    return entry["map_entry_id"]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("receipt", type=str, help="Path to receipt JSON")
+    parser.add_argument("--map", default="world_map.jsonl")
+    args = parser.parse_args()
+    result = append_world_map_entry(args.receipt, args.map)
+    print(result if result else "Rejected by WORLD_MAP_INGEST_POLICY_V0_1")


### PR DESCRIPTION
## Summary

Adds a receipt-first constitutional replay prototype for AI/governance workflows.

Core invariant:

> Receipts prove process only. Receipts do not prove truth or grant authority.

## Added

- `receipt.py` — receipt hashing, invariants, attestations
- `claim_pipeline.py` — claim verification receipt generator
- `policy_loader.py` — immutable policy registry
- `world_map.py` — receipt-backed projection layer
- `map_query.py` — read-only map inspection
- `replay_engine.py` — independent replay engine
- `receiptctl.py` — CLI control surface
- `verify_all.py` — one-command replay verifier
- `REPLAY_MANIFEST_V0_1.json` — canonical manifest
- Policies for claim verification and world-map ingest
- Pytest coverage for receipt, pipeline, map ingest, and query layers
- GitHub Action: `Constitutional Replay v0.1`

## Verification

Run locally:

```bash
python verify_all.py
```

Expected pass marker:

```text
CONSTITUTIONAL_REPLAY_PASS
```

## Authority boundary

- `authority` must remain `false`
- Authorization is explicit, scoped, and separate from receipts
- The world map consumes authorized receipts but never creates authority or decides truth

## Change size

17 files changed; branch is ahead of `master` by 17 commits.