### PR TITLE
v2.8 consensus scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,15 @@ tools/al-verifier/node_modules/
 target/
 tools/al-verifier/target/
 receiptnet/.keys/
+
+# Witness private material: public addresses may be committed, secrets never.
+*.privatekey
+*.key
+*.pem
+*.mnemonic
+*.seed
+keystore*.json
+node8.privatekey
+coldbox.privatekey
+alms-v2.8-node8-wallet/
+alms-v2.8-coldbox-wallet/

--- a/config/witnesses.v2.8.example.json
+++ b/config/witnesses.v2.8.example.json
@@ -1,0 +1,24 @@
+{
+  "version": "v2.8",
+  "threshold": 2,
+  "witnesses": [
+    {
+      "id": "witness_1_jay",
+      "address": "0xC345B26094c63C69222Ee775189a3d3eaead5a84",
+      "mode": "online",
+      "label": "Jay witness wallet"
+    },
+    {
+      "id": "witness_2_node8",
+      "address": "0x0000000000000000000000000000000000000000",
+      "mode": "node8",
+      "label": "Node8 separate host wallet"
+    },
+    {
+      "id": "witness_3_coldbox",
+      "address": "0x0000000000000000000000000000000000000000",
+      "mode": "coldbox",
+      "label": "ColdBox offline signer"
+    }
+  ]
+}

--- a/config/witnesses.v2.8.json
+++ b/config/witnesses.v2.8.json
@@ -1,0 +1,24 @@
+{
+  "version": "v2.8",
+  "threshold": 2,
+  "witnesses": [
+    {
+      "id": "witness_1_jay",
+      "address": "0xC345B26094c63C69222Ee775189a3d3eaead5a84",
+      "mode": "online",
+      "label": "Jay witness wallet"
+    },
+    {
+      "id": "witness_2_node8",
+      "address": "0x2AcdCE2FaF9Ffd9580897fF8d18919982b20b65c",
+      "mode": "node8",
+      "label": "Node8 separate host wallet"
+    },
+    {
+      "id": "witness_3_coldbox",
+      "address": "0x933527c220E2E47a9B26271920A7bd45D099358A",
+      "mode": "coldbox",
+      "label": "ColdBox offline signer"
+    }
+  ]
+}

--- a/docs/COLDBOX_WITNESS_V2_8.md
+++ b/docs/COLDBOX_WITNESS_V2_8.md
@@ -1,0 +1,27 @@
+# ColdBox Witness v2.8
+
+Purpose: provide a sovereignty-first third witness without pretending third-party decentralization exists yet.
+
+## Invariants
+
+- ColdBox key is separate from Jay and Node8 online keys.
+- ColdBox signs only witness receipts, never semantic truth claims.
+- `authority=false` is mandatory.
+- No `v2.8-live` tag without a consensus attestation.
+
+## Procedure
+
+1. Copy the replay bundle to ColdBox using removable media.
+2. Run replay verification offline.
+3. Confirm `status=PASS`, `authority=false`, and state root matches local output.
+4. Sign or prepare the EAS attestation payload offline.
+5. Broadcast from an online relay without exposing the ColdBox private key.
+6. Record the ColdBox attestation UID in the v2.8 manifest.
+
+## Halt conditions
+
+- State root mismatch.
+- Missing witness UID.
+- Any witness reports `authority=true`.
+- Any witness reports non-PASS status.
+- Threshold below 2-of-3.

--- a/schemas/WITNESS_CONSENSUS_V2_8.eas.txt
+++ b/schemas/WITNESS_CONSENSUS_V2_8.eas.txt
@@ -1,0 +1,1 @@
+string framework,string consensusId,string repo,string tag,uint8 threshold,uint8 witnessCount,bytes32 stateRoot,string matchedWitnesses,string witnessUids,string replayCid,bool authority,string status

--- a/schemas/WITNESS_CONSENSUS_V2_8.receipt.json
+++ b/schemas/WITNESS_CONSENSUS_V2_8.receipt.json
@@ -1,0 +1,9 @@
+{
+  "name": "WITNESS_CONSENSUS_V2_8",
+  "schema_uid": "0x1e529b53c46f168ff3864dfdc8368aa2f627ddaf6992a0a78cfbf40d8852e487",
+  "schema_number": 1627,
+  "registration_tx": "0x9c2103fb4de16fb5a91fba536fd5048ef9ec9058609bdc6db1e1595e2196ed20",
+  "resolver": "0x0000000000000000000000000000000000000000",
+  "revocable": true,
+  "network": "Base"
+}

