### PR TITLE
Define fail-closed full Cleansing Gate contract and Merkle schema

### DIFF
--- a/x-files-alien-files-26/privacy/cleansing-gate/schemas/PARENT_EXPORT_APPROVAL_V0_1.schema.json
+++ b/x-files-alien-files-26/privacy/cleansing-gate/schemas/PARENT_EXPORT_APPROVAL_V0_1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ParentExportApproval",
-  "description": "Schema for verifying parent-authorized export manifests. Runtime invariant: export_target.branch_id MUST equal branch_context.",
+  "description": "Schema for verifying parent-authorized export manifests. Runtime invariants: export_target.branch_id MUST equal branch_context and merkle.branch_id MUST equal branch_context.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -19,6 +19,7 @@
     "output_sha256",
     "preview_sha256",
     "export_target",
+    "merkle",
     "normalized_filename",
     "stego_policy",
     "signing_key_id",
@@ -26,109 +27,73 @@
     "cleansing_required"
   ],
   "properties": {
-    "version": {
-      "type": "string",
-      "const": "0.1"
-    },
-    "asset_id": {
-      "type": "string",
-      "minLength": 1
-    },
-    "branch_context": {
-      "type": "string",
-      "minLength": 1
-    },
+    "version": {"type": "string", "const": "0.1"},
+    "asset_id": {"type": "string", "minLength": 1},
+    "branch_context": {"type": "string", "minLength": 1},
     "lineage": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "minLength": 1
-      }
+      "items": {"type": "string", "minLength": 1}
     },
     "parent_signature": {
       "type": "string",
       "pattern": "^[A-Za-z0-9+/]+={0,2}$"
     },
-    "session_id": {
-      "type": "string",
-      "format": "uuid"
-    },
-    "nonce": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{64}$"
-    },
-    "issued_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "expires_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "pipeline_version": {
-      "type": "string",
-      "const": "CLEANSING_GATE_V0_1"
-    },
-    "input_sha256": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{64}$"
-    },
-    "output_sha256": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{64}$"
-    },
-    "preview_sha256": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{64}$"
-    },
+    "session_id": {"type": "string", "format": "uuid"},
+    "nonce": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "issued_at": {"type": "string", "format": "date-time"},
+    "expires_at": {"type": "string", "format": "date-time"},
+    "pipeline_version": {"type": "string", "const": "CLEANSING_GATE_V0_1"},
+    "input_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "output_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "preview_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
     "export_target": {
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "mode": {
-              "const": "local-only"
-            },
-            "destination": {
-              "type": "null"
-            },
-            "branch_id": {
-              "type": "string",
-              "minLength": 1
-            }
+            "mode": {"const": "local-only"},
+            "destination": {"type": "null"},
+            "branch_id": {"type": "string", "minLength": 1}
           },
-          "required": [
-            "mode",
-            "destination",
-            "branch_id"
-          ],
+          "required": ["mode", "destination", "branch_id"],
           "additionalProperties": false
         },
         {
           "type": "object",
           "properties": {
-            "mode": {
-              "const": "explicit-destination"
-            },
-            "destination": {
-              "type": "string",
-              "minLength": 1
-            },
-            "branch_id": {
-              "type": "string",
-              "minLength": 1
-            }
+            "mode": {"const": "explicit-destination"},
+            "destination": {"type": "string", "minLength": 1},
+            "branch_id": {"type": "string", "minLength": 1}
           },
-          "required": [
-            "mode",
-            "destination",
-            "branch_id"
-          ],
+          "required": ["mode", "destination", "branch_id"],
           "additionalProperties": false
         }
       ]
+    },
+    "merkle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["leaf_hash", "siblings", "root", "branch_id", "depth"],
+      "properties": {
+        "leaf_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "siblings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["position", "hash"],
+            "properties": {
+              "position": {"type": "string", "enum": ["left", "right"]},
+              "hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+            }
+          }
+        },
+        "root": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "branch_id": {"type": "string", "minLength": 1},
+        "depth": {"type": "integer", "minimum": 0}
+      }
     },
     "normalized_filename": {
       "type": "string",
@@ -136,21 +101,10 @@
     },
     "stego_policy": {
       "type": "string",
-      "enum": [
-        "REJECT_IF_DETECTED_OR_UNSUPPORTED"
-      ]
+      "enum": ["REJECT_IF_DETECTED_OR_UNSUPPORTED"]
     },
