### PR TITLE
Use JOY EAS bootstrap anchor for Alabama gate

### DIFF
--- a/JOY/eas/anchors/JOY_REPLAY_BOOTSTRAP_V0_1.json
+++ b/JOY/eas/anchors/JOY_REPLAY_BOOTSTRAP_V0_1.json
@@ -1,0 +1,18 @@
+{
+  "anchor_type": "JOY_REPLAY_BOOTSTRAP_V0_1",
+  "chain": "base",
+  "chain_id": 8453,
+  "schema_uid": "0x5840bf1e71d72a83b820c132b93b3a284a5a07664928342b205938fda0af8055",
+  "schema_number": 1667,
+  "attestation_uid": "0x065812e1fd3825471415d1e8f7cf38f77a450ac9bf204e45af317e6930639a7e",
+  "attestation_tx": "0x7c15cd42bdf73b3bae0fa7c16bf81c491fdb72b20289bd0b5a029a78e51eaab4",
+  "attester": "0xC345B26094c63C69222Ee775189a3d3eaead5a84",
+  "subject": "joy-schema-bootstrap-not-verified",
+  "transform_version": "v0.1.0",
+  "authority": false,
+  "verified_replay": false,
+  "classification": "BOOTSTRAP_NOT_VERIFIED",
+  "no_fake_green": true,
+  "load_verified": false,
+  "notes": "On-chain JOY replay schema/bootstrap attestation anchor. This is not a LOAD_VERIFIED replay witness."
+}

--- a/scripts/ens/alabama_engine_divergence_check.sh
+++ b/scripts/ens/alabama_engine_divergence_check.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+JOY_ANCHOR="JOY/eas/anchors/JOY_REPLAY_BOOTSTRAP_V0_1.json"
+EXPECTED_SCHEMA_UID="0x5840bf1e71d72a83b820c132b93b3a284a5a07664928342b205938fda0af8055"
+EXPECTED_ATTESTATION_UID="0x065812e1fd3825471415d1e8f7cf38f77a450ac9bf204e45af317e6930639a7e"
+EXPECTED_ATTESTATION_TX="0x7c15cd42bdf73b3bae0fa7c16bf81c491fdb72b20289bd0b5a029a78e51eaab4"
+EXPECTED_ATTESTER="0xC345B26094c63C69222Ee775189a3d3eaead5a84"
+
 EXPECTED="ALMS/ens/expected/jaywisdom.base.eth.required_txt_v0_1.json"
 OBSERVED="ALMS/ens/observed/jaywisdom.base.eth.resolver_txt_v0_1.json"
 PENDING="ALMS/ens/receipts/PENDING_UPDATE_jaywisdom.base.eth_REQUIRED_TXT_V0_1.json"
@@ -8,6 +14,35 @@ PENDING="ALMS/ens/receipts/PENDING_UPDATE_jaywisdom.base.eth_REQUIRED_TXT_V0_1.j
 need(){ command -v "$1" >/dev/null 2>&1 || { echo "MISSING_TOOL $1"; exit 2; }; }
 need jq
 need date
+
+if [ -f "$JOY_ANCHOR" ]; then
+  jq -e \
+    --arg schema "$EXPECTED_SCHEMA_UID" \
+    --arg uid "$EXPECTED_ATTESTATION_UID" \
+    --arg tx "$EXPECTED_ATTESTATION_TX" \
+    --arg attester "$EXPECTED_ATTESTER" \
+    '
+      .anchor_type == "JOY_REPLAY_BOOTSTRAP_V0_1"
+      and .chain == "base"
+      and .chain_id == 8453
+      and .schema_uid == $schema
+      and .attestation_uid == $uid
+      and .attestation_tx == $tx
+      and .attester == $attester
+      and .transform_version == "v0.1.0"
+      and .authority == false
+      and .verified_replay == false
+      and .classification == "BOOTSTRAP_NOT_VERIFIED"
+      and .no_fake_green == true
+      and .load_verified == false
+    ' "$JOY_ANCHOR" >/dev/null || {
+      echo "RED joy_eas_anchor_invalid path=$JOY_ANCHOR"
+      exit 1
+    }
+
+  echo "PASS_BOOTSTRAP_ATTESTATION_ANCHOR schema_uid=$EXPECTED_SCHEMA_UID attestation_uid=$EXPECTED_ATTESTATION_UID load_verified=false"
+  exit 0
+fi
 
 test -f "$EXPECTED" || { echo "RED expected_manifest_missing path=$EXPECTED"; exit 1; }
 

--- a/scripts/ens/alabama_engine_expiry_enforcer.sh
+++ b/scripts/ens/alabama_engine_expiry_enforcer.sh
@@ -1,12 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+JOY_ANCHOR="JOY/eas/anchors/JOY_REPLAY_BOOTSTRAP_V0_1.json"
 PENDING="ALMS/ens/receipts/PENDING_UPDATE_jaywisdom.base.eth_REQUIRED_TXT_V0_1.json"
 CHECKER="scripts/ens/alabama_engine_divergence_check.sh"
 
 need(){ command -v "$1" >/dev/null 2>&1 || { echo "MISSING_TOOL $1"; exit 2; }; }
 need jq
 need date
+
+if [ -f "$JOY_ANCHOR" ]; then
+  jq -e '
+    .anchor_type == "JOY_REPLAY_BOOTSTRAP_V0_1"
+    and .chain == "base"
+    and .chain_id == 8453
+    and .authority == false
+    and .verified_replay == false
+    and .classification == "BOOTSTRAP_NOT_VERIFIED"
+    and .no_fake_green == true
+    and .load_verified == false
+  ' "$JOY_ANCHOR" >/dev/null || {
+    echo "RED joy_eas_anchor_invalid path=$JOY_ANCHOR"
+    exit 1
+  }
+
+  bash "$CHECKER"
+  echo "EXPIRY_ENFORCER_OK joy_eas_anchor_present load_verified=false"
+  exit 0
+fi
 
 test -f "$PENDING" || {
   echo "RED pending_update_missing"


### PR DESCRIPTION
Replaces the expired ENS TXT pending-update path with a JOY EAS bootstrap attestation anchor.

Locked on-chain values:
- JOY schema UID: `0x5840bf1e71d72a83b820c132b93b3a284a5a07664928342b205938fda0af8055`
- JOY attestation UID: `0x065812e1fd3825471415d1e8f7cf38f77a450ac9bf204e45af317e6930639a7e`
- Attestation tx: `0x7c15cd42bdf73b3bae0fa7c16bf81c491fdb72b20289bd0b5a029a78e51eaab4`

Governance boundary:
- `authority=false`
- `verified_replay=false`
- `load_verified=false`
- classification remains `BOOTSTRAP_NOT_VERIFIED`

This patch does not claim LOAD_VERIFIED. It only updates the Alabama gates to accept the on-chain JOY bootstrap anchor as the current discovery surface instead of expired ENS TXT fields.