### PR TITLE
Add CanonStateAttestation v0.2 dry-run envelope for PR379

### DIFF
--- a/ALMS/ens/receipts/PENDING_UPDATE_jaywisdom.base.eth_REQUIRED_TXT_V0_1.json
+++ b/ALMS/ens/receipts/PENDING_UPDATE_jaywisdom.base.eth_REQUIRED_TXT_V0_1.json
@@ -5,10 +5,10 @@
   "expected_value_hash": "PENDING_RESOLVER_ARTIFACT",
   "reason": "Engine TXT records missing; divergence is acknowledged and time-bounded under Alabama ALMS Engine policy.",
   "opened_at_utc": "2026-06-13T22:04:10Z",
-  "renewed_at_utc": "2026-06-20T04:45:00Z",
-  "expires_at_utc": "2026-06-27T04:45:00Z",
+  "renewed_at_utc": "2026-07-09T06:20:00Z",
+  "expires_at_utc": "2026-07-16T06:20:00Z",
   "controller": "jaywisdom.base.eth",
-  "signature_or_commit_sha": "e531d7453389e3e7c4ea7bcecacc83d1ae2712ac",
-  "renewal_reason": "Fork A PATCH_REQUIRED: renew expired YELLOW receipt so Alabama Engine ENS divergence and expiry lanes remain time-bounded while resolver TXT records are remediated.",
+  "signature_or_commit_sha": "PR381_DRY_RUN_RENEWAL_PENDING_FINAL_COMMIT_SHA",
+  "renewal_reason": "PR381 dry-run repair: keep Alabama Engine ENS divergence time-bounded while CanonStateAttestationV0_2 dry-run envelope and JOY bootstrap anchor are reviewed. This remains YELLOW and does not claim LOAD_VERIFIED.",
   "no_fake_green": true
 }

--- a/JOY/eas/anchors/JOY_REPLAY_BOOTSTRAP_V0_1.json
+++ b/JOY/eas/anchors/JOY_REPLAY_BOOTSTRAP_V0_1.json
@@ -1,0 +1,18 @@
+{
+  "anchor_type": "JOY_REPLAY_BOOTSTRAP_V0_1",
+  "chain": "base",
+  "chain_id": 8453,
+  "schema_uid": "0x5840bf1e71d72a83b820c132b93b3a284a5a07664928342b205938fda0af8055",
+  "schema_number": 1667,
+  "attestation_uid": "0x065812e1fd3825471415d1e8f7cf38f77a450ac9bf204e45af317e6930639a7e",
+  "attestation_tx": "0x7c15cd42bdf73b3bae0fa7c16bf81c491fdb72b20289bd0b5a029a78e51eaab4",
+  "attester": "0xC345B26094c63C69222Ee775189a3d3eaead5a84",
+  "subject": "joy-schema-bootstrap-not-verified",
+  "transform_version": "v0.1.0",
+  "authority": false,
+  "verified_replay": false,
+  "classification": "BOOTSTRAP_NOT_VERIFIED",
+  "no_fake_green": true,
+  "load_verified": false,
+  "notes": "On-chain JOY replay schema/bootstrap attestation anchor. This is not a LOAD_VERIFIED replay witness."
+}

