### PR TITLE
Add Epstein law knobs v0.1

### DIFF
--- a/_truth/federal_epstein_mission/law_knobs/LAW_KNOB_SET_001.json
+++ b/_truth/federal_epstein_mission/law_knobs/LAW_KNOB_SET_001.json
@@ -1,0 +1,332 @@
+{
+  "artifact": "EPSTEIN_LAW_KNOB_SET",
+  "artifact_id": "LAW_KNOB_SET_001",
+  "version": "0.1",
+  "authority": false,
+  "legal_conclusion": false,
+  "purpose": "Deterministic, evidence-bounded comparison surface between Public Law 119-38 requirements and observed justice.gov release artifacts.",
+  "scope": {
+    "law": "Public Law 119-38, Epstein Files Transparency Act",
+    "target_surface": "justice.gov/epstein and DOJ publications concerning the Epstein Files Transparency Act",
+    "knob_count": 32,
+    "observation_slot_target": 32,
+    "matrix_target": "32x32 logical comparison matrix (1024 cells)",
+    "qubo_status": "NOT_COMPILED",
+    "compliance_status": "NOT_EVALUATED"
+  },
+  "state_values": [
+    "PASS",
+    "FAIL",
+    "UNRESOLVED",
+    "NOT_APPLICABLE"
+  ],
+  "hard_boundaries": [
+    "LAW_TEXT != COMPLIANCE_FINDING",
+    "DOJ_PUBLICATION != PROOF_OF_COMPLETE_COMPLIANCE",
+    "MISSING_PUBLIC_ARTIFACT != PROOF_OF_CONCEALMENT",
+    "POLICY_CHANGE != CONTRADICTION_WITHOUT_SHARED_PREDICATE_AND_TIME",
+    "PARODY != EVIDENCE",
+    "MODEL_OUTPUT != LEGAL_AUTHORITY",
+    "AUTHORITY_CREATED = FALSE"
+  ],
+  "official_sources": [
+    {
+      "id": "LAW_PL119_38",
+      "url": "https://www.congress.gov/119/plaws/publ38/PLAW-119publ38.htm",
+      "role": "governing_statute",
+      "byte_seal": "NOT_CAPTURED_THIS_RUN"
+    },
+    {
+      "id": "DOJ_RELEASE_2026_01_30",
+      "url": "https://www.justice.gov/opa/pr/department-justice-publishes-35-million-responsive-pages-compliance-epstein-files",
+      "role": "observed_DOJ_release_statement",
+      "byte_seal": "NOT_CAPTURED_THIS_RUN"
+    },
+    {
+      "id": "DOJ_EPSTEIN_LIBRARY",
+      "url": "https://www.justice.gov/epstein",
+      "role": "observed_DOJ_public_library",
+      "byte_seal": "NOT_CAPTURED_THIS_RUN"
+    },
+    {
+      "id": "DOJ_FBI_MEMO_2025_07",
+      "url": "https://www.justice.gov/opa/media/1407001/dl",
+      "role": "pre_statute_policy_baseline",
+      "byte_seal": "NOT_CAPTURED_THIS_RUN"
+    }
+  ],
+  "knobs": [
+    {
+      "id": "K01",
+      "name": "ENACTMENT",
+      "requirement": "Public Law 119-38 is the governing statute for this knob set.",
+      "authority_ref": "PL119-38: enactment",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K02",
+      "name": "RELEASE_DEADLINE_30_DAYS",
+      "requirement": "Release required not later than 30 days after enactment.",
+      "authority_ref": "Sec.2(a)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K03",
+      "name": "SEARCHABLE_FORMAT",
+      "requirement": "Covered release must be publicly available in searchable format.",
+      "authority_ref": "Sec.2(a)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K04",
+      "name": "DOWNLOADABLE_FORMAT",
+      "requirement": "Covered release must be publicly available in downloadable format.",
+      "authority_ref": "Sec.2(a)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K05",
+      "name": "ALL_UNCLASSIFIED_COVERED_RECORDS",
+      "requirement": "Scope covers all unclassified covered records in DOJ possession, subject to permitted withholdings.",
+      "authority_ref": "Sec.2(a),2(c)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K06",
+      "name": "FBI_INCLUDED",
+      "requirement": "FBI records are expressly within covered DOJ possession.",
+      "authority_ref": "Sec.2(a)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K07",
+      "name": "USAO_INCLUDED",
+      "requirement": "United States Attorneys' Offices are expressly within covered DOJ possession.",
+      "authority_ref": "Sec.2(a)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K08",
+      "name": "EPSTEIN_INVESTIGATION_PROSECUTION_CUSTODY",
+      "requirement": "Epstein investigations, prosecutions, and custodial matters are covered.",
+      "authority_ref": "Sec.2(a)(1)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K09",
+      "name": "MAXWELL_MATERIALS",
+      "requirement": "Ghislaine Maxwell materials are covered.",
+      "authority_ref": "Sec.2(a)(2)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K10",
+      "name": "FLIGHT_TRAVEL_RECORDS",
+      "requirement": "Flight logs and travel records are covered.",
+      "authority_ref": "Sec.2(a)(3)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K11",
+      "name": "NAMED_REFERENCED_INDIVIDUALS",
+      "requirement": "Individuals named or referenced in specified Epstein-related contexts are covered.",
+      "authority_ref": "Sec.2(a)(4)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K12",
+      "name": "RELATED_ENTITIES",
+      "requirement": "Specified corporate, nonprofit, academic, or governmental entities are covered.",
+      "authority_ref": "Sec.2(a)(5)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K13",
+      "name": "DEALS_AND_SETTLEMENTS",
+      "requirement": "Specified immunity, non-prosecution, plea, and sealed-settlement materials are covered.",
+      "authority_ref": "Sec.2(a)(6)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K14",
+      "name": "INTERNAL_DOJ_CHARGING_COMMUNICATIONS",
+      "requirement": "Internal DOJ communications about charging/investigative decisions are covered.",
+      "authority_ref": "Sec.2(a)(7)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K15",
+      "name": "DESTRUCTION_ALTERATION_CONCEALMENT_METADATA",
+      "requirement": "Specified records about destruction, deletion, alteration, misplacement, or concealment are covered.",
+      "authority_ref": "Sec.2(a)(8)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K16",
+      "name": "DETENTION_DEATH_RECORDS",
+      "requirement": "Specified detention and death records are covered.",
+      "authority_ref": "Sec.2(a)(9)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K17",
+      "name": "NO_EMBARRASSMENT_WITHHOLDING",
+      "requirement": "Embarrassment is prohibited as a withholding/delay/redaction basis.",
+      "authority_ref": "Sec.2(b)(1)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K18",
+      "name": "NO_REPUTATIONAL_HARM_WITHHOLDING",
+      "requirement": "Reputational harm is prohibited as a withholding/delay/redaction basis.",
+      "authority_ref": "Sec.2(b)(1)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K19",
+      "name": "NO_POLITICAL_SENSITIVITY_WITHHOLDING",
+      "requirement": "Political sensitivity is prohibited as a withholding/delay/redaction basis.",
+      "authority_ref": "Sec.2(b)(1)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K20",
+      "name": "VICTIM_PRIVACY_WITHHOLDING",
+      "requirement": "Segregable victim PII/private-file material may be withheld or redacted under the statute.",
+      "authority_ref": "Sec.2(c)(1)(A)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K21",
+      "name": "CSAM_WITHHOLDING",
+      "requirement": "CSAM may be withheld or redacted.",
+      "authority_ref": "Sec.2(c)(1)(B)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K22",
+      "name": "ACTIVE_INVESTIGATION_WITHHOLDING",
+      "requirement": "Active-investigation/prosecution withholding must be narrowly tailored and temporary.",
+      "authority_ref": "Sec.2(c)(1)(C)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K23",
+      "name": "DEATH_ABUSE_INJURY_IMAGES_WITHHOLDING",
+      "requirement": "Images of death, physical abuse, or injury may be withheld or redacted.",
+      "authority_ref": "Sec.2(c)(1)(D)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K24",
+      "name": "CLASSIFIED_INFORMATION_WITHHOLDING",
+      "requirement": "Properly classified national-defense/foreign-policy information may be withheld or redacted.",
+      "authority_ref": "Sec.2(c)(1)(E)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K25",
+      "name": "REDACTION_JUSTIFICATION_PUBLICATION",
+      "requirement": "Redactions require written justification published in the Federal Register and submitted to Congress.",
+      "authority_ref": "Sec.2(c)(2)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K26",
+      "name": "MAXIMUM_DECLASSIFICATION",
+      "requirement": "Covered classified information must be declassified to the maximum extent possible.",
+      "authority_ref": "Sec.2(c)(3)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K27",
+      "name": "UNCLASSIFIED_SUMMARY_IF_NOT_DECLASSIFIED",
+      "requirement": "If covered classified information cannot be released, an unclassified summary is required.",
+      "authority_ref": "Sec.2(c)(3)(A)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K28",
+      "name": "POST_JULY_1_CLASSIFICATION_DISCLOSURE",
+      "requirement": "Post-July 1, 2025 classification decisions require Federal Register publication and congressional submission with specified metadata.",
+      "authority_ref": "Sec.2(c)(4)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K29",
+      "name": "REPORT_TO_CONGRESS_15_DAYS",
+      "requirement": "Within 15 days of completion of the required release, the Attorney General must submit the Section 3 report.",
+      "authority_ref": "Sec.3",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K30",
+      "name": "REPORT_RELEASED_WITHHELD_CATEGORIES",
+      "requirement": "The Section 3 report must list categories of records released and withheld.",
+      "authority_ref": "Sec.3(1)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K31",
+      "name": "REPORT_REDACTION_SUMMARY_LEGAL_BASIS",
+      "requirement": "The Section 3 report must summarize redactions including legal basis.",
+      "authority_ref": "Sec.3(2)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    },
+    {
+      "id": "K32",
+      "name": "REPORT_OFFICIALS_PEPS",
+      "requirement": "The Section 3 report must list government officials and politically exposed persons named or referenced in released materials.",
+      "authority_ref": "Sec.3(3)",
+      "evaluation": "UNRESOLVED",
+      "evidence_refs": []
+    }
+  ],
+  "evaluation_rules": {
+    "pass": "Requires evidence sufficient to show the specific statutory requirement was met for the evaluated observation scope.",
+    "fail": "Requires evidence sufficient to show the specific statutory requirement was not met for the evaluated observation scope.",
+    "unresolved": "Default. Evidence is incomplete, ambiguous, not yet bound, or not yet evaluated.",
+    "not_applicable": "Requirement does not apply to the evaluated observation."
+  },
+  "qubo_bridge": {
+    "logical_law_variables": 32,
+    "logical_observation_slots": 32,
+    "logical_cells": 1024,
+    "cell_semantics": "law_knob_i x observation_j",
+    "physical_qubit_count": "UNKNOWN_UNTIL_EMBEDDING",
+    "energy_is_confidence": false
+  },
+  "write_policy": "APPEND_ONLY_SIDE_CAR",
+  "created_for": "jsonwisdom/AL _truth/federal_epstein_mission/law_knobs/"
+}

--- a/_truth/federal_epstein_mission/law_knobs/LAW_KNOB_SET_001.receipt.json
+++ b/_truth/federal_epstein_mission/law_knobs/LAW_KNOB_SET_001.receipt.json
@@ -1,0 +1,23 @@
+{
+  "receipt": "LAW_KNOB_SET_001_RECEIPT",
+  "version": "0.1",
+  "authority": false,
+  "artifact_path": "_truth/federal_epstein_mission/law_knobs/LAW_KNOB_SET_001.json",
+  "artifact_sha256": "db23c0ab7fd9a04e3be32f4a616427f441ebf552ac62066ede4178cc77720b40",
+  "artifact_blob_sha": "1edf63df8341182fc84d618dc15fd4d259a0a8d3",
+  "artifact_commit_sha": "37e0004edabff9eeee0aeed142f6c575c50f4e03",
+  "branch": "epstein-law-knobs-v0-1",
+  "knob_count": 32,
+  "matrix_target": "32x32 / 1024 logical comparison cells",
+  "evaluation_state": "NOT_RUN",
+  "compliance_finding": "NONE",
+  "qubo_state": "NOT_COMPILED",
+  "physical_qubit_count": "UNKNOWN_UNTIL_EMBEDDING",
+  "source_byte_seals": "NOT_CAPTURED_THIS_RUN",
+  "hard_boundaries": [
+    "RECEIPT != COMPLIANCE_FINDING",
+    "MODEL_OUTPUT != LEGAL_AUTHORITY",
+    "MISSING_PUBLIC_ARTIFACT != PROOF_OF_CONCEALMENT",
+    "AUTHORITY_CREATED = FALSE"
+  ]
+}

--- a/_truth/federal_epstein_mission/law_knobs/OBSERVATION_SLOT_REGISTRY_001.json
+++ b/_truth/federal_epstein_mission/law_knobs/OBSERVATION_SLOT_REGISTRY_001.json
@@ -1,0 +1,361 @@
+{
+  "artifact": "EPSTEIN_JUSTICE_GOV_OBSERVATION_SLOT_REGISTRY",
+  "artifact_id": "OBSERVATION_SLOT_REGISTRY_001",
+  "version": "0.1",
+  "authority": false,
+  "legal_conclusion": false,
+  "target": "justice.gov public Epstein/EFTA surfaces",
+  "slot_count": 32,
+  "bound_slots": 4,
+  "unbound_slots": 28,
+  "matrix_partner": "LAW_KNOB_SET_001",
+  "matrix_target": "32 law knobs x 32 observation slots = 1024 logical comparison cells",
+  "evaluation_state": "NOT_RUN",
+  "hard_boundaries": [
+    "PUBLIC_WEB_OBSERVATION != BYTE_SEALED_SOURCE",
+    "DOJ_SELF_DESCRIPTION != INDEPENDENT_COMPLIANCE_PROOF",
+    "MISSING_SLOT != MISSING_RECORD",
+    "UNBOUND != FAIL",
+    "AUTHORITY_CREATED = FALSE"
+  ],
+  "slots": [
+    {
+      "id": "O01",
+      "name": "DOJ_EPSTEIN_LIBRARY_ROOT",
+      "url": "https://www.justice.gov/epstein",
+      "observed_claims": [
+        "DOJ operates an Epstein Library for materials responsive under the Epstein Files Transparency Act.",
+        "The page states it will be updated if additional documents are identified for release.",
+        "The page displays a full-library search interface and notes technical limitations in searchability.",
+        "The page displayed Last Updated: July 17, 2026 when checked in this build."
+      ],
+      "slot": 1,
+      "binding_state": "BOUND_PUBLIC_SOURCE",
+      "byte_seal": "NOT_CAPTURED_THIS_RUN",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O02",
+      "name": "DOJ_RELEASE_2026_01_30",
+      "url": "https://www.justice.gov/opa/pr/department-justice-publishes-35-million-responsive-pages-compliance-epstein-files",
+      "observed_claims": [
+        "DOJ announced publication of over 3 million additional pages responsive to the Act.",
+        "DOJ described the production as nearly 3.5 million responsive pages total.",
+        "DOJ listed categories of duplicate, privileged, statutory-exception, and unrelated material in its release statement.",
+        "DOJ stated more than 500 attorneys and reviewers contributed to the review."
+      ],
+      "slot": 2,
+      "binding_state": "BOUND_PUBLIC_SOURCE",
+      "byte_seal": "NOT_CAPTURED_THIS_RUN",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O03",
+      "name": "DOJ_FBI_MEMO_2025_07",
+      "url": "https://www.justice.gov/opa/media/1407001/dl",
+      "observed_claims": [
+        "Pre-statute DOJ/FBI memo stated no incriminating client list was found.",
+        "Pre-statute DOJ/FBI memo stated no credible evidence was found of a blackmail scheme involving prominent individuals.",
+        "Pre-statute DOJ/FBI memo stated no further disclosure would be appropriate or warranted.",
+        "This observation is a pre-Public-Law-119-38 policy baseline and is not itself a compliance finding under the later statute."
+      ],
+      "slot": 3,
+      "binding_state": "BOUND_PUBLIC_SOURCE",
+      "byte_seal": "NOT_CAPTURED_THIS_RUN",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O04",
+      "name": "DOJ_DISCLOSURES_DIRECTORY",
+      "url": "https://www.justice.gov/epstein/doj-disclosures",
+      "observed_claims": [
+        "DOJ maintains a disclosures directory under the Epstein Library.",
+        "The directory presents DOJ disclosures and applies victim-identifying redactions."
+      ],
+      "slot": 4,
+      "binding_state": "BOUND_PUBLIC_SOURCE",
+      "byte_seal": "NOT_CAPTURED_THIS_RUN",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O05",
+      "slot": 5,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O06",
+      "slot": 6,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O07",
+      "slot": 7,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O08",
+      "slot": 8,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O09",
+      "slot": 9,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O10",
+      "slot": 10,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O11",
+      "slot": 11,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O12",
+      "slot": 12,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O13",
+      "slot": 13,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O14",
+      "slot": 14,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O15",
+      "slot": 15,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O16",
+      "slot": 16,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O17",
+      "slot": 17,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O18",
+      "slot": 18,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O19",
+      "slot": 19,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O20",
+      "slot": 20,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O21",
+      "slot": 21,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O22",
+      "slot": 22,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O23",
+      "slot": 23,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O24",
+      "slot": 24,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O25",
+      "slot": 25,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O26",
+      "slot": 26,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O27",
+      "slot": 27,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O28",
+      "slot": 28,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O29",
+      "slot": 29,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O30",
+      "slot": 30,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O31",
+      "slot": 31,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    },
+    {
+      "id": "O32",
+      "slot": 32,
+      "name": "UNSET",
+      "url": null,
+      "observed_claims": [],
+      "binding_state": "UNSET",
+      "byte_seal": "NOT_APPLICABLE",
+      "evaluation_state": "NOT_CROSSED_AGAINST_KNOBS"
+    }
+  ]
+}

--- a/_truth/federal_epstein_mission/law_knobs/OBSERVATION_SLOT_REGISTRY_001.receipt.json
+++ b/_truth/federal_epstein_mission/law_knobs/OBSERVATION_SLOT_REGISTRY_001.receipt.json
@@ -1,0 +1,21 @@
+{
+  "receipt": "OBSERVATION_SLOT_REGISTRY_001_RECEIPT",
+  "version": "0.1",
+  "authority": false,
+  "artifact_path": "_truth/federal_epstein_mission/law_knobs/OBSERVATION_SLOT_REGISTRY_001.json",
+  "artifact_sha256": "9acc28d18d5b6f9d7f6c6828c6e1d7a55ca466919865b0dddd5f01de4563a2cd",
+  "artifact_blob_sha": "978ee6ecbd8d3859ff03e43e986c35b895e8e9ea",
+  "artifact_commit_sha": "ccff4098a0e2a95f3c90ae0dd6437e2d1d703cab",
+  "branch": "epstein-law-knobs-v0-1",
+  "slot_count": 32,
+  "bound_slots": 4,
+  "unbound_slots": 28,
+  "evaluation_state": "NOT_RUN",
+  "source_byte_seals": "NOT_CAPTURED_THIS_RUN",
+  "hard_boundaries": [
+    "PUBLIC_WEB_OBSERVATION != BYTE_SEALED_SOURCE",
+    "DOJ_SELF_DESCRIPTION != INDEPENDENT_COMPLIANCE_PROOF",
+    "UNBOUND != FAIL",
+    "AUTHORITY_CREATED = FALSE"
+  ]
+}

--- a/_truth/federal_epstein_mission/law_knobs/README.md
+++ b/_truth/federal_epstein_mission/law_knobs/README.md
@@ -1,0 +1,61 @@
+# Epstein Law Knobs v0.1
+
+**Authority:** false  
+**Legal conclusion:** none  
+**Write model:** append-only sidecar  
+**Evaluation state:** NOT_RUN
+
+## Purpose
+
+This directory defines a deterministic comparison surface between Public Law 119-38 (Epstein Files Transparency Act) and observed public justice.gov Epstein/EFTA surfaces.
+
+The model is intentionally fail-closed:
+
+```text
+LAW TEXT != COMPLIANCE FINDING
+DOJ PUBLICATION != PROOF OF COMPLETE COMPLIANCE
+MISSING PUBLIC ARTIFACT != PROOF OF CONCEALMENT
+MODEL OUTPUT != LEGAL AUTHORITY
+PARODY != EVIDENCE
+```
+
+## Physics
+
+Treat source evidence as conserved input. Downstream normalization, scoring, QUBO compilation, replay, or parody may not manufacture evidentiary support.
+
+```text
+SUPPORTED_OUTPUT <= VERIFIED_INPUT
+```
+
+## Math
+
+- 32 statutory law knobs: `LAW_KNOB_SET_001.json`
+- 32 justice.gov observation slots: `OBSERVATION_SLOT_REGISTRY_001.json`
+- 32 x 32 = 1024 logical comparison cells
+- physical D-Wave qubit count: UNKNOWN until embedding
+- QUBO energy: not a confidence score
+
+All law knobs begin `UNRESOLVED`. Four observation slots are initially bound to public official URLs; 28 remain `UNSET`. No PASS/FAIL compliance evaluation has been run.
+
+## Current official anchors
+
+- Public Law 119-38: https://www.congress.gov/119/plaws/publ38/PLAW-119publ38.htm
+- DOJ Epstein Library: https://www.justice.gov/epstein
+- DOJ Jan. 30, 2026 release statement: https://www.justice.gov/opa/pr/department-justice-publishes-35-million-responsive-pages-compliance-epstein-files
+- DOJ/FBI July 2025 memo: https://www.justice.gov/opa/media/1407001/dl
+
+These URLs are referenced as official public sources. Their exact bytes were **not** captured or sealed in this build.
+
+## Next lawful transition
+
+1. Bind additional justice.gov / Federal Register / congressional report observations into unused O05-O32 slots.
+2. Capture and hash exact source bytes where feasible.
+3. Cross each observation against only the law knobs it can actually support.
+4. Emit `PASS`, `FAIL`, `UNRESOLVED`, or `NOT_APPLICABLE` with evidence refs.
+5. Only after the classical comparison matrix is reproducible may a QUBO projection be compiled.
+
+## JOY narrator lane 😂
+
+> Your Honor, the knobs are installed. Turning one does not create a statute, and turning all thirty-two at once does not summon a compliance finding from the quantum realm.
+
+The joke is disposable. The receipts are not.


### PR DESCRIPTION
## Purpose

Adds an append-only, authority-false law-to-DOJ comparison sidecar under `_truth/federal_epstein_mission/law_knobs/`.

## Build

- `LAW_KNOB_SET_001.json`: 32 statutory knobs derived from Public Law 119-38.
- `LAW_KNOB_SET_001.receipt.json`: binds artifact SHA-256, Git blob SHA, and commit SHA.
- `OBSERVATION_SLOT_REGISTRY_001.json`: 32 justice.gov observation slots; 4 bound to official public sources and 28 intentionally UNSET.
- `OBSERVATION_SLOT_REGISTRY_001.receipt.json`: binds the observation registry.
- `README.md`: physics → math → parody → files build order and fail-closed boundaries.

## Mathematical posture

32 law knobs × 32 observation slots = 1024 logical comparison cells.

This PR does **not** compile a QUBO, claim 1024 physical qubits, treat energy as confidence, or run a compliance evaluation.

## Hard boundaries

- LAW TEXT != COMPLIANCE FINDING
- DOJ PUBLICATION != PROOF OF COMPLETE COMPLIANCE
- MISSING PUBLIC ARTIFACT != PROOF OF CONCEALMENT
- POLICY CHANGE != CONTRADICTION WITHOUT SHARED PREDICATE AND TIME
- PARODY != EVIDENCE
- MODEL OUTPUT != LEGAL AUTHORITY
- AUTHORITY_CREATED = FALSE

## Source posture

Official public URLs are referenced, but their exact bytes are not sealed in this build. All 32 law knobs begin UNRESOLVED.
