### PR TITLE
Add ALABAMA_FAMILY_SECURE_CORRIDOR_V0_1

### DIFF
--- a/governance/ALABAMA_FAMILY_SECURE_CORRIDOR_V0_1.md
+++ b/governance/ALABAMA_FAMILY_SECURE_CORRIDOR_V0_1.md
@@ -1,0 +1,167 @@
+# ALABAMA_FAMILY_SECURE_CORRIDOR_V0_1
+
+## Status
+
+```text
+STATUS: CORRIDOR_SPEC_DRAFT
+REPO: jsonwisdom/AL
+MODE: GOVERNED_REVIEW
+TRUTH_STATE: YELLOW_PROTECTED
+AUTHORITY: false
+NO_FAKE_GREEN: true
+PUBLIC_CONTENT_CLAIM: BLOCKED_BY_DEFAULT
+FAMILY_CONSENT_GRANTED: false
+MRS_WISDOM_GATE_REQUIRED: true
+```
+
+## Purpose
+
+The Alabama Family Secure Corridor defines how `jsonwisdom/AL` connects to family-sensitive continuity work without overriding consent, exposing private family details, or promoting receipt evidence into truth authority.
+
+AL provides doctrine, replay discipline, public-source boundaries, and process receipts.
+
+AL does not grant family consent.
+AL does not authorize public render.
+AL does not decide private family meaning.
+AL does not turn anomaly leads, receipts, or repo state into unsupported claims.
+
+## Source Baseline
+
+The AL root mission states:
+
+```text
+Build simple, honest systems that can be read, replayed, and verified.
+```
+
+The root rule states:
+
+```text
+No fake green. No random noise. Start clean.
+```
+
+The receipt invariant states:
+
+```text
+Receipts prove process only. Receipts do not prove truth or grant authority.
+```
+
+The authority rule states:
+
+```text
+authority must always be false
+```
+
+## Corridor Map
+
+```json
+{
+  "corridor_id": "ALABAMA_FAMILY_SECURE_CORRIDOR_V0_1",
+  "repo": "jsonwisdom/AL",
+  "authority": false,
+  "no_fake_green": true,
+  "truth_state": "YELLOW_PROTECTED",
+  "public_content_claim": "BLOCKED_BY_DEFAULT",
+  "nodes": {
+    "AL": {
+      "role": "doctrine_and_receipt_first_replay_lane",
+      "mission": "simple_honest_systems_read_replayed_verified",
+      "allowed": [
+        "define_boundaries",
+        "preserve_process_receipts",
+        "route_public_source_review",
+        "block_unsupported_claims",
+        "teach_no_fake_green"
+      ],
+      "forbidden": [
+        "grant_family_consent",
+        "authorize_public_render",
+        "claim_truth_authority",
+        "publish_unsupported_verdicts",
+        "override_mrs_wisdom_gate"
+      ]
+    },
+    "JOY": {
+      "role": "family_consent_and_protection_lane",
+      "handoff_rule": "JOY consent state outranks AL replay for family-sensitive publication",
+      "mrs_wisdom_gate_required": true
+    },
+    "COMPUTERWISDOM": {
+      "role": "operational_control_plane_and_family_system_index",
+      "handoff_rule": "COMPUTERWISDOM may coordinate machinery but may not create family authority"
+    },
+    "BOSS_BRE": {
+      "role": "public_fiscal_forensics_lane",
+      "handoff_rule": "evidence_trails_and_anomaly_leads_only_until_human_review",
+      "unsupported_verdicts_blocked": true
+    }
+  }
+}
+```
+
+## Boundary Rules
+
+```text
+AL_DOES_NOT_GRANT_FAMILY_CONSENT = ACTIVE
+AL_RECEIPTS_PROVE_PROCESS_ONLY = ACTIVE
+JOY_CONSENT_STATE_OUTRANKS_AL_REPLAY = ACTIVE
+MRS_WISDOM_GATE_REQUIRED_FOR_FAMILY_PUBLICATION = ACTIVE
+BOSS_BRE_PUBLIC_CLAIMS_BLOCKED_BY_DEFAULT = ACTIVE
+NO_FAKE_GREEN = ACTIVE
+AUTHORITY_FALSE = ACTIVE
+```
+
+## Secure Family Handoff
+
+AL may hand off a family-sensitive artifact only when the packet contains:
+
+```yaml
+authority: false
+no_fake_green: true
+private_details_exposed: false
+family_consent_claimed: false
+mrs_wisdom_gate_required: true
+joy_consent_reference: required_or_pending
+public_render_allowed: false
+human_review_required: true
+```
+
+If any field is missing, the packet remains blocked:
+
+```text
+AL_HANDOFF_STATE: BLOCKED_PENDING_REVIEW
+```
+
+## Boss Bre Public Claim Boundary
+
+Boss Bre may surface public evidence trails, source inventories, hashes, anomaly leads, and review statuses.
+
+Boss Bre may not publish unsupported fraud verdicts or family-sensitive claims without governed human review.
+
+```text
+PUBLIC_CONTENT_CLAIM: BLOCKED_BY_DEFAULT
+HUMAN_REVIEW_REQUIRED: TRUE
+NO_FAKE_GREEN: ACTIVE
+```
+
+## Non-Promotion Rules
+
+```text
+RECEIPT_EXISTS != TRUTH_PROVEN
+PROCESS_VERIFIED != FAMILY_CONSENT_GRANTED
+AL_REPLAY_PASS != JOY_CONSENT_PASS
+GITHUB_GREEN != HUMAN_REVIEW_GREEN
+ANOMALY_LEAD != VERDICT
+PUBLIC_SOURCE != PUBLIC_PERMISSION
+```
+
+## Final Ruling
+
+```text
+ALABAMA_FAMILY_SECURE_CORRIDOR_CREATED
+AUTHORITY_FALSE
+NO_FAKE_GREEN_ACTIVE
+FAMILY_CONSENT_NOT_GRANTED
+MRS_WISDOM_GATE_REQUIRED
+JOY_CONSENT_OUTRANKS_AL_REPLAY
+PUBLIC_RENDER_BLOCKED
+```


### PR DESCRIPTION
## Summary

Adds the Alabama Family Secure Corridor as a governed boundary spec for `jsonwisdom/AL`.

## Purpose

Defines how AL connects to family-sensitive continuity work without overriding consent, exposing private family details, or promoting receipt evidence into truth authority.

## Boundary

- `authority: false`
- `no_fake_green: true`
- AL does not grant family consent
- AL does not authorize public render
- JOY consent state outranks AL replay for family-sensitive publication
- Mrs Wisdom gate remains required
- Boss Bre public claims remain blocked by default until human review

## Files added

- `governance/ALABAMA_FAMILY_SECURE_CORRIDOR_V0_1.md`

## Activation posture

This is a corridor specification only. It does not activate public render, create family authority, or grant consent.