### PR TITLE
Add Cleansing Gate manifest boundary integration tests

### DIFF
--- a/.github/workflows/merkle-validator.yml
+++ b/.github/workflows/merkle-validator.yml
@@ -13,9 +13,6 @@ permissions:
 jobs:
   merkle-validator:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: x-files-alien-files-26/privacy/cleansing-gate/src/validator
 
     steps:
       - name: Checkout
@@ -25,10 +22,18 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
-          cache-dependency-path: x-files-alien-files-26/privacy/cleansing-gate/src/validator/go.mod
+          cache-dependency-path: |
+            x-files-alien-files-26/privacy/cleansing-gate/src/validator/go.mod
+            x-files-alien-files-26/privacy/cleansing-gate/tests/integration/boundary/go.mod
 
       - name: Run validator tests
+        working-directory: x-files-alien-files-26/privacy/cleansing-gate/src/validator
         run: go test ./... -v
 
       - name: Build CLI bridge
+        working-directory: x-files-alien-files-26/privacy/cleansing-gate/src/validator
         run: go build ./cmd/merkle-validator
+
+      - name: Run manifest boundary integration tests
+        working-directory: x-files-alien-files-26/privacy/cleansing-gate/tests/integration/boundary
+        run: go test ./... -v

--- a/x-files-alien-files-26/privacy/cleansing-gate/tests/integration/boundary/go.mod
+++ b/x-files-alien-files-26/privacy/cleansing-gate/tests/integration/boundary/go.mod
@@ -1,0 +1,7 @@
+module cleansing-gate/integration-boundary
+
+go 1.22
+
+require cleansing-gate/merkle-validator v0.0.0
+
+replace cleansing-gate/merkle-validator => ../../../src/validator

--- a/x-files-alien-files-26/privacy/cleansing-gate/tests/integration/boundary/manifest_binding_test.go
+++ b/x-files-alien-files-26/privacy/cleansing-gate/tests/integration/boundary/manifest_binding_test.go
@@ -1,0 +1,72 @@
+package boundary
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+
+	validator "cleansing-gate/merkle-validator"
+)
+
+type manifest struct {
+	Version       string   `json:"version"`
+	AssetID       string   `json:"asset_id"`
+	BranchContext string   `json:"branch_context"`
+	Lineage       []string `json:"lineage"`
+	ExportTarget  struct {
+		Mode        string  `json:"mode"`
+		Destination *string `json:"destination"`
+		BranchID    string  `json:"branch_id"`
+	} `json:"export_target"`
+	Merkle validator.MerkleProof `json:"merkle"`
+}
+
+func loadManifest(t *testing.T, path string) manifest {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var m manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	return m
+}
+
+func validateBoundary(m manifest) error {
+	if m.BranchContext == "" || m.ExportTarget.BranchID == "" || m.Merkle.BranchID == "" {
+		return validator.ErrMerkleMismatch
+	}
+	if m.BranchContext != m.ExportTarget.BranchID {
+		return validator.ErrMerkleMismatch
+	}
+	if m.BranchContext != m.Merkle.BranchID {
+		return validator.ErrMerkleMismatch
+	}
+	return validator.ValidateMerkleProof(m.Merkle, m.BranchContext)
+}
+
+func TestManifestMerkleBindingAcceptsConsistentManifest(t *testing.T) {
+	m := loadManifest(t, "valid-binding.json")
+	if err := validateBoundary(m); err != nil {
+		t.Fatalf("expected valid manifest boundary, got %v", err)
+	}
+}
+
+func TestManifestMerkleBindingRejectsExportTargetDivergence(t *testing.T) {
+	m := loadManifest(t, "valid-binding.json")
+	m.ExportTarget.BranchID = "reston/memory-blossom/alternate"
+	if err := validateBoundary(m); !errors.Is(err, validator.ErrMerkleMismatch) {
+		t.Fatalf("expected ErrMerkleMismatch, got %v", err)
+	}
+}
+
+func TestManifestMerkleBindingRejectsMerkleBranchDivergence(t *testing.T) {
+	m := loadManifest(t, "valid-binding.json")
+	m.Merkle.BranchID = "reston/emergent-sovereignty/alternate"
+	if err := validateBoundary(m); !errors.Is(err, validator.ErrMerkleMismatch) {
+		t.Fatalf("expected ErrMerkleMismatch, got %v", err)
+	}
+}

--- a/x-files-alien-files-26/privacy/cleansing-gate/tests/integration/boundary/valid-binding.json
+++ b/x-files-alien-files-26/privacy/cleansing-gate/tests/integration/boundary/valid-binding.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.1",
+  "asset_id": "gray-baby-memory-blossom-001",
+  "branch_context": "reston/memory-blossom/main",
+  "lineage": [
+    "reston",
+    "memory-blossom",
+    "main"
+  ],
+  "export_target": {
+    "mode": "local-only",
+    "destination": null,
+    "branch_id": "reston/memory-blossom/main"
+  },
+  "merkle": {
+    "leaf_hash": "2a18af40425f9232914f2a39bb86d657e6e565840a96d8419ce89f3789da3cc0",
+    "siblings": [
+      {
+        "position": "right",
+        "hash": "48178dbc3645aba3865d00a384a53a58bcedbb3cd840b21d06ebb4d00756888d"
+      }
+    ],
+    "root": "26100e348b15e808ec4a2f54ae3995afc5e8adee297d51298c5d287ebc85ed89",
+    "branch_id": "reston/memory-blossom/main",
+    "depth": 1
+  }
+}


### PR DESCRIPTION
## Summary
Adds an integration boundary test for the Cleansing Gate manifest-to-Merkle binding chain.

## Covered
- `branch_context == export_target.branch_id`
- `branch_context == merkle.branch_id`
- valid Merkle proof acceptance
- export-target branch divergence rejection
- Merkle branch divergence rejection

## Test structure
- dedicated integration-test Go module under `tests/integration/boundary`
- local `replace` directive to the existing validator module
- deterministic `valid-binding.json` fixture
- GitHub Actions workflow extended to execute the boundary module

## Current scope boundary
This PR does not yet implement or claim end-to-end signature verification, nonce/replay enforcement, or file-hash authorization. It closes only the manifest branch-binding-to-Merkle integration gap.

## Governance posture
- fail-closed mismatch semantics preserved
- no root-module pollution
- no test success claimed until GitHub Actions completes
- `AUTHORITY = FALSE`