--- a/schemas/replay_manifest.schema.v2.8.json
+++ b/schemas/replay_manifest.schema.v2.8.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "ALMS_REPLAY_MANIFEST_V2_8",
+  "type": "object",
+  "required": ["version", "framework", "status", "authority", "state_root", "consensus"],
+  "properties": {
+    "version": { "const": "v2.8" },
+    "framework": { "type": "string" },
+    "status": { "enum": ["PASS", "FAIL", "INCOMPLETE", "HALT_ON_MISMATCH"] },
+    "authority": { "const": false },
+    "state_root": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" },
+    "replay_cid": { "type": "string" },
+    "consensus": {
+      "type": "object",
+      "required": ["threshold", "witnesses", "attestations"],
+      "properties": {
+        "threshold": { "type": "integer", "minimum": 2 },
+        "witnesses": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "object",
+            "required": ["id", "address", "mode"],
+            "properties": {
+              "id": { "type": "string" },
+              "address": { "type": "string", "pattern": "^0x[a-fA-F0-9]{40}$" },
+              "mode": { "enum": ["online", "node8", "coldbox", "third_party"] }
+            }
+          }
+        },
+        "attestations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["uid", "witness_id", "state_root", "status", "authority"],
+            "properties": {
+              "uid": { "type": "string", "pattern": "^0x[a-fA-F0-9]{64}$" },
+              "witness_id": { "type": "string" },
+              "state_root": { "type": "string", "pattern": "^0x[a-fA-F0-9]{64}$" },
+              "status": { "const": "PASS" },
+              "authority": { "const": false }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/consensus_aggregate.py
+++ b/scripts/consensus_aggregate.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """ALMS v2.8 witness consensus aggregator.
 
-Reads witness attestations from JSON, requires one unique winning state_root
-from threshold distinct witnesses, and emits a consensus packet. Posting the
+Sprint 1 strict mode: every submitted configured witness attestation must be
+PASS, authority=false, and all submitted state_roots must match. Posting the
 final EAS consensus attestation is explicit/off by default so CI cannot
 silently mint authority.
 """
@@ -73,26 +73,30 @@ def aggregate(manifest: dict[str, Any]) -> dict[str, Any]:
         seen_uids.add(uid)
 
         if item.get("status") != "PASS":
-            continue
+            raise ConsensusError(f"HALT_ON_MISMATCH: non-PASS status from {witness_id}")
         if item.get("authority") is not False:
-            continue
+            raise ConsensusError(f"HALT_ON_MISMATCH: authority claim from {witness_id}")
 
         valid.append({**item, "state_root": norm_root(item["state_root"])})
 
-    if not valid:
-        raise ConsensusError("HALT_ON_MISMATCH: no valid PASS/authority=false attestations")
+    if len(valid) < threshold:
+        raise ConsensusError(
+            f"HALT_ON_MISMATCH: valid={len(valid)}, threshold={threshold}"
+        )
 
     by_root: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for item in valid:
         by_root[item["state_root"]].append(item)
 
-    winners = {root: group for root, group in by_root.items() if len(group) >= threshold}
-    if len(winners) != 1:
+    if len(by_root) != 1:
+        raise ConsensusError(f"HALT_ON_MISMATCH: root_groups={len(by_root)}")
+
+    state_root, matched = next(iter(by_root.items()))
+    if len(matched) < threshold:
         raise ConsensusError(
-            f"HALT_ON_MISMATCH: winners={len(winners)}, threshold={threshold}"
+            f"HALT_ON_MISMATCH: matched={len(matched)}, threshold={threshold}"
         )
 
-    state_root, matched = next(iter(winners.items()))
     return {
         "framework": "WITNESS_CONSENSUS_V2_8",
         "consensus_id": manifest.get("consensus_id", ""),

--- a/scripts/consensus_aggregate.py
+++ b/scripts/consensus_aggregate.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""ALMS v2.8 witness consensus aggregator.
+
+Reads witness attestations from JSON, requires threshold matching state_root,
+and emits a consensus packet. Posting the final EAS consensus attestation is
+left explicit/off by default so CI cannot silently mint authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def norm_root(value: str) -> str:
+    value = value.strip()
+    if not value.startswith("0x"):
+        value = "0x" + value
+    if len(value) != 66:
+        raise ValueError(f"invalid state_root length: {value}")
+    return value.lower()
+
+
+def aggregate(manifest: dict[str, Any]) -> dict[str, Any]:
+    consensus = manifest["consensus"]
+    threshold = int(consensus["threshold"])
+    attestations = consensus["attestations"]
+
+    valid = []
+    for item in attestations:
+        if item.get("status") != "PASS":
+            continue
+        if item.get("authority") is not False:
+            continue
+        valid.append({**item, "state_root": norm_root(item["state_root"])})
+
+    counts = Counter(a["state_root"] for a in valid)
+    if not counts:
+        raise SystemExit("HALT_ON_MISMATCH: no valid PASS/authority=false attestations")
+
+    state_root, count = counts.most_common(1)[0]
+    if count < threshold:
+        raise SystemExit(f"HALT_ON_MISMATCH: best={count}, threshold={threshold}")
+
+    matched = [a for a in valid if a["state_root"] == state_root]
+    return {
+        "framework": "WITNESS_CONSENSUS_V2_8",
+        "consensus_id": manifest.get("consensus_id", ""),
+        "repo": manifest.get("repo", "jsonwisdom/AL"),
+        "tag": manifest.get("tag", "v2.8-live"),
+        "threshold": threshold,
+        "witness_count": len(consensus.get("witnesses", [])),
+        "state_root": state_root,
+        "matched_witnesses": [a["witness_id"] for a in matched],
+        "witness_uids": [a["uid"] for a in matched],
+        "replay_cid": manifest.get("replay_cid", ""),
+        "authority": False,
+        "status": "PASS"
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest", help="v2.8 replay manifest JSON")
+    parser.add_argument("--out", default="consensus-output.v2.8.json")
+    args = parser.parse_args()
+
+    result = aggregate(load_json(args.manifest))
+    Path(args.out).write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/consensus_aggregate.py
+++ b/scripts/consensus_aggregate.py
@@ -99,15 +99,15 @@ def aggregate(manifest: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "framework": "WITNESS_CONSENSUS_V2_8",
-        "consensus_id": manifest.get("consensus_id", ""),
+        "consensusId": manifest.get("consensusId", manifest.get("consensus_id", "")),
         "repo": manifest.get("repo", "jsonwisdom/AL"),
         "tag": manifest.get("tag", "v2.8-live"),
         "threshold": threshold,
-        "witness_count": len(configured_ids),
-        "state_root": state_root,
-        "matched_witnesses": [a["witness_id"] for a in matched],
-        "witness_uids": [a["uid"] for a in matched],
-        "replay_cid": manifest.get("replay_cid", ""),
+        "witnessCount": len(configured_ids),
+        "stateRoot": state_root,
+        "matchedWitnesses": ",".join(a["witness_id"] for a in matched),
+        "witnessUids": ",".join(a["uid"] for a in matched),
+        "replayCid": manifest.get("replayCid", manifest.get("replay_cid", "")),
         "authority": False,
         "status": "PASS"
     }

--- a/scripts/consensus_aggregate.py
+++ b/scripts/consensus_aggregate.py
@@ -2,9 +2,9 @@
 """ALMS v2.8 witness consensus aggregator.
 
 Sprint 1 strict mode: every submitted configured witness attestation must be
-PASS, authority=false, and all submitted state_roots must match. Posting the
-final EAS consensus attestation is explicit/off by default so CI cannot
-silently mint authority.
+PASS, authority=false, and all submitted state_roots must match the replay
+manifest state_root. The witness allow-list comes from the committed witness
+config, not from the manifest being evaluated.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ class ConsensusError(SystemExit):
     """Explicit halt for non-consensus states."""
 
 
-def load_json(path: str) -> dict[str, Any]:
+def load_json(path: str | Path) -> dict[str, Any]:
     return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
@@ -35,20 +35,32 @@ def norm_root(value: str) -> str:
     return value.lower()
 
 
-def configured_witness_ids(consensus: dict[str, Any]) -> set[str]:
-    witnesses = consensus.get("witnesses", [])
+def configured_witness_ids(witness_config: dict[str, Any]) -> set[str]:
+    witnesses = witness_config.get("witnesses", [])
     ids = [w["id"] for w in witnesses]
     if len(ids) != len(set(ids)):
         raise ConsensusError("HALT_ON_MISMATCH: duplicate configured witness id")
     return set(ids)
 
 
-def aggregate(manifest: dict[str, Any]) -> dict[str, Any]:
+def manifest_status_ok(manifest: dict[str, Any]) -> None:
+    if manifest.get("status") != "PASS":
+        raise ConsensusError("HALT_ON_MISMATCH: manifest status is not PASS")
+    if manifest.get("authority") is not False:
+        raise ConsensusError("HALT_ON_MISMATCH: manifest authority is not false")
+
+
+def aggregate(manifest: dict[str, Any], witness_config: dict[str, Any]) -> dict[str, Any]:
+    manifest_status_ok(manifest)
+
     consensus = manifest["consensus"]
     threshold = int(consensus["threshold"])
     attestations = consensus["attestations"]
-    configured_ids = configured_witness_ids(consensus)
+    configured_ids = configured_witness_ids(witness_config)
+    manifest_root = norm_root(manifest["state_root"])
 
+    if threshold != int(witness_config.get("threshold", threshold)):
+        raise ConsensusError("HALT_ON_MISMATCH: manifest threshold differs from witness config")
     if threshold < 2:
         raise ConsensusError("HALT_ON_MISMATCH: threshold must be >= 2")
     if len(configured_ids) < threshold:
@@ -77,7 +89,11 @@ def aggregate(manifest: dict[str, Any]) -> dict[str, Any]:
         if item.get("authority") is not False:
             raise ConsensusError(f"HALT_ON_MISMATCH: authority claim from {witness_id}")
 
-        valid.append({**item, "state_root": norm_root(item["state_root"])})
+        witness_root = norm_root(item["state_root"])
+        if witness_root != manifest_root:
+            raise ConsensusError(f"HALT_ON_MISMATCH: state_root mismatch from {witness_id}")
+
+        valid.append({**item, "state_root": witness_root})
 
     if len(valid) < threshold:
         raise ConsensusError(
@@ -92,6 +108,8 @@ def aggregate(manifest: dict[str, Any]) -> dict[str, Any]:
         raise ConsensusError(f"HALT_ON_MISMATCH: root_groups={len(by_root)}")
 
     state_root, matched = next(iter(by_root.items()))
+    if state_root != manifest_root:
+        raise ConsensusError("HALT_ON_MISMATCH: consensus root differs from manifest root")
     if len(matched) < threshold:
         raise ConsensusError(
             f"HALT_ON_MISMATCH: matched={len(matched)}, threshold={threshold}"
@@ -116,10 +134,15 @@ def aggregate(manifest: dict[str, Any]) -> dict[str, Any]:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("manifest", help="v2.8 replay manifest JSON")
+    parser.add_argument(
+        "--witness-config",
+        default="config/witnesses.v2.8.json",
+        help="committed witness allow-list JSON"
+    )
     parser.add_argument("--out", default="consensus-output.v2.8.json")
     args = parser.parse_args()
 
-    result = aggregate(load_json(args.manifest))
+    result = aggregate(load_json(args.manifest), load_json(args.witness_config))
     Path(args.out).write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
     print(json.dumps(result, indent=2))
     return 0

--- a/scripts/consensus_aggregate.py
+++ b/scripts/consensus_aggregate.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """ALMS v2.8 witness consensus aggregator.
 
-Reads witness attestations from JSON, requires threshold matching state_root,
-and emits a consensus packet. Posting the final EAS consensus attestation is
-left explicit/off by default so CI cannot silently mint authority.
+Reads witness attestations from JSON, requires one unique winning state_root
+from threshold distinct witnesses, and emits a consensus packet. Posting the
+final EAS consensus attestation is explicit/off by default so CI cannot
+silently mint authority.
 """
 
 from __future__ import annotations
@@ -11,9 +12,13 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections import Counter, defaultdict
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
+
+
+class ConsensusError(SystemExit):
+    """Explicit halt for non-consensus states."""
 
 
 def load_json(path: str) -> dict[str, Any]:
@@ -26,38 +31,75 @@ def norm_root(value: str) -> str:
         value = "0x" + value
     if len(value) != 66:
         raise ValueError(f"invalid state_root length: {value}")
+    int(value[2:], 16)
     return value.lower()
+
+
+def configured_witness_ids(consensus: dict[str, Any]) -> set[str]:
+    witnesses = consensus.get("witnesses", [])
+    ids = [w["id"] for w in witnesses]
+    if len(ids) != len(set(ids)):
+        raise ConsensusError("HALT_ON_MISMATCH: duplicate configured witness id")
+    return set(ids)
 
 
 def aggregate(manifest: dict[str, Any]) -> dict[str, Any]:
     consensus = manifest["consensus"]
     threshold = int(consensus["threshold"])
     attestations = consensus["attestations"]
+    configured_ids = configured_witness_ids(consensus)
 
-    valid = []
+    if threshold < 2:
+        raise ConsensusError("HALT_ON_MISMATCH: threshold must be >= 2")
+    if len(configured_ids) < threshold:
+        raise ConsensusError("HALT_ON_MISMATCH: threshold exceeds configured witnesses")
+
+    seen_witness_ids: set[str] = set()
+    seen_uids: set[str] = set()
+    valid: list[dict[str, Any]] = []
+
     for item in attestations:
+        witness_id = item.get("witness_id")
+        uid = item.get("uid")
+
+        if witness_id not in configured_ids:
+            raise ConsensusError(f"HALT_ON_MISMATCH: unknown witness_id {witness_id}")
+        if witness_id in seen_witness_ids:
+            raise ConsensusError(f"HALT_ON_MISMATCH: duplicate witness_id {witness_id}")
+        if uid in seen_uids:
+            raise ConsensusError(f"HALT_ON_MISMATCH: duplicate uid {uid}")
+
+        seen_witness_ids.add(witness_id)
+        seen_uids.add(uid)
+
         if item.get("status") != "PASS":
             continue
         if item.get("authority") is not False:
             continue
+
         valid.append({**item, "state_root": norm_root(item["state_root"])})
 
-    counts = Counter(a["state_root"] for a in valid)
-    if not counts:
-        raise SystemExit("HALT_ON_MISMATCH: no valid PASS/authority=false attestations")
+    if not valid:
+        raise ConsensusError("HALT_ON_MISMATCH: no valid PASS/authority=false attestations")
 
-    state_root, count = counts.most_common(1)[0]
-    if count < threshold:
-        raise SystemExit(f"HALT_ON_MISMATCH: best={count}, threshold={threshold}")
+    by_root: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for item in valid:
+        by_root[item["state_root"]].append(item)
 
-    matched = [a for a in valid if a["state_root"] == state_root]
+    winners = {root: group for root, group in by_root.items() if len(group) >= threshold}
+    if len(winners) != 1:
+        raise ConsensusError(
+            f"HALT_ON_MISMATCH: winners={len(winners)}, threshold={threshold}"
+        )
+
+    state_root, matched = next(iter(winners.items()))
     return {
         "framework": "WITNESS_CONSENSUS_V2_8",
         "consensus_id": manifest.get("consensus_id", ""),
         "repo": manifest.get("repo", "jsonwisdom/AL"),
         "tag": manifest.get("tag", "v2.8-live"),
         "threshold": threshold,
-        "witness_count": len(consensus.get("witnesses", [])),
+        "witness_count": len(configured_ids),
         "state_root": state_root,
         "matched_witnesses": [a["witness_id"] for a in matched],
         "witness_uids": [a["uid"] for a in matched],


### PR DESCRIPTION
Bootstraps v2.8 multi-witness consensus after v2.7 witness live seal.

Adds:
- WITNESS_CONSENSUS_V2_8 EAS schema draft
- replay_manifest.schema.v2.8.json consensus extension
- witnesses.v2.8.example.json with Jay / Node8 / ColdBox slots
- scripts/consensus_aggregate.py 2-of-3 state_root matcher
- ColdBox witness procedure

Consensus invariant:
- threshold = 2-of-3
- matching state_root required
- status=PASS required
- authority=false required
- mismatch halts; no v2.8-live tag

Sprint 1 witness_3 is ColdBox. Third-party migration comes after aggregator stability.