-    "signing_key_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{64}$"
-    },
-    "signature_algorithm": {
-      "type": "string",
-      "const": "Ed25519"
-    },
-    "cleansing_required": {
-      "type": "boolean",
-      "const": true
-    }
+    "signing_key_id": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "signature_algorithm": {"type": "string", "const": "Ed25519"},
+    "cleansing_required": {"type": "boolean", "const": true}
   }
 }

--- a/x-files-alien-files-26/privacy/cleansing-gate/src/validator/full_gate.go
+++ b/x-files-alien-files-26/privacy/cleansing-gate/src/validator/full_gate.go
@@ -1,0 +1,67 @@
+package validator
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"io"
+	"time"
+)
+
+// ErrFullGateNotImplemented is returned until every dependency in the
+// Cleansing Gate decision chain has a concrete fail-closed implementation.
+var ErrFullGateNotImplemented = errors.New("FULL_GATE_NOT_IMPLEMENTED")
+
+// Manifest is the runtime contract consumed by ValidateFullCleansingGate.
+// It intentionally separates expected values from observed inputs supplied
+// through FileSet and NonceStore.
+type Manifest struct {
+	BranchContext string
+	Nonce         string
+	Merkle        MerkleProof
+}
+
+// FileSet supplies the actual bytes whose SHA-256 digests must be recomputed.
+type FileSet struct {
+	Input   io.Reader
+	Output  io.Reader
+	Preview io.Reader
+}
+
+// NonceStore must atomically consume a nonce. Implementations must reject a
+// nonce that has already been consumed in the applicable key/session scope.
+type NonceStore interface {
+	Consume(ctx context.Context, nonce string) error
+}
+
+// ValidateFullCleansingGate defines the complete fail-closed entrypoint.
+//
+// Required execution order:
+//   1. Ed25519 signature and signing-key binding
+//   2. Atomic nonce consumption / replay rejection
+//   3. Branch binding
+//   4. Merkle proof verification
+//   5. Input/output/preview SHA-256 recomputation
+//
+// This contract scaffold never returns nil. Concrete dependency
+// implementations must be introduced and tested before an ALLOW decision is
+// possible.
+func ValidateFullCleansingGate(
+	ctx context.Context,
+	manifest Manifest,
+	publicKey ed25519.PublicKey,
+	files FileSet,
+	nonceStore NonceStore,
+	now time.Time,
+) error {
+	if ctx == nil || len(publicKey) != ed25519.PublicKeySize || nonceStore == nil || now.IsZero() {
+		return ErrFullGateNotImplemented
+	}
+	if manifest.BranchContext == "" || manifest.Nonce == "" {
+		return ErrFullGateNotImplemented
+	}
+	if files.Input == nil || files.Output == nil || files.Preview == nil {
+		return ErrFullGateNotImplemented
+	}
+	return ErrFullGateNotImplemented
+}

