### PR TITLE
Lock ReplayIngressSpec_V1 membrane

### DIFF
--- a/.github/workflows/replayingress-ci.yml
+++ b/.github/workflows/replayingress-ci.yml
@@ -1,6 +1,14 @@
 name: ReplayIngress CI Witness
 
 on:
+  push:
+    branches:
+      - "replayingress/v1-lock"
+    paths:
+      - "ReplayIngress/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/replayingress-ci.yml"
   pull_request:
     branches: [master]
     paths:

--- a/.github/workflows/replayingress-ci.yml
+++ b/.github/workflows/replayingress-ci.yml
@@ -1,0 +1,53 @@
+name: ReplayIngress CI Witness
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "ReplayIngress/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/replayingress-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  replayingress-vitest:
+    name: ReplayIngress Vitest Witness
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ReplayIngress Vitest
+        run: npm run test:replayingress -- --reporter=json --outputFile=replayingress-test-summary.json
+
+      - name: Emit test summary to runner log
+        if: always()
+        run: |
+          if [ -f replayingress-test-summary.json ]; then
+            cat replayingress-test-summary.json
+          else
+            echo '{"summary":"NOT_PRODUCED"}'
+          fi
+
+      - name: Upload ReplayIngress test summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: replayingress-test-summary
+          path: replayingress-test-summary.json
+          if-no-files-found: warn
+          retention-days: 90