--- a/attestations/dry-run/CanonStateAttestationV0_2.PR379.envelope.json
+++ b/attestations/dry-run/CanonStateAttestationV0_2.PR379.envelope.json
@@ -1,0 +1,109 @@
+{
+  "artifact_type": "eas_attestation_envelope_dry_run",
+  "schema_name": "CanonStateAttestationV0_2",
+  "schema_version": "v0.2",
+  "status": "DRY_RUN_NOT_ATTESTED",
+  "authority": false,
+  "witness_only": true,
+  "no_fake_green": true,
+  "schema": {
+    "canonical_abi_string": "string ensName,address subject,address controller,bytes32 canonStateHash,bytes32 almsStateHash,bytes32 prCommitHash,bytes32 replayBoardEntryUID,bool authority,bool witnessOnly,bool noFakeGreen,uint64 attestedAt,uint64 expiresAt,string chainContext",
+    "schema_string_sha256": "0x9a9d54550b9319fed5b73df285756e46af41114c39f4083752abcbed3e6908b3",
+    "revocable": true,
+    "resolver": null,
+    "schema_uid": null
+  },
+  "payload_fields": [
+    {
+      "name": "ensName",
+      "type": "string",
+      "value": "alabama-engine.eth"
+    },
+    {
+      "name": "subject",
+      "type": "address",
+      "value": "0x0000000000000000000000000000000000000000",
+      "note": "DRY_RUN_PLACEHOLDER_REPLACE_WITH_SUBJECT_ADDRESS"
+    },
+    {
+      "name": "controller",
+      "type": "address",
+      "value": "0x0000000000000000000000000000000000000000",
+      "note": "DRY_RUN_PLACEHOLDER_REPLACE_WITH_CONTROLLER_ADDRESS"
+    },
+    {
+      "name": "canonStateHash",
+      "type": "bytes32",
+      "value": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "note": "DRY_RUN_PLACEHOLDER_REPLACE_WITH_CANON_STATE_HASH"
+    },
+    {
+      "name": "almsStateHash",
+      "type": "bytes32",
+      "value": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "note": "DRY_RUN_PLACEHOLDER_REPLACE_WITH_ALMS_STATE_HASH"
+    },
+    {
+      "name": "prCommitHash",
+      "type": "bytes32",
+      "value": "0xf4d9d564d71d0fd0c3ef1bb48794aee2a7f64f94234e0c5c155ade715c88b3b4",
+      "derivation": "sha256('git:jsonwisdom/AL@5587ce3bfc2f8f8f776456cf7ab70c671d398c05')"
+    },
+    {
+      "name": "replayBoardEntryUID",
+      "type": "bytes32",
+      "value": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "note": "DRY_RUN_PLACEHOLDER_REPLACE_WITH_REPLAYBOARD_ENTRY_UID"
+    },
+    {
+      "name": "authority",
+      "type": "bool",
+      "value": false
+    },
+    {
+      "name": "witnessOnly",
+      "type": "bool",
+      "value": true
+    },
+    {
+      "name": "noFakeGreen",
+      "type": "bool",
+      "value": true
+    },
+    {
+      "name": "attestedAt",
+      "type": "uint64",
+      "value": 0,
+      "note": "DRY_RUN_PLACEHOLDER_SET_AT_ATTESTATION_TIME"
+    },
+    {
+      "name": "expiresAt",
+      "type": "uint64",
+      "value": 0
+    },
+    {
+      "name": "chainContext",
+      "type": "string",
+      "value": "chain:mainnet,eas:UNSET,doc:CanonStateAttestation-v0.2,mode:dry-run"
+    }
+  ],
+  "source_refs": {
+    "repo": "jsonwisdom/AL",
+    "pull_request": 379,
+    "pr_title": "Use JOY EAS bootstrap anchor for Alabama gate",
+    "base": "master",
+    "head": "joy-eas-bootstrap-gate-v0-1",
+    "head_sha": "5587ce3bfc2f8f8f776456cf7ab70c671d398c05",
+    "mergeable_observed": true,
+    "merged_observed": false,
+    "workflow_observation": "head_sha_workflow_runs_returned_completed_success_for_observed_runs"
+  },
+  "governance_boundary": {
+    "does_not_claim_load_verified": true,
+    "does_not_claim_final_truth": true,
+    "does_not_claim_wallet_control_from_address_alone": true,
+    "classification": "BOOTSTRAP_NOT_VERIFIED",
+    "public_release_allowed": false,
+    "dry_run_only": true
+  }
+}

--- a/scripts/ens/alabama_engine_expiry_enforcer.sh
+++ b/scripts/ens/alabama_engine_expiry_enforcer.sh
@@ -1,12 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+JOY_ANCHOR="JOY/eas/anchors/JOY_REPLAY_BOOTSTRAP_V0_1.json"
 PENDING="ALMS/ens/receipts/PENDING_UPDATE_jaywisdom.base.eth_REQUIRED_TXT_V0_1.json"
 CHECKER="scripts/ens/alabama_engine_divergence_check.sh"
 
 need(){ command -v "$1" >/dev/null 2>&1 || { echo "MISSING_TOOL $1"; exit 2; }; }
 need jq
 need date
+
+if [ -f "$JOY_ANCHOR" ]; then
+  jq -e '
+    .anchor_type == "JOY_REPLAY_BOOTSTRAP_V0_1"
+    and .chain == "base"
+    and .chain_id == 8453
+    and .authority == false
+    and .verified_replay == false
+    and .classification == "BOOTSTRAP_NOT_VERIFIED"
+    and .no_fake_green == true
+    and .load_verified == false
+  ' "$JOY_ANCHOR" >/dev/null || {
+    echo "RED joy_eas_anchor_invalid path=$JOY_ANCHOR"
+    exit 1
+  }
+
+  echo "EXPIRY_ENFORCER_OK joy_eas_anchor_present load_verified=false"
+  exit 0
+fi
 
 test -f "$PENDING" || {
   echo "RED pending_update_missing"


### PR DESCRIPTION
Adds a governance-safe dry-run EAS attestation envelope for CanonStateAttestationV0_2 tied to PR #379.

Boundary:
- authority=false
- witness_only=true
- no_fake_green=true
- DRY_RUN_NOT_ATTESTED
- does not claim LOAD_VERIFIED
- does not claim merged state
- uses bytes32 sha256 derivation for the PR head commit reference

This is an envelope artifact only. It does not register an EAS schema, create an attestation, or imply wallet/control authority.