### PR TITLE
rotate Jay v2.8 witness wallet

### DIFF
--- a/config/witnesses.v2.8.json
+++ b/config/witnesses.v2.8.json
@@ -4,7 +4,7 @@
   "witnesses": [
     {
       "id": "witness_1_jay",
-      "address": "0xC345B26094c63C69222Ee775189a3d3eaead5a84",
+      "address": "0x992d94aA31dcD8fDb7d8E6885370ef8202AED399",
       "mode": "online",
       "label": "Jay witness wallet"
     },


### PR DESCRIPTION
Rotates the committed v2.8 Jay witness address before LIVE_ROUND_001.

Old witness_1_jay:
- 0xC345B26094c63C69222Ee775189a3d3eaead5a84

New witness_1_jay:
- 0x992d94aA31dcD8fDb7d8E6885370ef8202AED399

Node8 and ColdBox witness addresses are unchanged.

Reason:
- Round 001 must use the committed allow-list. Attesting from an address not in config/witnesses.v2.8.json would be treated as unconfigured/fake by the aggregator.