--- a/x-files-alien-files-26/privacy/cleansing-gate/src/validator/full_gate.go
+++ b/x-files-alien-files-26/privacy/cleansing-gate/src/validator/full_gate.go
@@ -12,13 +12,36 @@ import (
 // Cleansing Gate decision chain has a concrete fail-closed implementation.
 var ErrFullGateNotImplemented = errors.New("FULL_GATE_NOT_IMPLEMENTED")
 
+// ExportTarget is the runtime export destination binding.
+type ExportTarget struct {
+	Mode        string  `json:"mode"`
+	Destination *string `json:"destination"`
+	BranchID    string  `json:"branch_id"`
+}
+
 // Manifest is the runtime contract consumed by ValidateFullCleansingGate.
-// It intentionally separates expected values from observed inputs supplied
-// through FileSet and NonceStore.
+// ParentSignature is excluded from the canonical signed payload.
 type Manifest struct {
-	BranchContext string
-	Nonce         string
-	Merkle        MerkleProof
+	Version            string       `json:"version"`
+	AssetID            string       `json:"asset_id"`
+	BranchContext      string       `json:"branch_context"`
+	Lineage            []string     `json:"lineage"`
+	ParentSignature    []byte       `json:"parent_signature"`
+	SessionID          string       `json:"session_id"`
+	Nonce              string       `json:"nonce"`
+	IssuedAt           string       `json:"issued_at"`
+	ExpiresAt          string       `json:"expires_at"`
+	PipelineVersion    string       `json:"pipeline_version"`
+	InputSHA256        string       `json:"input_sha256"`
+	OutputSHA256       string       `json:"output_sha256"`
+	PreviewSHA256      string       `json:"preview_sha256"`
+	ExportTarget       ExportTarget `json:"export_target"`
+	Merkle             MerkleProof  `json:"merkle"`
+	NormalizedFilename string       `json:"normalized_filename"`
+	StegoPolicy        string       `json:"stego_policy"`
+	SigningKeyID       string       `json:"signing_key_id"`
+	SignatureAlgorithm string       `json:"signature_algorithm"`
+	CleansingRequired  bool         `json:"cleansing_required"`
 }
 
 // FileSet supplies the actual bytes whose SHA-256 digests must be recomputed.
@@ -35,17 +58,6 @@ type NonceStore interface {
 }
 
 // ValidateFullCleansingGate defines the complete fail-closed entrypoint.
-//
-// Required execution order:
-//   1. Ed25519 signature and signing-key binding
-//   2. Atomic nonce consumption / replay rejection
-//   3. Branch binding
-//   4. Merkle proof verification
-//   5. Input/output/preview SHA-256 recomputation
-//
-// This contract scaffold never returns nil. Concrete dependency
-// implementations must be introduced and tested before an ALLOW decision is
-// possible.
 func ValidateFullCleansingGate(
 	ctx context.Context,
 	manifest Manifest,
@@ -54,14 +66,14 @@ func ValidateFullCleansingGate(
 	nonceStore NonceStore,
 	now time.Time,
 ) error {
-	if ctx == nil || len(publicKey) != ed25519.PublicKeySize || nonceStore == nil || now.IsZero() {
-		return ErrFullGateNotImplemented
-	}
-	if manifest.BranchContext == "" || manifest.Nonce == "" {
+	if ctx == nil || nonceStore == nil || now.IsZero() {
 		return ErrFullGateNotImplemented
 	}
 	if files.Input == nil || files.Output == nil || files.Preview == nil {
 		return ErrFullGateNotImplemented
+	}
+	if err := verifySignature(manifest, publicKey); err != nil {
+		return err
 	}
 	return ErrFullGateNotImplemented
 }

--- a/x-files-alien-files-26/privacy/cleansing-gate/src/validator/go.mod
+++ b/x-files-alien-files-26/privacy/cleansing-gate/src/validator/go.mod
@@ -1,3 +1,5 @@
 module cleansing-gate/merkle-validator
 
 go 1.22
+
+require github.com/cyberphone/json-canonicalization v0.0.0-20241216160745-19d51d7fe467

--- a/x-files-alien-files-26/privacy/cleansing-gate/src/validator/go.mod
+++ b/x-files-alien-files-26/privacy/cleansing-gate/src/validator/go.mod
@@ -2,4 +2,4 @@ module cleansing-gate/merkle-validator
 
 go 1.22
 
-require github.com/cyberphone/json-canonicalization v0.0.0-20241216160745-19d51d7fe467
+require github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467

--- a/x-files-alien-files-26/privacy/cleansing-gate/src/validator/go.sum
+++ b/x-files-alien-files-26/privacy/cleansing-gate/src/validator/go.sum
@@ -1,0 +1,2 @@
+github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
+github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=

--- a/x-files-alien-files-26/privacy/cleansing-gate/src/validator/signature.go
+++ b/x-files-alien-files-26/privacy/cleansing-gate/src/validator/signature.go
@@ -1,0 +1,95 @@
+package validator
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+)
+
+var (
+	ErrInvalidSignature = errors.New("INVALID_SIGNATURE")
+	ErrKeyBinding       = errors.New("KEY_BINDING_MISMATCH")
+	ErrCanonicalPayload = errors.New("CANONICAL_PAYLOAD_INVALID")
+)
+
+// verifySignature validates both the Ed25519 signature and the binding between
+// the supplied public key and manifest.signing_key_id.
+func verifySignature(manifest Manifest, publicKey ed25519.PublicKey) error {
+	if len(publicKey) != ed25519.PublicKeySize {
+		return ErrKeyBinding
+	}
+
+	digest := sha256.Sum256(publicKey)
+	if manifest.SigningKeyID == "" || manifest.SigningKeyID != hex.EncodeToString(digest[:]) {
+		return ErrKeyBinding
+	}
+
+	payload, err := canonicalPayload(manifest)
+	if err != nil {
+		return err
+	}
+	if len(manifest.ParentSignature) != ed25519.SignatureSize || !ed25519.Verify(publicKey, payload, manifest.ParentSignature) {
+		return ErrInvalidSignature
+	}
+	return nil
+}
+
+// canonicalPayload returns RFC 8785 / JCS canonical JSON for the signed
+// manifest payload. parent_signature is deliberately excluded.
+func canonicalPayload(manifest Manifest) ([]byte, error) {
+	payload := struct {
+		Version           string      `json:"version"`
+		AssetID           string      `json:"asset_id"`
+		BranchContext     string      `json:"branch_context"`
+		Lineage           []string    `json:"lineage"`
+		SessionID         string      `json:"session_id"`
+		Nonce             string      `json:"nonce"`
+		IssuedAt          string      `json:"issued_at"`
+		ExpiresAt         string      `json:"expires_at"`
+		PipelineVersion   string      `json:"pipeline_version"`
+		InputSHA256       string      `json:"input_sha256"`
+		OutputSHA256      string      `json:"output_sha256"`
+		PreviewSHA256     string      `json:"preview_sha256"`
+		ExportTarget      ExportTarget `json:"export_target"`
+		Merkle            MerkleProof `json:"merkle"`
+		NormalizedFilename string     `json:"normalized_filename"`
+		StegoPolicy       string      `json:"stego_policy"`
+		SigningKeyID      string      `json:"signing_key_id"`
+		SignatureAlgorithm string     `json:"signature_algorithm"`
+		CleansingRequired bool        `json:"cleansing_required"`
+	}{
+		Version: manifest.Version,
+		AssetID: manifest.AssetID,
+		BranchContext: manifest.BranchContext,
+		Lineage: manifest.Lineage,
+		SessionID: manifest.SessionID,
+		Nonce: manifest.Nonce,
+		IssuedAt: manifest.IssuedAt,
+		ExpiresAt: manifest.ExpiresAt,
+		PipelineVersion: manifest.PipelineVersion,
+		InputSHA256: manifest.InputSHA256,
+		OutputSHA256: manifest.OutputSHA256,
+		PreviewSHA256: manifest.PreviewSHA256,
+		ExportTarget: manifest.ExportTarget,
+		Merkle: manifest.Merkle,
+		NormalizedFilename: manifest.NormalizedFilename,
+		StegoPolicy: manifest.StegoPolicy,
+		SigningKeyID: manifest.SigningKeyID,
+		SignatureAlgorithm: manifest.SignatureAlgorithm,
+		CleansingRequired: manifest.CleansingRequired,
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, ErrCanonicalPayload
+	}
+	canonical, err := jsoncanonicalizer.Transform(raw)
+	if err != nil {
+		return nil, ErrCanonicalPayload
+	}
+	return canonical, nil
+}

--- a/x-files-alien-files-26/privacy/cleansing-gate/src/validator/signature_test.go
+++ b/x-files-alien-files-26/privacy/cleansing-gate/src/validator/signature_test.go
@@ -1,0 +1,90 @@
+package validator
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"testing"
+)
+
+func signedManifest(t *testing.T) (Manifest, ed25519.PublicKey) {
+	t.Helper()
+	seed := sha256.Sum256([]byte("cleansing-gate-signature-test-seed-v0.1"))
+	privateKey := ed25519.NewKeyFromSeed(seed[:])
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	keyID := sha256.Sum256(publicKey)
+
+	m := Manifest{
+		Version: "0.1",
+		AssetID: "gray-baby-memory-blossom-001",
+		BranchContext: "reston/memory-blossom/main",
+		Lineage: []string{"reston", "memory-blossom", "main"},
+		SessionID: "018f4f0c-7f93-7c13-9e42-0f4f44fc7482",
+		Nonce: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		IssuedAt: "2026-07-12T01:40:00Z",
+		ExpiresAt: "2026-07-12T01:45:00Z",
+		PipelineVersion: "CLEANSING_GATE_V0_1",
+		InputSHA256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		OutputSHA256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		PreviewSHA256: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		ExportTarget: ExportTarget{Mode: "local-only", Destination: nil, BranchID: "reston/memory-blossom/main"},
+		Merkle: MerkleProof{
+			LeafHash: "2a18af40425f9232914f2a39bb86d657e6e565840a96d8419ce89f3789da3cc0",
+			Siblings: []MerkleSibling{{Position: "right", Hash: "48178dbc3645aba3865d00a384a53a58bcedbb3cd840b21d06ebb4d00756888d"}},
+			Root: "26100e348b15e808ec4a2f54ae3995afc5e8adee297d51298c5d287ebc85ed89",
+			BranchID: "reston/memory-blossom/main",
+			Depth: 1,
+		},
+		NormalizedFilename: "20260712T014000Z_bbbbbbbbbbbbbbbb.png",
+		StegoPolicy: "REJECT_IF_DETECTED_OR_UNSUPPORTED",
+		SigningKeyID: hex.EncodeToString(keyID[:]),
+		SignatureAlgorithm: "Ed25519",
+		CleansingRequired: true,
+	}
+	payload, err := canonicalPayload(m)
+	if err != nil {
+		t.Fatalf("canonical payload: %v", err)
+	}
+	m.ParentSignature = ed25519.Sign(privateKey, payload)
+	return m, publicKey
+}
+
+func TestVerifySignatureAcceptsValidSignatureAndKeyBinding(t *testing.T) {
+	m, publicKey := signedManifest(t)
+	if err := verifySignature(m, publicKey); err != nil {
+		t.Fatalf("expected signature acceptance, got %v", err)
+	}
+}
+
+func TestVerifySignatureRejectsMutatedPayload(t *testing.T) {
+	m, publicKey := signedManifest(t)
+	m.AssetID = "mutated-asset"
+	if err := verifySignature(m, publicKey); !errors.Is(err, ErrInvalidSignature) {
+		t.Fatalf("expected ErrInvalidSignature, got %v", err)
+	}
+}
+
+func TestVerifySignatureRejectsWrongKeyBinding(t *testing.T) {
+	m, publicKey := signedManifest(t)
+	m.SigningKeyID = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	if err := verifySignature(m, publicKey); !errors.Is(err, ErrKeyBinding) {
+		t.Fatalf("expected ErrKeyBinding, got %v", err)
+	}
+}
+
+func TestCanonicalPayloadExcludesParentSignature(t *testing.T) {
+	m, _ := signedManifest(t)
+	first, err := canonicalPayload(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.ParentSignature = make([]byte, ed25519.SignatureSize)
+	second, err := canonicalPayload(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("parent_signature affected canonical payload")
+	}
+}


### PR DESCRIPTION
## Summary
Defines the contract surface for a future end-to-end Cleansing Gate decision and extends the approval schema with the required Merkle proof object.

## Included
- `ValidateFullCleansingGate(ctx, manifest, publicKey, files, nonceStore, now)` contract
- `FileSet` observed-byte inputs
- `NonceStore` atomic consume interface
- explicit fail-closed `FULL_GATE_NOT_IMPLEMENTED` sentinel
- schema-required `merkle` object with ordered siblings, root, branch ID, and depth
- runtime invariant documentation for `merkle.branch_id == branch_context`

## Important non-claim
The full gate does not yet allow export. The current contract always fails closed until concrete implementations exist for:
1. Ed25519 verification and signing-key binding
2. nonce replay enforcement
3. branch binding orchestration
4. Merkle verification orchestration
5. file-hash recomputation

No full-gate success is claimed. `AUTHORITY = FALSE`.