--- a/ReplayIngress/ReplayIngressSpec_V1.json
+++ b/ReplayIngress/ReplayIngressSpec_V1.json
@@ -1,0 +1,236 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "JSONWisdom/AL/ReplayIngress/ReplayIngressSpec_V1.json",
+  "title": "ReplayIngressSpec_V1",
+  "type": "object",
+  "required": [
+    "replay_result",
+    "receipt_id",
+    "parent_receipt_ids",
+    "replay_hash",
+    "procedure_id",
+    "timestamp",
+    "authority_created",
+    "acceptance_created",
+    "correctness_proved"
+  ],
+  "properties": {
+    "replay_result": {
+      "type": "string",
+      "enum": [
+        "REPLAY_MATCH",
+        "REPLAY_MISMATCH",
+        "REPLAY_DRIFT",
+        "REPLAY_UNREPLAYABLE"
+      ]
+    },
+    "receipt_id": {
+      "$ref": "#/definitions/safe_string"
+    },
+    "parent_receipt_ids": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/safe_string"
+      }
+    },
+    "replay_hash": {
+      "$ref": "#/definitions/safe_string"
+    },
+    "procedure_id": {
+      "$ref": "#/definitions/safe_string"
+    },
+    "timestamp": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/safe_string"
+        },
+        {
+          "type": "string",
+          "format": "date-time"
+        }
+      ]
+    },
+    "authority_created": {
+      "type": "boolean",
+      "const": false
+    },
+    "acceptance_created": {
+      "type": "boolean",
+      "const": false
+    },
+    "correctness_proved": {
+      "type": "boolean",
+      "const": false
+    },
+    "diff_summary": {
+      "type": "object",
+      "propertyNames": {
+        "not": {
+          "enum": [
+            "MATCH",
+            "DELTA",
+            "HOLD",
+            "MISMATCH",
+            "DRIFT",
+            "UNREPLAYABLE",
+            "al_match",
+            "al_delta",
+            "al_hold",
+            "authorized",
+            "accepted",
+            "correct",
+            "truth",
+            "verified",
+            "valid",
+            "actor",
+            "identity",
+            "signer",
+            "wallet",
+            "settled",
+            "final",
+            "approved"
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/safe_diff_value"
+      }
+    },
+    "unreplayable_reason": {
+      "$ref": "#/definitions/safe_string"
+    }
+  },
+  "propertyNames": {
+    "not": {
+      "enum": [
+        "MATCH",
+        "DELTA",
+        "HOLD",
+        "MISMATCH",
+        "DRIFT",
+        "UNREPLAYABLE",
+        "al_match",
+        "al_delta",
+        "al_hold",
+        "authorized",
+        "accepted",
+        "correct",
+        "truth",
+        "verified",
+        "valid",
+        "actor",
+        "identity",
+        "signer",
+        "wallet",
+        "settled",
+        "final",
+        "approved"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "replay_result": {
+            "enum": [
+              "REPLAY_MISMATCH",
+              "REPLAY_DRIFT"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "diff_summary"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "replay_result": {
+            "const": "REPLAY_UNREPLAYABLE"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "unreplayable_reason"
+        ]
+      }
+    }
+  ],
+  "definitions": {
+    "safe_string": {
+      "type": "string",
+      "not": {
+        "enum": [
+          "MATCH",
+          "DELTA",
+          "HOLD",
+          "MISMATCH",
+          "DRIFT",
+          "UNREPLAYABLE"
+        ]
+      }
+    },
+    "safe_diff_value": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/definitions/safe_string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/safe_diff_value"
+          }
+        },
+        {
+          "type": "object",
+          "propertyNames": {
+            "not": {
+              "enum": [
+                "MATCH",
+                "DELTA",
+                "HOLD",
+                "MISMATCH",
+                "DRIFT",
+                "UNREPLAYABLE",
+                "al_match",
+                "al_delta",
+                "al_hold",
+                "authorized",
+                "accepted",
+                "correct",
+                "truth",
+                "verified",
+                "valid",
+                "actor",
+                "identity",
+                "signer",
+                "wallet",
+                "settled",
+                "final",
+                "approved"
+              ]
+            }
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/safe_diff_value"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/ReplayIngress/ReplayIngressTestMatrix_V1.md
+++ b/ReplayIngress/ReplayIngressTestMatrix_V1.md
@@ -1,0 +1,41 @@
+# ReplayIngress Test Matrix V1
+
+Status: **LOCK CANDIDATE**  
+Namespace: `JSONWisdom/AL/ReplayIngress/ReplayIngressSpec_V1.json`
+
+The matrix tests the membrane rule: replay outputs are evidence inputs only and never become AL adjudication by naming collision or implied authority.
+
+| ID | Input condition | Expected |
+|---|---|---|
+| RI-001 | `REPLAY_MATCH` with all required fields and all three authority flags `false` | ACCEPT |
+| RI-002 | `MATCH`, `DELTA`, or `HOLD` as `replay_result` | REJECT |
+| RI-003 | `MISMATCH`, `DRIFT`, or `UNREPLAYABLE` as `replay_result` | REJECT |
+| RI-004 | Any bare verdict token in another string field | REJECT |
+| RI-005 | `REPLAY_MISMATCH` without `diff_summary` | REJECT |
+| RI-006 | `REPLAY_DRIFT` without `diff_summary` | REJECT |
+| RI-007 | `REPLAY_MISMATCH` or `REPLAY_DRIFT` with safe `diff_summary` | ACCEPT |
+| RI-008 | `REPLAY_UNREPLAYABLE` without `unreplayable_reason` | REJECT |
+| RI-009 | `REPLAY_UNREPLAYABLE` with safe `unreplayable_reason` | ACCEPT |
+| RI-010 | `authority_created: true` | REJECT |
+| RI-011 | `acceptance_created: true` | REJECT |
+| RI-012 | `correctness_proved: true` | REJECT |
+| RI-013 | Top-level forbidden authority/identity/settlement property | REJECT |
+| RI-014 | Forbidden authority/identity/settlement property nested in `diff_summary` | REJECT |
+| RI-015 | Bare verdict token nested in `diff_summary` | REJECT |
+| RI-016 | Unknown top-level property | REJECT |
+
+## Locked invariants
+
+```text
+REPRODUCIBLE ≠ CORRECT
+CORRECT      ≠ ACCEPTED
+ACCEPTED     ≠ AUTHORIZED
+
+REPLAY_RESULT
+↓
+AL_EVIDENCE_INPUT
+↓
+AL_MATCH | AL_DELTA | AL_HOLD
+```
+
+No direct replay-verdict-to-AL-verdict mapping is encoded by this schema.

--- a/ReplayIngress/Tests/RejectAuthorityClaims.spec.js
+++ b/ReplayIngress/Tests/RejectAuthorityClaims.spec.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { basePacket, validateReplayIngress } from "./validator.js";
+
+describe("ReplayIngressSpec_V1 authority and inference rejection", () => {
+  const forbiddenProperties = [
+    "al_match",
+    "al_delta",
+    "al_hold",
+    "authorized",
+    "accepted",
+    "correct",
+    "truth",
+    "verified",
+    "valid",
+    "actor",
+    "identity",
+    "signer",
+    "wallet",
+    "settled",
+    "final",
+    "approved"
+  ];
+
+  it.each(forbiddenProperties)("rejects forbidden top-level property %s", (property) => {
+    expect(
+      validateReplayIngress(basePacket({ [property]: true }))
+    ).toBe(false);
+  });
+
+  it.each(forbiddenProperties)("rejects forbidden nested diff property %s", (property) => {
+    expect(
+      validateReplayIngress(
+        basePacket({
+          replay_result: "REPLAY_MISMATCH",
+          diff_summary: { [property]: true }
+        })
+      )
+    ).toBe(false);
+  });
+
+  it.each([
+    "authority_created",
+    "acceptance_created",
+    "correctness_proved"
+  ])("requires %s to remain false", (property) => {
+    expect(
+      validateReplayIngress(basePacket({ [property]: true }))
+    ).toBe(false);
+  });
+});

--- a/ReplayIngress/Tests/RejectBareMatch.spec.js
+++ b/ReplayIngress/Tests/RejectBareMatch.spec.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { basePacket, validateReplayIngress } from "./validator.js";
+
+describe("ReplayIngressSpec_V1 bare verdict rejection", () => {
+  const bareVerdicts = [
+    "MATCH",
+    "DELTA",
+    "HOLD",
+    "MISMATCH",
+    "DRIFT",
+    "UNREPLAYABLE"
+  ];
+
+  it.each(bareVerdicts)("rejects bare replay_result %s", (bareVerdict) => {
+    expect(
+      validateReplayIngress(basePacket({ replay_result: bareVerdict }))
+    ).toBe(false);
+  });
+
+  it.each(bareVerdicts)("rejects bare verdict string elsewhere: %s", (bareVerdict) => {
+    expect(
+      validateReplayIngress(basePacket({ receipt_id: bareVerdict }))
+    ).toBe(false);
+  });
+
+  it("rejects bare verdict strings nested inside diff_summary", () => {
+    expect(
+      validateReplayIngress(
+        basePacket({
+          replay_result: "REPLAY_MISMATCH",
+          diff_summary: { observed_state: "DRIFT" }
+        })
+      )
+    ).toBe(false);
+  });
+});

--- a/ReplayIngress/Tests/RequireDiffSummary.spec.js
+++ b/ReplayIngress/Tests/RequireDiffSummary.spec.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { basePacket, validateReplayIngress } from "./validator.js";
+
+describe("ReplayIngressSpec_V1 diff_summary requirements", () => {
+  it.each(["REPLAY_MISMATCH", "REPLAY_DRIFT"])(
+    "requires diff_summary for %s",
+    (replayResult) => {
+      expect(
+        validateReplayIngress(basePacket({ replay_result: replayResult }))
+      ).toBe(false);
+    }
+  );
+
+  it.each(["REPLAY_MISMATCH", "REPLAY_DRIFT"])(
+    "accepts safe diff_summary for %s",
+    (replayResult) => {
+      expect(
+        validateReplayIngress(
+          basePacket({
+            replay_result: replayResult,
+            diff_summary: { byte_delta: 1 }
+          })
+        )
+      ).toBe(true);
+    }
+  );
+
+  it("does not require diff_summary for REPLAY_MATCH", () => {
+    expect(validateReplayIngress(basePacket())).toBe(true);
+  });
+});

--- a/ReplayIngress/Tests/RequireUnreplayableReason.spec.js
+++ b/ReplayIngress/Tests/RequireUnreplayableReason.spec.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { basePacket, validateReplayIngress } from "./validator.js";
+
+describe("ReplayIngressSpec_V1 unreplayable reason requirements", () => {
+  it("requires unreplayable_reason for REPLAY_UNREPLAYABLE", () => {
+    expect(
+      validateReplayIngress(
+        basePacket({ replay_result: "REPLAY_UNREPLAYABLE" })
+      )
+    ).toBe(false);
+  });
+
+  it("accepts REPLAY_UNREPLAYABLE with a safe reason", () => {
+    expect(
+      validateReplayIngress(
+        basePacket({
+          replay_result: "REPLAY_UNREPLAYABLE",
+          unreplayable_reason: "required primitive unavailable"
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("does not require unreplayable_reason for REPLAY_MATCH", () => {
+    expect(validateReplayIngress(basePacket())).toBe(true);
+  });
+});

--- a/ReplayIngress/Tests/validator.js
+++ b/ReplayIngress/Tests/validator.js
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import Ajv from "ajv";
+
+const schema = JSON.parse(
+  fs.readFileSync(new URL("../ReplayIngressSpec_V1.json", import.meta.url), "utf8")
+);
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+
+ajv.addFormat("date-time", {
+  type: "string",
+  validate(value) {
+    return (
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(value) &&
+      !Number.isNaN(Date.parse(value))
+    );
+  }
+});
+
+export const validateReplayIngress = ajv.compile(schema);
+
+export function basePacket(overrides = {}) {
+  return {
+    replay_result: "REPLAY_MATCH",
+    receipt_id: "receipt-001",
+    parent_receipt_ids: [],
+    replay_hash: "sha256:example",
+    procedure_id: "procedure-001",
+    timestamp: "2026-08-24T13:14:00Z",
+    authority_created: false,
+    acceptance_created: false,
+    correctness_proved: false,
+    ...overrides
+  };
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "npm run witness:build",
+    "test:replayingress": "vitest run ReplayIngress/Tests",
     "track001:preflight": "node scripts/track001_preflight.js",
     "track001:finalize": "node scripts/track001_finalize.js",
     "track001:verify": "node scripts/track001_verify.js",


### PR DESCRIPTION
## ReplayIngressSpec_V1 lock candidate

Adds the ReVerseRePlay → JSONWisdom/AL ingress membrane under `ReplayIngress/`.

### Added
- `ReplayIngress/ReplayIngressSpec_V1.json`
- `ReplayIngress/ReplayIngressTestMatrix_V1.md`
- `ReplayIngress/Tests/RejectBareMatch.spec.js`
- `ReplayIngress/Tests/RejectAuthorityClaims.spec.js`
- `ReplayIngress/Tests/RequireDiffSummary.spec.js`
- `ReplayIngress/Tests/RequireUnreplayableReason.spec.js`
- `ReplayIngress/Tests/validator.js`
- `package.json` script: `npm run test:replayingress`

### Boundary invariants
```text
REPRODUCIBLE ≠ CORRECT
CORRECT      ≠ ACCEPTED
ACCEPTED     ≠ AUTHORIZED

Replay verdicts are AL evidence inputs, never direct AL judgments.
```

### Hardening applied before lock
The original proposed shape had two mechanical escape hatches: forbidden property names could appear inside unconstrained `diff_summary`, and bare verdict strings could appear in non-`replay_result` string fields. This branch closes both recursively.

### Exact schema receipt
- bytes: `4759`
- SHA-256: `065cc0be7cd2628c189a801a19201f91fda3b72c8464e6d7d3cabda6ac36855c`
- Git blob SHA: `f09d7346b16f0e34a0ff3240bb885d5275e2b201`

### Verification state
- JSON Schema Draft-07 structure validation: PASS
- semantic matrix spot-checks: PASS
- GitHub byte readback: MATCH
- Vitest execution in repository CI: NOT YET WITNESSED

No authority, acceptance, correctness, or merge authorization is created by this PR.